### PR TITLE
initialize architecture decision records

### DIFF
--- a/docs/decisions/adr-000-document-architecture-decisions.md
+++ b/docs/decisions/adr-000-document-architecture-decisions.md
@@ -1,4 +1,4 @@
-# ADR 0: Document architecture decisions
+# ADR 000: Document architecture decisions
 
 ## Status
 


### PR DESCRIPTION
This PR adds a `docs/decisions` directory, intended for documenting Architecture Decision Records. It also adds `adr-000-document-architecture-decisions.md`, which proposes this form of documentation.

For more context, see:

- [Slack message spurring this decision](https://hashicorp.slack.com/archives/C058H0MULTE/p1721429501597389?thread_ts=1721423327.119409&cid=C058H0MULTE)
- Reference on [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)