### PR TITLE
propose adr-001 on parity with existing API

### DIFF
--- a/docs/decisions/adr-001-parity-with-existing-api.md
+++ b/docs/decisions/adr-001-parity-with-existing-api.md
@@ -28,6 +28,7 @@ As a more specific commitment to parity, we will implement `GET` operations for 
 
 - [`/api/content/<productSlug>/version-metadata`](https://github.com/hashicorp/mktg-content-workflows/blob/01c3c1bd8c1be5d0d036835f90d191b2b1cca3a1/api/content.ts#L41)
   - Purpose: Returns version metadata. Version metadata determines which versioned `nav-data` will be fetched, and serves as the content source for versioned docs dropdowns.
+  - Note: we'd ideally like to move this API route to `/api/version-metadata/<product>`. We intend to adopt this new route after migration is complete. See [this GitHub comment](https://github.com/hashicorp/web-presence-experimental-docs/pull/9#discussion_r1695970388) for more context.
 - [`/api/content/<productSlug>/nav-data/<version>/<section>`](https://github.com/hashicorp/mktg-content-workflows/blob/01c3c1bd8c1be5d0d036835f90d191b2b1cca3a1/api/content.ts#L41)
   - Purpose: Returns `nav-data`. Nav data determines which individual documents will be rendered, and serves as the content source for the sidebars for each documentation section.
   - Note that `section` is sometimes referred to as a docs "category". Some products, such as `boundary`, have a single `docs` section. Other products include sections such as `intro`, `commands`, `tools`, `guides`, and others.
@@ -35,7 +36,7 @@ As a more specific commitment to parity, we will implement `GET` operations for 
   - Purpose: Returns individual `.mdx` documents
 - [`/api/content-versions`](https://github.com/hashicorp/mktg-content-workflows/blob/01c3c1bd8c1be5d0d036835f90d191b2b1cca3a1/api/content-versions.ts)
   - Purpose: Returns version metadata on specific `.mdx` documents, which allows us to filter our versioned docs dropdowns to only show links to documents that actually exist in the associated versioned set of content.
-  - Note: we'd ideally like to move this API route to `/api/content/<productSlug>/content-versions/doc/<...docsPath>`, for consistency with other API routes. We intend to adopt this new route after migration is complete.
+  - Note: we'd ideally like to move this API route to `/api/content/<productSlug>/content-versions/doc/<...docsPath>`, for consistency with other API routes. We intend to adopt this new route after migration is complete. See [this GitHub comment](https://github.com/hashicorp/web-presence-experimental-docs/pull/9#discussion_r1695450448) for more context.
 
 Note that our front-end code in [hashicorp/dev-portal](https://github.com/hashicorp/dev-portal) makes use of an additional endpoint which we do _not_ intend to replace at this time:
 


### PR DESCRIPTION
This PR proposes `adr-001-parity-with-existing-api.md`.

In brief:

## Context

While the _implicit_ direction of parity in this new repo-backed API _may_ be understood, we've never _explicitly_ articulated it. This lack of explicit direction creates a lack of clarity around scope, and around how to proceed with implementation.

## Decision

We will implement this new API with exact parity relative to the relevant operations of the existing API (`content.hashicorp.com`). "Relevant operations" means any operation that our `dev-portal` front-end uses _directly_ in order to render documentation content.

## Consequences

We expect migrating to our new API will be easier and faster, among other benefits.

We do not expect any negative consequences on the internal implementation details of our new API.

> **Note**: this summary intentionally skips over a lot of backlinks, details, and examples. We expect the actual ADR will be more long-lived than this PR description, so we've included much more detail in the full document.

> **Note**: if slash when we have enough approvals on this PR, we'll change the status from `Proposed` to `Accepted` and then merge in the PR. Intent is to avoid having to open a separate PR with a one-line change to "Accept" a proposed ADR.