### PR TITLE
bump ts version to fix Response type error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "experimental-docs-api",
+  "name": "web-presence-experimental-docs",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@types/node": "20.4.5",
         "@types/react": "18.2.18",
-        "typescript": "5.1.3"
+        "typescript": "^5.5.4"
       }
     },
     "node_modules/@next/env": {
@@ -429,9 +429,9 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "devDependencies": {
     "@types/node": "20.4.5",
     "@types/react": "18.2.18",
-    "typescript": "5.1.3"
+    "typescript": "^5.5.4"
   }
 }


### PR DESCRIPTION
This PR bumps the dev-dependency [typescript](https://www.npmjs.com/package/typescript) version to greater than `5.2` to avoid a Response-related type error.

## 💭 Details

From the [Vercel docs](https://nextjs.org/docs/app/building-your-application/routing/route-handlers#behavior):

> TypeScript Warning: Response.json() is only valid from TypeScript 5.2. If you use a lower TypeScript version, you can use [NextResponse.json()](https://nextjs.org/docs/app/api-reference/functions/next-response#json) for typed responses instead.

Upstream, we're using `typescript` version `5.1.3`, so the following error comes up during build:

![CleanShot 2024-07-26 at 12 23 29@2x](https://github.com/user-attachments/assets/7f04f1c8-8967-4ae3-9327-3f0f17bd115a)

We expect that upgrading to the latest version of [typescript](https://www.npmjs.com/package/typescript) will resolve this issue.

## 🧪 Testing

- [ ] The deploy preview for this PR should be successful
    - Note this project contains `/api` routes only, so the root preview URL is not expected to return meaningful content
- [ ] API routes such as [/api/content/vault/version-metadata](https://web-presence-experimental-docs-git-zsfix-ts-version-hashicorp.vercel.app/api/content/vault/version-metadata) should return a JSON response