### PR TITLE
propose adr-003 on authoring mdx content outside public dir

### DIFF
--- a/docs/decisions/adr-001-parity-with-existing-api.md
+++ b/docs/decisions/adr-001-parity-with-existing-api.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/decisions/adr-003-author-mdx-content-outside-the-public-directory.md
+++ b/docs/decisions/adr-003-author-mdx-content-outside-the-public-directory.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 


### PR DESCRIPTION
This PR adds `adr-003-author-mdx-content-outside-the-public-directory.md`, which proposes moving content from its current location in `public/products` into a new `content` directory at the root of this repository.

To add a more concrete dimension to this proposal, the PR below reflects this proposal:

- #15 