### PR TITLE
Fix for no version metadata found in watch-content

### DIFF
--- a/scripts/mdx-transforms/build-mdx-transforms-file.mjs
+++ b/scripts/mdx-transforms/build-mdx-transforms-file.mjs
@@ -49,8 +49,7 @@ export async function buildFileMdxTransforms(filePath) {
 	}
 	const versionMetadata = fs.readFileSync(VERSION_METADATA_FILE, 'utf-8')
 	const serializedVersionMetadata = JSON.parse(versionMetadata)
-	console.log(`🪄 Running MDX transformar
-		 on ${filePath}...`)
+	console.log(`🪄 Running MDX transform on ${filePath}...`)
 	const result = await applyFileMdxTransforms(entry, serializedVersionMetadata)
 	if (result.error) {
 		console.error(`❗ Encountered an error: ${result.error}`)


### PR DESCRIPTION
Fix for the error
```
- File changed: /server/content/ptfe-releases/v202410-1/docs/enterprise/api-docs/run.mdx

🪄 Running MDX transform on /server/content/ptfe-releases/v202410-1/docs/enterprise/api-docs/run.mdx...
❗ Encountered an error: Error: No version metadata found for product: ptfe-releases
- File changed: /server/content/ptfe-releases/v202410-1/docs/enterprise/api-docs/run.mdx

🪄 Running MDX transform on /server/content/ptfe-releases/v202410-1/docs/enterprise/api-docs/run.mdx...
❗ Encountered an error: Error: No version metadata found for product: ptfe-releases
```

# Testing
- checkout this branch
- run `make`
- wait for docker containers to finish build
- edit a file in `public/content`
- see that there is no error `Error: No version metadata found for product` in the console