### PR TITLE
Correctly inject env vars into deploy preview

### DIFF
--- a/content/terraform/v1.11.x/docs/intro/core-workflow.mdx
+++ b/content/terraform/v1.11.x/docs/intro/core-workflow.mdx
@@ -3,7 +3,7 @@ page_title: Overview of the core Terraform workflow
 description: Learn how to provision and manage infrastructure using the core Terraform workflow for individuals, teams, and organizations.
 ---
 
-# Core Terraform Workflow Overview 2
+# Core Terraform Workflow Overview
 
 The core Terraform workflow has three steps:
 
@@ -16,12 +16,12 @@ of working as an individual practitioner, how they evolve when a team is
 collaborating on infrastructure, and how HCP Terraform enables this
 workflow to run smoothly for entire organizations.
 
-## Working as an Individual Practitioner 2
+## Working as an Individual Practitioner
 
 Let's first walk through how these parts fit together as an individual working
 on infrastructure as code.
 
-### Write 3
+### Write
 
 You write Terraform configuration just like you write code: in your editor of
 choice. It's common practice to store your work in a version controlled
@@ -62,7 +62,7 @@ $ vim main.tf
 This parallels working on application code as an individual, where a tight
 feedback loop between editing code and running test commands is useful.
 
-### Plan 2
+### Plan
 
 When the feedback loop of the Write step has yielded a change that looks good,
 it's time to commit your work and review the final plan.
@@ -243,7 +243,7 @@ terraform {
         layer = "networking"
         source = "cli"
       }
-
+      
       # For terraform versions below 1.10, you must specify key-only tags
       # using a list of strings. Example:
       # tags = ["networking", "source:cli"]


### PR DESCRIPTION
env vars were not being injected correctly which was causing preview builds to not show the content changes. this PR fixes that.

- **Before** fix ([using commit 1c507c3](https://github.com/hashicorp/web-unified-docs/pull/124/commits/1c507c3ed525f857354e9777e69faae082ac721c)): [terraform/intro/core-workflow](https://unified-docs-frontend-preview-qsdmhznsh-hashicorp.vercel.app/terraform/intro/core-workflow)
    - Notice that the content DID NOT change to reflect the changes in this PR

- **After** fix ([using commit fcaeefd](https://github.com/hashicorp/web-unified-docs/pull/124/commits/fcaeefd2a1db990881612fa9d63ef0096f36999f)): [terraform/intro/core-workflow](https://unified-docs-frontend-preview-mhbzcj9a3-hashicorp.vercel.app/terraform/intro/core-workflow)
    - Notice that the content DID CHANGE to reflect the changes in this PR

❗ After this PR is approved, the content changes to terraform/intro/core-workflow will be reverted prior to merging. ❗ 

