### PR TITLE
feat: update terraform-docs-agents assetDir

### DIFF
--- a/app/utils/productConfig.mjs
+++ b/app/utils/productConfig.mjs
@@ -270,7 +270,7 @@ export const PRODUCT_CONFIG = {
 		 * directory structure that needs to be accounted for. Need to confirm.
 		 * See note at top of this document on `pages` directories for details.
 		 */
-		assetDir: ['img', 'public'],
+		assetDir: ['img', 'public/img'],
 		basePaths: ['cloud-docs/agents'],
 		contentDir: 'docs',
 		dataDir: 'data',


### PR DESCRIPTION
### Description

[Asana task 🎟️ ](https://app.asana.com/0/1209152747858598/1209286418212825)

This PR updates the possible asset directories for terraform-docs-agents. In v1.18.x, the asset directory got changed from `img` to `public/img`. I updated the product config so that it pulls from both of those directories. 

### Testing

1. Pull down this branch
2. Run `node ./scripts/migrate-content/migrate-content.mjs terraform-docs-agents`
3. Verify that the images added are in the `/img` directory and not `/img/img`