### PR TITLE
fix: broken test for content-versions

### DIFF
--- a/app/api/content-versions/route.test.ts
+++ b/app/api/content-versions/route.test.ts
@@ -48,7 +48,7 @@ test('should return 400 if `fullPath` query parameter is missing', async () => {
 	)
 })
 
-test('should return 200 and empty array if no content exists for the query params', async () => {
+test('should return 404 if the product is invalid', async () => {
 	vol.fromJSON({})
 
 	const mockRequest = (url: string) => {
@@ -58,9 +58,9 @@ test('should return 200 and empty array if no content exists for the query param
 		'http://localhost:8080/api/content-versions?product=nonexistent&fullPath=doc#docs/internals',
 	)
 	const response = await GET(request)
-	expect(response.status).toBe(200)
-	const json = await response.json()
-	expect(json).toEqual({ versions: [] })
+	expect(response.status).toBe(404)
+	const text = await response.text()
+	expect(text).toBe('Not found')
 })
 
 test('should return 200 and array of strings on valid params', async () => {

--- a/app/api/content-versions/route.ts
+++ b/app/api/content-versions/route.ts
@@ -20,6 +20,11 @@ export async function GET(request: Request) {
 			{ status: 400 },
 		)
 	}
+
+	if (!Object.keys(PRODUCT_CONFIG).includes(product)) {
+		console.error(`API Error: Product, ${product}, not found in contentDirMap`)
+		return new Response('Not found', { status: 404 })
+	}
 	/**
 	 * reformat fullPath to searchable file path
 	 * e.g. doc#cdktf/api-reference/python/classes -> api-reference/python/classes


### PR DESCRIPTION
### Description

[Asana task 🎟️ ](https://app.asana.com/0/1209152747858598/1209433368860963)

This PR adds a check for if the product passed in to the content-versions endpoint is valid. This is necessary because a test was failing for invalid products since they don't exist in the product config. The broken test is also fixed since it should return a 404 now in stead of a 200.

### Testing
1. Check out this branch
2. Run `npm run coverage`
3. Verify that all tests pass