### PR TITLE
Fix docker compose dev-portal image 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,6 @@
 services:
   dev-portal:
-    # image: 'hashicorp/dev-portal:latest'
-    image: 'dev-portal:terraform-plugin-framework'
+    image: 'hashicorp/dev-portal:latest'
     container_name: dev-portal
     ports:
       - ${DEV_PORTAL_PORT}:${DEV_PORTAL_PORT}


### PR DESCRIPTION
Moving docker compose image  back to:
`image: 'hashicorp/dev-portal:latest`