### PR TITLE
Fix failing test: app/api/content-versions/route.test.ts 

### DIFF
--- a/app/api/content-versions/route.test.ts
+++ b/app/api/content-versions/route.test.ts
@@ -8,6 +8,23 @@ import { vol } from 'memfs'
 vi.mock('node:fs')
 vi.mock('node:fs/promises')
 
+// Mock PRODUCT_CONFIG
+vi.mock('@utils/productConfig.mjs', () => {
+	return {
+		PRODUCT_CONFIG: {
+			'terraform-cdk': {
+				assetDir: '',
+				basePaths: ['cdktf'],
+				contentDir: 'docs',
+				dataDir: 'data',
+				productSlug: 'terraform',
+				versionedDocs: true,
+				websiteDir: 'website',
+			},
+		},
+	}
+})
+
 beforeEach(() => {
 	// Reset the state of in-memory fs
 	vol.reset()


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/1209152747858598/1209458839630725)

## Changes
### Locally
- Added a mock for the `PRODUCT_CONFIG` import in `app/api/content-versions/route`

## Testing
1. Checkout main `git checkout main`
1. Run `npm run test app/api/content-versions/route.test.ts`
1. See that the test suite fails on the last test: `should return 200 and array of strings on valid params`
```shell
 ❯ app/api/content-versions/route.test.ts (4)
   ✓ should return 400 if `product` query parameter is missing
   ✓ should return 400 if `fullPath` query parameter is missing
   ✓ should return 404 if the product is invalid
   × should return 200 and array of strings on valid params

⎯⎯⎯⎯⎯⎯Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

FAIL  app/api/content-versions/route.test.ts > should return 200 and array of strings on valid params
AssertionError: expected 404 to be 200 // Object.is equality

- Expected
+ Received

- 200
+ 404

 ❯ app/api/content-versions/route.test.ts:136:26
    134|  )
    135|  const response = await GET(request)
    136|  expect(response.status).toBe(200)
       |                          ^
    137|  const json = await response.json()
    138|  expect(json).toEqual(mockedResponse)
```

### GHA runs
#### `main`
1. See the failing run [here](https://github.com/hashicorp/web-unified-docs/actions/runs/13416883766/job/37479781379#step:6:43)
<img width="705" alt="Screenshot 2025-02-21 at 13 10 14" src="https://github.com/user-attachments/assets/b28a6465-5592-4870-860b-5e670a024482" />


#### `heat/chore/content-versions-route-test`
1. Visit the test & lint run for this PR [here](https://github.com/hashicorp/web-unified-docs/actions/runs/13462592237/job/37621229218#step:6:41)
1. Search for 'app/api/content-versions/route.test.ts` in the logs
1. You should see the test suite passing
<img width="575" alt="Screenshot 2025-02-21 at 13 07 58" src="https://github.com/user-attachments/assets/3fab72c4-d8f6-44d8-be2e-346bb4f4e3d2" />
