### PR TITLE
Fix failing tests for add-version-to-internal-links test suite

### DIFF
--- a/scripts/mdx-transforms/add-version-to-internal-links/add-version-to-internal-links.test.mjs
+++ b/scripts/mdx-transforms/add-version-to-internal-links/add-version-to-internal-links.test.mjs
@@ -1,6 +1,41 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { transformRewriteInternalLinks } from './add-version-to-internal-links.mjs'
-import versionMetadata from '../../../__fixtures__/versionMetadata.json'
+import versionMetadata from '__fixtures__/versionMetadata.json'
+
+// Mock PRODUCT_CONFIG
+vi.mock('../../../app/utils/productConfig.mjs', () => {
+	return {
+		PRODUCT_CONFIG: {
+			terraform: {
+				basePaths: ['cli', 'internals', 'intro', 'language'],
+			},
+			'ptfe-releases': {
+				basePaths: ['enterprise'],
+			},
+			'terraform-cdk': {
+				basePaths: ['cdktf'],
+			},
+			'terraform-docs-agents': {
+				basePaths: ['cloud-docs/agents'],
+			},
+			'terraform-plugin-framework': {
+				basePaths: ['plugin/framework'],
+			},
+			'terraform-plugin-log': {
+				basePaths: ['plugin/log'],
+			},
+			'terraform-plugin-mux': {
+				basePaths: ['plugin/mux'],
+			},
+			'terraform-plugin-sdk': {
+				basePaths: ['plugin/sdkv2'],
+			},
+			'terraform-plugin-testing': {
+				basePaths: ['plugin/testing'],
+			},
+		},
+	}
+})
 
 describe('transformRewriteInternalLinks', () => {
 	it('should not rewrite internal links for paths other than the basePaths', async () => {


### PR DESCRIPTION
This PR fixes the failing test in `scripts/mdx-transforms/add-version-to-internal-links/add-version-to-internal-links.test.mjs`.
>Note: there will still be failing tests as multiple test suites are failing for this repo. See failing tests in the subtask list for [this task](https://app.asana.com/0/1205788188868789/1209444713668271).

[Asana task](https://app.asana.com/0/0/1209458839630723/f)

## Changes
- Mocked `PRODUCT_CONFIG` to fix failing tests in `scripts/mdx-transforms/add-version-to-internal-links/add-version-to-internal-links.test.mjs`


## Testing
- [See failing tests here](https://github.com/hashicorp/web-unified-docs/actions/runs/13462213122/job/37619987810#step:6:33)
<img width="1367" alt="Screenshot 2025-02-24 at 18 27 41" src="https://github.com/user-attachments/assets/b13e3b58-c4c0-4a56-8e87-c20f7e2b29ac" />

- See test run for this PR here. This change has fixed the failing tests on `main`
<img width="1373" alt="Screenshot 2025-02-24 at 18 28 33" src="https://github.com/user-attachments/assets/f2d4034e-3d95-48b8-b420-b6075496f738" />

### To test locally
- `git checkout heat/chore/fix-failing-add-version-to-internal-links-test`
- `npm run test scripts/mdx-transforms/add-version-to-internal-links/add-version-to-internal-links.test.mjs`
- all tests should pass and you should see an output like this:
```bash
> test
> vitest scripts/mdx-transforms/add-version-to-internal-links/add-version-to-internal-links.test.mjs

 ✓ scripts/mdx-transforms/add-version-to-internal-links/add-version-to-internal-links.test.mjs (13)
   ✓ transformRewriteInternalLinks (13)
     ✓ should not rewrite internal links for paths other than the basePaths
     ✓ should not rewrite links if the version is the latest
     ✓ should not rewrite external links
     ✓ should rewrite internal links with basePaths
     ✓ should rewrite internal links for ptfe-releases
     ✓ should rewrite internal links for terraform-cdk
     ✓ should rewrite internal links for terraform-docs-agents
     ✓ should not rewrite internal links for a product with no basePaths array
     ✓ should rewrite internal links for terraform-plugin-framework
     ✓ should rewrite internal links for terraform-plugin-log
     ✓ should rewrite internal links for terraform-plugin-mux
     ✓ should rewrite internal links for terraform-plugin-sdk
     ✓ should rewrite internal links for terraform-plugin-testing
```