### PR TITLE
Fix failing test in scripts/gather-all-docs-paths.test.ts

### DIFF
--- a/app/api/all-docs-paths/__fixtures__/consul-test/consul-test.mdx
+++ b/app/api/all-docs-paths/__fixtures__/consul-test/consul-test.mdx
@@ -1,9 +1,0 @@
----
-title: Consul test document
----
-
-# Hello world!
-
-This is a test file.
-
-This is the end of the test file.

--- a/app/api/all-docs-paths/__fixtures__/hcp-docs-test/hcp-docs-test.mdx
+++ b/app/api/all-docs-paths/__fixtures__/hcp-docs-test/hcp-docs-test.mdx
@@ -1,9 +1,0 @@
----
-title: HCP docs test document
----
-
-# Hello world!
-
-This is a test file.
-
-This is the end of the test file.

--- a/app/api/all-docs-paths/__fixtures__/terraform-test/terraform-test.mdx
+++ b/app/api/all-docs-paths/__fixtures__/terraform-test/terraform-test.mdx
@@ -1,9 +1,0 @@
----
-title: Terraform test document
----
-
-# Hello world!
-
-This is a test file.
-
-This is the end of the test file.


### PR DESCRIPTION
This PR fixes the failing test in `scripts/gather-all-docs-paths.test.ts`.
>Note: there will still be failing tests as multiple test suites are failing for this repo. See failing tests in the subtask list for [this task](https://app.asana.com/0/1205788188868789/1209444713668271).

[Asana task](https://app.asana.com/0/1205788188868789/1209458839630726) 

## Changes
- Deleted test fixtures from `app/api/all-docs-paths` as they are now mocked using `memfs`
- Mocked `PRODUCT_CONFIG` import; deleted file import
- Added `versionMetadata` fixture; deleted scoped `versionMetadata` variable
- Removed instances of `vi.spyOn(...)` as `PRODUCT_CONFIG` import is now is mocked



## Testing
1. `git checkout main`
1. `npm run test scripts/gather-all-docs-paths.test.ts`
1. You should see the test fail with this output:
```shell
 FAIL  scripts/gather-all-docs-paths.test.ts > gatherAllDocsPaths returns the paths
Error: ENOENT: no such file or directory, scandir 'content/terraform/v1.9.x/docs'
 ❯ traverseDirectory scripts/gather-all-docs-paths.mjs:44:20
     42| 
     43|  function traverseDirectory(currentPath, relativePath = '') {
     44|   const items = fs.readdirSync(currentPath)
       |                    ^
     45| 
     46|   items.forEach((item) => {
 ❯ getProductPaths scripts/gather-all-docs-paths.mjs:72:2
 ❯ Module.gatherAllDocsPaths scripts/gather-all-docs-paths.mjs:29:20
 ❯ scripts/gather-all-docs-paths.test.ts:32:23
```


1. `git checkout heat/chore/fix-failing-gather-all-docs-paths-test`
1. `npm run test scripts/gather-all-docs-paths.test.ts`
1. You should see the tests pass with this output:
```shell
> test
> vitest scripts/gather-all-docs-paths.test.ts

 ✓ scripts/gather-all-docs-paths.test.ts (5)
   ✓ gatherAllDocsPaths returns the paths
   ✓ gatherAllDocsPaths throws an error if no version metadata is found for a product
   ✓ getProductPaths should determine correct productName for hcp-docs
   ✓ getProductPaths should determine correct productName for terraform products
   ✓ getProductPaths should have the default productName for all other products
```