### PR TITLE
Fix failing test for build-mdx-transforms-file script

### DIFF
--- a/scripts/mdx-transforms/build-mdx-transforms-file.test.mjs
+++ b/scripts/mdx-transforms/build-mdx-transforms-file.test.mjs
@@ -1,43 +1,53 @@
-import { expect, test, vi, afterEach, beforeEach } from 'vitest'
-import { vol } from 'memfs'
+import { expect, test, vi, beforeEach } from 'vitest'
+import { fs, vol } from 'memfs'
 import {
 	buildFileMdxTransforms,
 	applyFileMdxTransforms,
 } from './build-mdx-transforms-file.mjs'
 import versionMetadata from '__fixtures__/versionMetadata.json'
-import fs from 'fs'
+import * as repoConfig from '../../app/utils/productConfig.mjs'
 
 vi.mock('fs')
-vi.mock('fs/promises')
 
-afterEach(() => {
-	vol.reset()
-})
+const mdxContent = `---
+page_title: 'Plugin Development - Framework: Paths'
+---
+
+# Paths
+
+An exact location within a [schema](/plugin/framework/schemas)
+`
+
+const transformedMdxContent = `---
+page_title: 'Plugin Development - Framework: Paths'
+---
+# Paths
+
+An exact location within a [schema](/plugin/framework/schemas)`
 
 beforeEach(() => {
 	vol.fromJSON({
 		'/content/terraform/v1.19.x/test.mdx': mdxContent,
+		'/public/content/terraform/v1.19.x/test.mdx': transformedMdxContent,
 		'app/api/versionMetadata.json': JSON.stringify(versionMetadata),
+		'/content/terraform/v1.19.x/partials': {},
 	})
 })
 
-const mdxContent = `
-# Hello World
-
-export const ComplexComponent = () => <div>Hello to the world</div>
-
-</ComplexComponent />
-`
-
-const transformedOutPath = '/content/terraform/v1.19.x/test.mdx'
+const transformedOutPath = '/public/content/terraform/v1.19.x/test.mdx'
 
 test('test buildfileMdxTransforms', async () => {
 	await buildFileMdxTransforms('/content/terraform/v1.19.x/test.mdx')
 	const transformedContent = fs.readFileSync(transformedOutPath, 'utf8')
-	expect(transformedContent).toContain(mdxContent)
+	expect(transformedContent).toContain(transformedMdxContent)
 })
 
 test('test applyFileMdxTransforms', async () => {
+	vi.spyOn(repoConfig, 'PRODUCT_CONFIG', 'get').mockReturnValue({
+		terraform: {
+			basePaths: ['cli', 'internals', 'intro', 'language'],
+		},
+	})
 	const entry = {
 		filePath: '/content/terraform/v1.19.x/test.mdx',
 		partialsDir: '../../partials',
@@ -47,5 +57,5 @@ test('test applyFileMdxTransforms', async () => {
 	expect(result).toStrictEqual({ error: null })
 
 	const transformedContent = fs.readFileSync(entry.outPath, 'utf8')
-	expect(transformedContent.trim()).toContain(mdxContent.trim())
+	expect(transformedContent.trim()).toContain(transformedMdxContent.trim())
 })


### PR DESCRIPTION
This PR fixes the failing test in `build-mdx-transforms-file`.

**Note: there will still be failing tests as multiple test suites are failing for this repo.** See failing tests in the subtask list for [this task](https://app.asana.com/0/1205788188868789/1209444713668271).

[Asana task](https://app.asana.com/0/0/1209458839630727/f)

## Changes
- Added `transformedMdxContent`
- Import actual product config and mocked addition of `terraform` property

## Testing
1. `git checkout main`
1. `npm run test scripts/mdx-transforms/build-mdx-transforms-file.test.mjs`
1. You should see the test fail with this output:
```shell
 FAIL  scripts/mdx-transforms/build-mdx-transforms-file.test.mjs > test applyFileMdxTransforms
AssertionError: expected { Object (error) } to strictly equal { error: null }

- Expected
+ Received

  Object {
-   "error": null,
+   "error": "TypeError: Cannot read properties of undefined (reading 'basePaths')",
  }
```


1. `git checkout heat/chore/build-mdx-transforms-file-failing-test`
1. `npm run test scripts/mdx-transforms/build-mdx-transforms-file.test.mjs`
1. You should see the tests pass with this output:
```shell
> test
> vitest scripts/mdx-transforms/build-mdx-transforms-file.test.mjs

 ✓ scripts/mdx-transforms/build-mdx-transforms-file.test.mjs (2)
   ✓ test buildfileMdxTransforms
   ✓ test applyFileMdxTransforms
```