### PR TITLE
Delete redundant test

### DIFF
--- a/scripts/gather-all-versions-docs-paths.test.ts
+++ b/scripts/gather-all-versions-docs-paths.test.ts
@@ -1,8 +1,5 @@
 import { expect, test, vi, afterEach } from 'vitest'
-import {
-	gatherAllVersionsDocsPaths,
-	getProductPaths,
-} from './gather-all-versions-docs-paths.mjs'
+import { gatherAllVersionsDocsPaths } from './gather-all-versions-docs-paths.mjs'
 import * as repoConfig from '../app/utils/productConfig.mjs'
 
 afterEach(() => {
@@ -59,15 +56,4 @@ test('gatherAllDocsPaths throws an error if no version metadata is found for a p
 	await expect(gatherAllVersionsDocsPaths(versionMetadata)).rejects.toThrow(
 		'No version metadata found for product',
 	)
-})
-
-// getProductPaths tests
-
-test('getProductPaths should return product baths', async () => {
-	const apiPaths = await getProductPaths(
-		'app/api/all-docs-paths/__fixtures__/terraform-test',
-		'terraform',
-	)
-
-	expect(apiPaths[0].path).toBe('terraform/terraform-test')
 })


### PR DESCRIPTION
## Changes
- Deleting redundant test, which is for gather-all-docs-paths, not for the functionality tested in the rest of the file for `scripts/gather-all-versions-docs-paths`
- [This failing test](https://github.com/hashicorp/web-unified-docs/actions/runs/13552168237/job/37878132667#step:6:56) is a repeat of [this test](https://github.com/hashicorp/web-unified-docs/blob/main/scripts/gather-all-docs-paths.test.ts#L114-L121)

[Asana task](https://app.asana.com/0/1205788188868789/1209518780543448)