### PR TITLE
Add GHA to deploy dev-portal production via deploy hook

### DIFF
--- a/.github/workflows/redeploy-dev-portal.yml
+++ b/.github/workflows/redeploy-dev-portal.yml
@@ -3,7 +3,7 @@ name: Trigger production deployment for Dev Portal
 on:
   push:
     branches:
-      - 'heat/chore/dev-portal-deploy-gha'
+      - 'main'
     paths:
       - 'content/**'
       - 'app/**'
@@ -22,5 +22,4 @@ jobs:
         run: sleep 600
 
       - name: re-deploy dev portal production
-        # run: curl -X POST ${{ secrets.DEV_PORTAL_DEPLOY_HOOK_PROD }}
-        run: curl -X POST ${{ secrets.DEV_PORTAL_DEPLOY_HOOK_TEST }}
+        run: curl -X POST ${{ secrets.DEV_PORTAL_DEPLOY_HOOK_PROD }}


### PR DESCRIPTION
## Changes
- copy/paste the implementation for the dev-portal-preview action to get Vercel data etc to wait for api docs to finish building
- Added glob pattern to trigger this GHA only for `content/**` and `app/**`
 
[ Asana task](https://app.asana.com/1/90955849329269/project/1209152747858598/task/1209469124677595)