### PR TITLE
Add BUSL license header to mdx migration script

### DIFF
--- a/scripts/update-mdx-files.sh
+++ b/scripts/update-mdx-files.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
 
 # Check if a path was provided
 if [ -z "$1" ]; then


### PR DESCRIPTION
Add BUSL license to MDX migration script using `copywrite`