### PR TITLE
Redirect index pages to web-unified-docs

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,11 +6,14 @@
 import React from 'react'
 
 // eslint-disable-next-line no-restricted-exports
-export default function RootLayout() {
+export default function RootLayout({
+	children,
+}: {
+	children: React.ReactNode
+}) {
 	return (
-		<html>
-			<head />
-			<body></body>
+		<html lang="en">
+			<body>{children}</body>
 		</html>
 	)
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/** Add your relevant code here for the issue to reproduce */
+import { redirect } from 'next/navigation'
+
+// Redirect to the web-unified-docs repository
 // eslint-disable-next-line no-restricted-exports
 export default function Home() {
-	return null
+	redirect('https://github.com/hashicorp/web-unified-docs')
 }


### PR DESCRIPTION
🎟️ [Asana](https://app.asana.com/1/90955849329269/project/1209152747858598/task/1209560807449237)

This PR updates the index page to redirect to the `web-unified-docs` repo (instead of showing an blank page).

This is a temporary solution until we've decided on a better place to point the content API.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209560807449237