### PR TITLE
fix: /terrafrom/plugin/framework/provider links

### DIFF
--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 In this example, a resource schema defines a top level required bool attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -53,7 +53,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 
 In this example, a resource schema defines a top level required dynamic attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/float32.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/float32.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float32 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float32Attribute) |
 
 In this example, a resource schema defines a top level required float32 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 In this example, a resource schema defines a top level required float64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/int32.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/int32.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int32 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int32Attribute) |
 
 In this example, a resource schema defines a top level required int32 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 In this example, a resource schema defines a top level required int64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a list nested value to 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a list value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the list.

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a map nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the map.

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 In this example, a resource schema defines a top level required number attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -32,7 +32,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 The `AttributeTypes` field must be defined, which represents the mapping of explicit string object attribute names to [value types](/terraform/plugin/framework/handling-data/types).

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a set nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a set value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the set.

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a single nested value t
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 
 In most use cases, the `Attributes` field should be defined, which represents the mapping of explicit string attribute names to nested attributes.

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 In this example, a resource schema defines a top level required string attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -38,7 +38,7 @@ Use one of the following block types to directly add a single nested value to a 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
 In most use cases, the `Attributes` or `Blocks` field should be defined, which represents the mapping of explicit string attribute names to nested attributes and/or blocks.

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 If the bool value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.BoolType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -27,7 +27,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 
 Dynamic values are not supported as the element type of a [collection type](/terraform/plugin/framework/handling-data/types#collection-types) or within [collection attribute types](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types).

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/float32.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/float32.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float32 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float32Attribute) |
 
 If the float32 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float32Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 If the float64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/int32.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/int32.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int32 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int32Attribute) |
 
 If the int32 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int32Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 If the int64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a list of a single elem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 Use one of the following attribute types to directly add a list of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a list of a nested attr
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a map of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 Use one of the following attribute types to directly add a map of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -25,7 +25,7 @@ Use one of the following attribute types to directly add a map of a nested attri
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 If the map value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.MapType{ElemType: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 If the number value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.NumberType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -24,8 +24,8 @@ Use one of the following attribute types to directly add a single structure of a
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
@@ -36,7 +36,7 @@ Use one of the following attribute types to directly add an object value directl
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 If the object value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.ObjectType{AttrTypes: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a set of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 Use one of the following attribute types to directly add a set of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a set of a nested attri
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 If the string value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.StringType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 In this example, a resource schema defines a top level required bool attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -53,7 +53,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 
 In this example, a resource schema defines a top level required dynamic attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/float32.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/float32.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float32 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float32Attribute) |
 
 In this example, a resource schema defines a top level required float32 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 In this example, a resource schema defines a top level required float64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/int32.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/int32.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int32 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int32Attribute) |
 
 In this example, a resource schema defines a top level required int32 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 In this example, a resource schema defines a top level required int64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a list nested value to 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a list value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the list.

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a map nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the map.

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 In this example, a resource schema defines a top level required number attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -32,7 +32,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 The `AttributeTypes` field must be defined, which represents the mapping of explicit string object attribute names to [value types](/terraform/plugin/framework/handling-data/types).

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a set nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a set value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the set.

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a single nested value t
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 
 In most use cases, the `Attributes` field should be defined, which represents the mapping of explicit string attribute names to nested attributes.

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 In this example, a resource schema defines a top level required string attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -38,7 +38,7 @@ Use one of the following block types to directly add a single nested value to a 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
 In most use cases, the `Attributes` or `Blocks` field should be defined, which represents the mapping of explicit string attribute names to nested attributes and/or blocks.

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 If the bool value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.BoolType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -27,7 +27,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 
 Dynamic values are not supported as the element type of a [collection type](/terraform/plugin/framework/handling-data/types#collection-types) or within [collection attribute types](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types).

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/float32.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/float32.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float32 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float32Attribute) |
 
 If the float32 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float32Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 If the float64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/int32.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/int32.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int32 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int32Attribute) |
 
 If the int32 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int32Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 If the int64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a list of a single elem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 Use one of the following attribute types to directly add a list of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a list of a nested attr
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a map of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 Use one of the following attribute types to directly add a map of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -25,7 +25,7 @@ Use one of the following attribute types to directly add a map of a nested attri
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 If the map value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.MapType{ElemType: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 If the number value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.NumberType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -24,8 +24,8 @@ Use one of the following attribute types to directly add a single structure of a
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
@@ -36,7 +36,7 @@ Use one of the following attribute types to directly add an object value directl
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 If the object value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.ObjectType{AttrTypes: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a set of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 Use one of the following attribute types to directly add a set of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a set of a nested attri
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 If the string value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.StringType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 In this example, a resource schema defines a top level required bool attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -53,7 +53,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 
 In this example, a resource schema defines a top level required dynamic attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/float32.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/float32.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float32 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float32Attribute) |
 
 In this example, a resource schema defines a top level required float32 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 In this example, a resource schema defines a top level required float64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/int32.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/int32.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int32 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int32Attribute) |
 
 In this example, a resource schema defines a top level required int32 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 In this example, a resource schema defines a top level required int64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a list nested value to 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a list value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the list.

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a map nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the map.

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 In this example, a resource schema defines a top level required number attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -32,7 +32,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 The `AttributeTypes` field must be defined, which represents the mapping of explicit string object attribute names to [value types](/terraform/plugin/framework/handling-data/types).

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a set nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a set value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the set.

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a single nested value t
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 
 In most use cases, the `Attributes` field should be defined, which represents the mapping of explicit string attribute names to nested attributes.

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 In this example, a resource schema defines a top level required string attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -38,7 +38,7 @@ Use one of the following block types to directly add a single nested value to a 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
 In most use cases, the `Attributes` or `Blocks` field should be defined, which represents the mapping of explicit string attribute names to nested attributes and/or blocks.

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 If the bool value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.BoolType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -27,7 +27,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 
 Dynamic values are not supported as the element type of a [collection type](/terraform/plugin/framework/handling-data/types#collection-types) or within [collection attribute types](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types).

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/float32.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/float32.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float32 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float32Attribute) |
 
 If the float32 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float32Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 If the float64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/int32.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/int32.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int32 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int32Attribute) |
 
 If the int32 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int32Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 If the int64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a list of a single elem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 Use one of the following attribute types to directly add a list of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a list of a nested attr
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a map of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 Use one of the following attribute types to directly add a map of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -25,7 +25,7 @@ Use one of the following attribute types to directly add a map of a nested attri
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 If the map value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.MapType{ElemType: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 If the number value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.NumberType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -24,8 +24,8 @@ Use one of the following attribute types to directly add a single structure of a
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
@@ -36,7 +36,7 @@ Use one of the following attribute types to directly add an object value directl
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 If the object value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.ObjectType{AttrTypes: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a set of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 Use one of the following attribute types to directly add a set of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a set of a nested attri
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 If the string value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.StringType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#BoolAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -53,7 +53,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#DynamicAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/float32.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/float32.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float32 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float32Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Float32Attribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Float64Attribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/int32.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/int32.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int32 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int32Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Int32Attribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Int64Attribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a list nested value to 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ListNestedAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a list value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ListAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a map nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#MapNestedAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#MapAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#NumberAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -32,7 +32,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ObjectAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a set nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SetNestedAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a set value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SetAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a single nested value t
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SingleNestedAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#StringAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ListNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SetNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -38,7 +38,7 @@ Use one of the following block types to directly add a single nested value to a 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SingleNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#BoolAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -27,7 +27,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#DynamicAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/float32.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/float32.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float32 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float32Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Float32Attribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Float64Attribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/int32.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/int32.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int32 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int32Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Int32Attribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Int64Attribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a list of a single elem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ListAttribute) |
 
@@ -27,8 +27,8 @@ Use one of the following attribute types to directly add a list of a nested attr
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ListNestedAttribute) |

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a map of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#MapAttribute) |
 
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map of a nested attri
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#MapNestedAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#NumberAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -24,8 +24,8 @@ Use one of the following attribute types to directly add a single structure of a
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SingleNestedAttribute) |
@@ -38,7 +38,7 @@ Use one of the following attribute types to directly add an object value directl
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ObjectAttribute) |
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a set of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SetAttribute) |
 
@@ -27,8 +27,8 @@ Use one of the following attribute types to directly add a set of a nested attri
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SetNestedAttribute) |

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#StringAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -24,7 +24,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#BoolAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -53,7 +53,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#DynamicAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/float32.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/float32.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a float32 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float32Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Float32Attribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Float64Attribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/int32.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/int32.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a int32 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int32Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Int32Attribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Int64Attribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a list nested value to 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ListNestedAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a list value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ListAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a map nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#MapNestedAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#MapAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#NumberAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -32,7 +32,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ObjectAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a set nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SetNestedAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a set value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SetAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a single nested value t
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SingleNestedAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#StringAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -44,7 +44,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ListNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SetNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -39,7 +39,7 @@ Use one of the following block types to directly add a single nested value to a 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SingleNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#BoolAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -27,7 +27,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#DynamicAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/float32.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/float32.mdx
@@ -24,7 +24,7 @@ Use one of the following attribute types to directly add a float32 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float32Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Float32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Float32Attribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -24,7 +24,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Float64Attribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/int32.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/int32.mdx
@@ -24,7 +24,7 @@ Use one of the following attribute types to directly add a int32 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int32Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int32Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int32Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Int32Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Int32Attribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -24,7 +24,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#Int64Attribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -18,7 +18,7 @@ Use one of the following attribute types to directly add a list of a single elem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ListAttribute) |
 
@@ -28,8 +28,8 @@ Use one of the following attribute types to directly add a list of a nested attr
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ListNestedAttribute) |

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -18,7 +18,7 @@ Use one of the following attribute types to directly add a map of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#MapAttribute) |
 
@@ -27,7 +27,7 @@ Use one of the following attribute types to directly add a map of a nested attri
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#MapNestedAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -24,7 +24,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#NumberAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -24,8 +24,8 @@ Use one of the following attribute types to directly add a single structure of a
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SingleNestedAttribute) |
@@ -38,7 +38,7 @@ Use one of the following attribute types to directly add an object value directl
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#ObjectAttribute) |
 

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a set of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SetAttribute) |
 
@@ -27,8 +27,8 @@ Use one of the following attribute types to directly add a set of a nested attri
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#SetNestedAttribute) |

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 | [Ephemeral Resource](/terraform/plugin/framework/ephemeral-resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral/schema#StringAttribute) |
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 In this example, a resource schema defines a top level required bool attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 In this example, a resource schema defines a top level required float64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 In this example, a resource schema defines a top level required int64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a list nested value to 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a list value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the list.

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a map nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the map.

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 In this example, a resource schema defines a top level required number attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -32,7 +32,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 The `AttributeTypes` field must be defined, which represents the mapping of explicit string object attribute names to [value types](/terraform/plugin/framework/handling-data/types).

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a set nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a set value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the set.

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a single nested value t
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 
 In most use cases, the `Attributes` field should be defined, which represents the mapping of explicit string attribute names to nested attributes.

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 In this example, a resource schema defines a top level required string attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -38,7 +38,7 @@ Use one of the following block types to directly add a single nested value to a 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
 In most use cases, the `Attributes` or `Blocks` field should be defined, which represents the mapping of explicit string attribute names to nested attributes and/or blocks.

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 If the bool value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.BoolType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 If the float64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 If the int64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a list of a single elem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 Use one of the following attribute types to directly add a list of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a list of a nested attr
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a map of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 Use one of the following attribute types to directly add a map of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -25,7 +25,7 @@ Use one of the following attribute types to directly add a map of a nested attri
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 If the map value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.MapType{ElemType: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 If the number value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.NumberType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -24,8 +24,8 @@ Use one of the following attribute types to directly add a single structure of a
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
@@ -36,7 +36,7 @@ Use one of the following attribute types to directly add an object value directl
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 If the object value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.ObjectType{AttrTypes: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a set of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 Use one of the following attribute types to directly add a set of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a set of a nested attri
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 If the string value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.StringType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 In this example, a resource schema defines a top level required bool attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 In this example, a resource schema defines a top level required float64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 In this example, a resource schema defines a top level required int64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a list nested value to 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a list value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the list.

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a map nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the map.

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 In this example, a resource schema defines a top level required number attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -32,7 +32,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 The `AttributeTypes` field must be defined, which represents the mapping of explicit string object attribute names to [value types](/terraform/plugin/framework/handling-data/types).

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a set nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a set value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the set.

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a single nested value t
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 
 In most use cases, the `Attributes` field should be defined, which represents the mapping of explicit string attribute names to nested attributes.

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 In this example, a resource schema defines a top level required string attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -38,7 +38,7 @@ Use one of the following block types to directly add a single nested value to a 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
 In most use cases, the `Attributes` or `Blocks` field should be defined, which represents the mapping of explicit string attribute names to nested attributes and/or blocks.

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 If the bool value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.BoolType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 If the float64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 If the int64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a list of a single elem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 Use one of the following attribute types to directly add a list of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a list of a nested attr
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a map of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 Use one of the following attribute types to directly add a map of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -25,7 +25,7 @@ Use one of the following attribute types to directly add a map of a nested attri
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 If the map value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.MapType{ElemType: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 If the number value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.NumberType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -24,8 +24,8 @@ Use one of the following attribute types to directly add a single structure of a
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
@@ -36,7 +36,7 @@ Use one of the following attribute types to directly add an object value directl
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 If the object value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.ObjectType{AttrTypes: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a set of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 Use one of the following attribute types to directly add a set of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a set of a nested attri
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 If the string value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.StringType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 In this example, a resource schema defines a top level required bool attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 In this example, a resource schema defines a top level required float64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 In this example, a resource schema defines a top level required int64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a list nested value to 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a list value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the list.

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a map nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the map.

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 In this example, a resource schema defines a top level required number attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -32,7 +32,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 The `AttributeTypes` field must be defined, which represents the mapping of explicit string object attribute names to [value types](/terraform/plugin/framework/handling-data/types).

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a set nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a set value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the set.

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a single nested value t
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 
 In most use cases, the `Attributes` field should be defined, which represents the mapping of explicit string attribute names to nested attributes.

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 In this example, a resource schema defines a top level required string attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -38,7 +38,7 @@ Use one of the following block types to directly add a single nested value to a 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
 In most use cases, the `Attributes` or `Blocks` field should be defined, which represents the mapping of explicit string attribute names to nested attributes and/or blocks.

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 If the bool value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.BoolType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 If the float64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 If the int64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a list of a single elem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 Use one of the following attribute types to directly add a list of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a list of a nested attr
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a map of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 Use one of the following attribute types to directly add a map of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -25,7 +25,7 @@ Use one of the following attribute types to directly add a map of a nested attri
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 If the map value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.MapType{ElemType: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 If the number value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.NumberType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -24,8 +24,8 @@ Use one of the following attribute types to directly add a single structure of a
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
@@ -36,7 +36,7 @@ Use one of the following attribute types to directly add an object value directl
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 If the object value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.ObjectType{AttrTypes: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a set of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 Use one of the following attribute types to directly add a set of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a set of a nested attri
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 If the string value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.StringType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 In this example, a resource schema defines a top level required bool attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 In this example, a resource schema defines a top level required float64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 In this example, a resource schema defines a top level required int64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a list nested value to 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a list value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the list.

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a map nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the map.

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 In this example, a resource schema defines a top level required number attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -32,7 +32,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 The `AttributeTypes` field must be defined, which represents the mapping of explicit string object attribute names to [value types](/terraform/plugin/framework/handling-data/types).

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a set nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a set value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the set.

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a single nested value t
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 
 In most use cases, the `Attributes` field should be defined, which represents the mapping of explicit string attribute names to nested attributes.

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 In this example, a resource schema defines a top level required string attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -38,7 +38,7 @@ Use one of the following block types to directly add a single nested value to a 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
 In most use cases, the `Attributes` or `Blocks` field should be defined, which represents the mapping of explicit string attribute names to nested attributes and/or blocks.

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 If the bool value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.BoolType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 If the float64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 If the int64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a list of a single elem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 Use one of the following attribute types to directly add a list of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a list of a nested attr
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a map of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 Use one of the following attribute types to directly add a map of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -25,7 +25,7 @@ Use one of the following attribute types to directly add a map of a nested attri
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 If the map value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.MapType{ElemType: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 If the number value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.NumberType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -24,8 +24,8 @@ Use one of the following attribute types to directly add a single structure of a
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
@@ -36,7 +36,7 @@ Use one of the following attribute types to directly add an object value directl
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 If the object value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.ObjectType{AttrTypes: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a set of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 Use one of the following attribute types to directly add a set of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a set of a nested attri
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 If the string value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.StringType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 In this example, a resource schema defines a top level required bool attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -53,7 +53,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 
 In this example, a resource schema defines a top level required dynamic attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 In this example, a resource schema defines a top level required float64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 In this example, a resource schema defines a top level required int64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a list nested value to 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a list value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the list.

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a map nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the map.

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 In this example, a resource schema defines a top level required number attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -32,7 +32,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 The `AttributeTypes` field must be defined, which represents the mapping of explicit string object attribute names to [value types](/terraform/plugin/framework/handling-data/types).

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a set nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a set value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the set.

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a single nested value t
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 
 In most use cases, the `Attributes` field should be defined, which represents the mapping of explicit string attribute names to nested attributes.

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 In this example, a resource schema defines a top level required string attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -38,7 +38,7 @@ Use one of the following block types to directly add a single nested value to a 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
 In most use cases, the `Attributes` or `Blocks` field should be defined, which represents the mapping of explicit string attribute names to nested attributes and/or blocks.

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 If the bool value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.BoolType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -27,7 +27,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 
 Dynamic values are not supported as the element type of a [collection type](/terraform/plugin/framework/handling-data/types#collection-types) or within [collection attribute types](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types).

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 If the float64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 If the int64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a list of a single elem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 Use one of the following attribute types to directly add a list of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a list of a nested attr
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a map of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 Use one of the following attribute types to directly add a map of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -25,7 +25,7 @@ Use one of the following attribute types to directly add a map of a nested attri
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 If the map value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.MapType{ElemType: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 If the number value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.NumberType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -24,8 +24,8 @@ Use one of the following attribute types to directly add a single structure of a
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
@@ -36,7 +36,7 @@ Use one of the following attribute types to directly add an object value directl
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 If the object value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.ObjectType{AttrTypes: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a set of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 Use one of the following attribute types to directly add a set of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a set of a nested attri
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 If the string value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.StringType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 In this example, a resource schema defines a top level required bool attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -53,7 +53,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 
 In this example, a resource schema defines a top level required dynamic attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 In this example, a resource schema defines a top level required float64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 In this example, a resource schema defines a top level required int64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a list nested value to 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a list value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the list.

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a map nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the map.

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 In this example, a resource schema defines a top level required number attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -32,7 +32,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 The `AttributeTypes` field must be defined, which represents the mapping of explicit string object attribute names to [value types](/terraform/plugin/framework/handling-data/types).

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a set nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a set value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the set.

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a single nested value t
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 
 In most use cases, the `Attributes` field should be defined, which represents the mapping of explicit string attribute names to nested attributes.

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 In this example, a resource schema defines a top level required string attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -38,7 +38,7 @@ Use one of the following block types to directly add a single nested value to a 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
 In most use cases, the `Attributes` or `Blocks` field should be defined, which represents the mapping of explicit string attribute names to nested attributes and/or blocks.

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 If the bool value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.BoolType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -27,7 +27,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 
 Dynamic values are not supported as the element type of a [collection type](/terraform/plugin/framework/handling-data/types#collection-types) or within [collection attribute types](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types).

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 If the float64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 If the int64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a list of a single elem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 Use one of the following attribute types to directly add a list of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a list of a nested attr
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a map of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 Use one of the following attribute types to directly add a map of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -25,7 +25,7 @@ Use one of the following attribute types to directly add a map of a nested attri
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 If the map value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.MapType{ElemType: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 If the number value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.NumberType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -24,8 +24,8 @@ Use one of the following attribute types to directly add a single structure of a
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
@@ -36,7 +36,7 @@ Use one of the following attribute types to directly add an object value directl
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 If the object value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.ObjectType{AttrTypes: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a set of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 Use one of the following attribute types to directly add a set of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a set of a nested attri
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 If the string value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.StringType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 In this example, a resource schema defines a top level required bool attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -53,7 +53,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 
 In this example, a resource schema defines a top level required dynamic attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 In this example, a resource schema defines a top level required float64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 In this example, a resource schema defines a top level required int64 attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a list nested value to 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a list value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the list.

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a map nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the map.

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -29,7 +29,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 In this example, a resource schema defines a top level required number attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -32,7 +32,7 @@ Use one of the following attribute types to directly add a map value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 The `AttributeTypes` field must be defined, which represents the mapping of explicit string object attribute names to [value types](/terraform/plugin/framework/handling-data/types).

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -30,7 +30,7 @@ Use one of the following attribute types to directly add a set nested value to a
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a set value to a [schem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 The `ElementType` field must be defined, which represents the single [value type](/terraform/plugin/framework/handling-data/types) of every element of the set.

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -26,7 +26,7 @@ Use one of the following attribute types to directly add a single nested value t
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 
 In most use cases, the `Attributes` field should be defined, which represents the mapping of explicit string attribute names to nested attributes.

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 In this example, a resource schema defines a top level required string attribute named `example_attribute`:

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the list.

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -43,7 +43,7 @@ Use one of the following block types to directly add a list nested value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 
 The `NestedObject` field must be defined, which represents the [object value type](/terraform/plugin/framework/handling-data/types/object) of every element of the set.

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -38,7 +38,7 @@ Use one of the following block types to directly add a single nested value to a 
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
 In most use cases, the `Attributes` or `Blocks` field should be defined, which represents the mapping of explicit string attribute names to nested attributes and/or blocks.

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a bool value to a [sche
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#BoolAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#BoolAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.BoolAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#BoolAttribute) |
 
 If the bool value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.BoolType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -27,7 +27,7 @@ Use one of the following attribute types to directly add a dynamic value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#DynamicAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#DynamicAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.DynamicAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#DynamicAttribute) |
 
 Dynamic values are not supported as the element type of a [collection type](/terraform/plugin/framework/handling-data/types#collection-types) or within [collection attribute types](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types).

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a float64 value to a [s
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Float64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Float64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Float64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Float64Attribute) |
 
 If the float64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Float64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a int64 value to a [sch
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#Int64Attribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#Int64Attribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.Int64Attribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Int64Attribute) |
 
 If the int64 value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.Int64Type` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a list of a single elem
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListAttribute) |
 
 Use one of the following attribute types to directly add a list of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a list of a nested attr
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ListNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ListNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ListNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ListNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a map of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#MapAttribute) |
 
 Use one of the following attribute types to directly add a map of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -25,7 +25,7 @@ Use one of the following attribute types to directly add a map of a nested attri
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#MapNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#MapNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.MapNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 
 If the map value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.MapType{ElemType: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -23,7 +23,7 @@ Use one of the following attribute types to directly add a number value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#NumberAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#NumberAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.NumberAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#NumberAttribute) |
 
 If the number value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.NumberType` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -24,8 +24,8 @@ Use one of the following attribute types to directly add a single structure of a
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SingleNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SingleNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SingleNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SingleNestedBlock) |
 
@@ -36,7 +36,7 @@ Use one of the following attribute types to directly add an object value directl
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#ObjectAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#ObjectAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.ObjectAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#ObjectAttribute) |
 
 If the object value should be the element type of another [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElementType` field to `types.ObjectType{AttrTypes: /* ... */}` or the appropriate [custom type](#extending).

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a set of a single eleme
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetAttribute) |
 
 Use one of the following attribute types to directly add a set of a nested attributes to a [schema](/terraform/plugin/framework/handling-data/schemas) or [nested attribute type](/terraform/plugin/framework/handling-data/attributes#nested-attribute-types):
@@ -26,8 +26,8 @@ Use one of the following attribute types to directly add a set of a nested attri
 |-------------|-------------------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedAttribute) |
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#SetNestedBlock) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#SetNestedBlock) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.SetNestedBlock`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#SetNestedBlock) |
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -17,7 +17,7 @@ Use one of the following attribute types to directly add a string value to a [sc
 | Schema Type | Attribute Type |
 |-------------|----------------|
 | [Data Source](/terraform/plugin/framework/data-sources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/datasource/schema#StringAttribute) |
-| [Provider](/terraform/plugin/framework/provider) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
+| [Provider](/terraform/plugin/framework/providers) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider/schema#StringAttribute) |
 | [Resource](/terraform/plugin/framework/resources) | [`schema.StringAttribute`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute) |
 
 If the string value should be the element type of a [collection attribute type](/terraform/plugin/framework/handling-data/attributes#collection-attribute-types), set the `ElemType` field to `types.StringType` or the appropriate [custom type](#extending).


### PR DESCRIPTION
### Description

[Asana task 🎟️ ](https://app.asana.com/1/90955849329269/project/1209152747858598/task/1209571039231719)

Fixes broken `/terrafrom/plugin/framework/provider`  links. Replaces them with `/terrafrom/plugin/framework/providers`.

### Testing 

1. Go to [preview link](https://unified-docs-frontend-preview-89b8sb32u-hashicorp.vercel.app/terraform/plugin/framework/handling-data/attributes/bool)
2. Verify that the `Provider` link in the schema type column goes to `/terraform/plugin/framework/providers`
3. Go to another version of the first page
4. Verify the link works on that version too
5. Check any other links in this PR to make sure they work (you don't need to check all 300+ changes)
---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209571039231719