### PR TITLE
add terraform-plugin codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,7 @@
 
 # Terraform Plugin Framework documentation ownership
 /content/terraform-plugin-framework @hashicorp/terraform-devex @hashicorp/terraform-education
+/content/terraform-plugin-log @hashicorp/terraform-devex @hashicorp/terraform-education
+/content/terraform-plugin-mux @hashicorp/terraform-devex @hashicorp/terraform-education
+/content/terraform-plugin-sdk @hashicorp/terraform-devex @hashicorp/terraform-education
+/content/terraform-plugin-testing @hashicorp/terraform-devex @hashicorp/terraform-education


### PR DESCRIPTION
### Description

This PR adds the codeowner teams for the rest of the terraform-plugin repos.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209570270238967