### PR TITLE
Don't check compiled actions for missing copyright header

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -17,5 +17,6 @@ project {
     "Gemfile",
     "scripts/tfe-releases/tfe-releases-repos.yaml",
     "scripts/tfe-releases/app_repos.yaml",
+    ".github/actions/**/out/**",
   ]
 }


### PR DESCRIPTION
The content of this action is(somewhat) auto generated by `ncc` meaning we don't have a great deal of control over its content. Therefore, we can probably safely ignore it when checking for missing copyright headers as it is isn't a source file