### PR TITLE
4. Add APIs for stack states and stack approval

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/stacks.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/stacks.mdx
@@ -78,6 +78,10 @@ The scope of the API includes the following endpoints:
 | `GET`    | `/stack-deployment-steps/:stack_deployment_step_id/stack-diagnostics`                                | Call this endpoint to [list stack deployment step diagnostics](#list-stack-deployment-step-diagnostics).   |
 | `POST`   | `/stack-deployment-steps/:stack_deployment_step_id/advance`                                          | Call this endpoint to [advance a stack deployment step](#advance-a-stack-deployment-step).                 |
 | `POST`   | `/stack-deployment-steps/:stack_deployment_step_id/fail`                                             | Call this endpoint to [fail a stack deployment step](#fail-a-stack-deployment-step).                       |
+| `GET`    | `/stack-approvals/:stack_approval_id`                                                                | Call this endpoint to [show a stack approval](#show-a-stack-approval).                                     |
+| `GET`    | `/stacks/:stack_id/stack-states`                                                                     | Call this endpoint to [list stack states](#list-stack-states).                                             |
+| `GET`    | `/stack-states/:stack_state_id`                                                                      | Call this endpoint to [show a stack state](#show-a-stack-state).                                           |
+| `GET`    | `/stack-states/:stack_state_id/description`                                                          | Call this endpoint to [show a stack state description](#show-a-stack-state-description).                   |
 
 ## Create a stack
 
@@ -1490,7 +1494,7 @@ $ curl\
         "self": "/stack-deployment-groups/stg-RSqektntTNJrAhCm/stack-deployment-runs",
         "stack-states": "/api/v2/stacks/st-ZqqektntTNJrAhCm/stack-states",
         "stack-deployments": "/api/v2/stacks/st-ZqqektntTNJrAhCt/stack-deployments",
-        "stack-deployment-steps": "/stack-deployment-runs/sdr-LSqektntTNJrAhCt/stack-deployment-steps"
+        "stack-deployment-steps": "/api/v2/stack-deployment-runs/sdr-LSqektntTNJrAhCt/stack-deployment-steps"
       },
       "relationships": {
        "stack-deployment-group": {
@@ -1581,10 +1585,10 @@ $ curl\
       "updated-at": "2025-06-11T22:53:04.324Z"
     },
     "links": {
-      "self": "/stack-deployment-groups/stg-RSqektntTNJrAhCm/stack-deployment-runs",
+      "self": "/api/v2/stack-deployment-groups/stg-RSqektntTNJrAhCm/stack-deployment-runs",
       "stack-states": "/api/v2/stacks/st-ZqqektntTNJrAhCm/stack-states",
       "stack-deployments": "/api/v2/stacks/st-ZqqektntTNJrAhCt/stack-deployments",
-      "stack-deployment-steps": "/stack-deployment-runs/sdr-LSqektntTNJrAhCt/stack-deployment-steps"
+      "stack-deployment-steps": "/api/v2/stack-deployment-runs/sdr-LSqektntTNJrAhCt/stack-deployment-steps"
     },
     "relationships": {
       "stack-deployment-group": {
@@ -1731,7 +1735,7 @@ $ curl\
         "updated-at": "2025-06-11T22:53:04.324Z"
       },
       "links": {
-        "self": "/stack-deployment-runs/str-RSqektntTNJrAhCm/stack-deployment-steps",
+        "self": "/api/v2/stack-deployment-runs/str-RSqektntTNJrAhCm/stack-deployment-steps",
         "stack-diagnostics": "/api/v2/stacks/st-EJyw2MktbRjdsg96/stack-diagnostics",
         "plan-description": "/api/v2/stacks/st-EJyw2MktbRjdsg96/plan-description",
         "apply-description": "/api/v2/stacks/st-EJyw2MktbRjdsg96/apply-description",
@@ -1813,7 +1817,7 @@ $ curl\
       "updated-at": "2025-06-11T22:53:04.324Z"
     },
     "links": {
-      "self": "/stack-deployment-runs/str-RSqektntTNJrAhCm/stack-deployment-steps",
+      "self": "/api/v2/stack-deployment-runs/str-RSqektntTNJrAhCm/stack-deployment-steps",
       "stack-diagnostics": "/api/v2/stacks/st-EJyw2MktbRjdsg96/stack-diagnostics",
       "plan-description": "/api/v2/stacks/st-EJyw2MktbRjdsg96/plan-description",
       "apply-description": "/api/v2/stacks/st-EJyw2MktbRjdsg96/apply-description",
@@ -1882,7 +1886,7 @@ $ curl\
         "created-at": "2025-06-11T06:13:01.082Z"
       },
       "links": {
-        "self": "/stack-deployment-steps/sds-LSqektntTNJrAhCt/stack-diagnostics"
+        "self": "/api/v2/stack-deployment-steps/sds-LSqektntTNJrAhCt/stack-diagnostics"
       },
       "relationships": {
        "stack-configuration": {
@@ -1966,4 +1970,246 @@ $ curl\
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   https://app.terraform.io/api/v2/stack-deployment-steps/sds-LSqektntTNJrAhCt/fail
+```
+
+## Show a stack approval
+
+This endpoint gets details about a stack approval.
+
+`GET /stack-approvals/:stack_approval_id`
+
+| Parameter            | Description                           |
+|----------------------|---------------------------------------|
+| `:stack_approval_id` | The id of the stack approval to show. |
+
+### Sample Request
+
+```shell
+$ curl\
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://app.terraform.io/api/v2/stack-approvals/sta-LSqektntTNJrAhCt
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "id": "sta-LSqektntTNJrAhCt",
+    "type": "stack-approvals",
+    "attributes": {
+      "reason": "Infrastructure changes",
+      "created-at": "2025-06-11T15:19:42.478Z",
+    },
+    "links": {
+      "self": "/api/v2/stack-approvals/sta-LSqektntTNJrAhCt"
+    },
+    "relationships": {
+      "stack-deployment-run": {
+        "data": {
+          "id": "sdr-RSqektntTNJrAhCm",
+          "type": "stack-deployment-runs"
+        }
+      },
+      "stack-approval": {
+        "data": {
+          "id": "sta-qB6dJk7G7r7icTE8",
+          "type": "stack-approvals"
+        }
+      }
+    }
+  }
+}
+```
+
+## List stack states
+
+/*TODO: For reviewer - check if the examples for address, component-address, instance-correlator and component-correlator make sense */
+
+This endpoint lists states for a stack.
+
+`GET /stacks/:stack_id/stack-states`
+
+| Parameter   | Description                                                |
+|-------------|------------------------------------------------------------|
+| `:stack_id` | The id of the stack for which the states are being listed. |
+
+### Query Parameters
+
+This endpoint supports pagination [with standard URL query parameters](/terraform/cloud-docs/api-docs#query-parameters); remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
+
+| Parameter      | Description                                                                  |
+|----------------|------------------------------------------------------------------------------|
+| `page[number]` | **Optional.** If omitted, the endpoint will return the first page.           |
+| `page[size]`   | **Optional.** If omitted, the endpoint will return 20 stack states per page. |
+
+### Sample Request
+
+```shell
+$ curl\
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://app.terraform.io/api/v2/stacks/st-VrqRktntTNJrAhBz/stack-states
+```
+
+### Sample Response
+
+```json
+{
+  "data": [
+    {
+      "id": "sts-PrqektntTNJrAhCm",
+      "type": "stack-states",
+      "attributes": {
+        "generation": 0,
+            "deployment-name": "staging",
+        "status": "created",
+        "components": [
+          {
+            "name": "webserver",
+            "address": "192.168.1.1",
+            "component-address": "ec2-3-91-22-35.compute-1.amazonaws.com",
+            "instance-correlator": "instance-12345",
+            "component-correlator": "component-67890",
+            "resource-instance-count": 3
+          }
+        ],
+        "is-current": true,
+        "resource-instance-count": 3
+      },
+      "links": {
+        "self": "/api/v2/stacks/st-VrqRktntTNJrAhBz/stack-states",
+        "description": "/api/v2/stacks/st-VrqRktntTNJrAhBz/description",
+        "stack-deployment": "/api/v2/stacks/st-VrqRktntTNJrAhBz/stack-deployments"
+      },
+      "relationships": {
+       "stack": {
+          "data": {
+            "id": "st-VrqRktntTNJrAhBz",
+            "type": "stacks"
+          }
+        },
+        "stack-deployment-run": {
+          "data": {
+            "id": "sdr-qB6dJk7G7r7icTE8",
+            "type": "stack-deployment-runs "
+          }
+        }
+      }
+    }
+  ],
+  "links": {
+    "self": "https://app.terraform.io/api/v2/stacks/st-VrqRktntTNJrAhBz/stack-states?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+    "first": "https://app.terraform.io/api/v2/stacks/st-VrqRktntTNJrAhBz/stack-states?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+    "prev": null,
+    "next": null,
+    "last": "https://app.terraform.io/api/v2/stacks/st-VrqRktntTNJrAhBz/stack-states?page%5Bnumber%5D=1&page%5Bsize%5D=20"
+  },
+  "meta": {
+    "pagination": {
+      "current-page": 1,
+      "page-size": 20,
+      "prev-page": null,
+      "next-page": null,
+      "total-pages": 1,
+      "total-count": 1
+    }
+  }
+}
+```
+
+## Show a stack state
+
+/*TODO: For reviewer - check if the examples for address, component-address, instance-correlator and component-correlator make sense */
+
+This endpoint gets details about a stack state.
+
+`GET /stack_states/:stack_state_id`
+
+| Parameter         | Description                                   |
+|-------------------|-----------------------------------------------|
+| `:stack_state_id` | The id of the stack state to get details for. |
+
+### Sample Request
+
+```shell
+$ curl\
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://app.terraform.io/api/v2/stack-states/sts-PrqektntTNJrAhCm
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "id": "sts-PrqektntTNJrAhCm",
+    "type": "stack-states",
+    "attributes": {
+      "generation": 0,
+      "deployment-name": "staging",
+      "status": "created",
+      "components": [
+        {
+          "name": "webserver",
+          "address": "192.168.1.1",
+          "component-address": "ec2-3-91-22-35.compute-1.amazonaws.com",
+          "instance-correlator": "instance-12345",
+          "component-correlator": "component-67890",
+          "resource-instance-count": 3
+        }
+      ],
+      "is-current": true,
+      "resource-instance-count": 3
+    },
+    "links": {
+      "self": "/api/v2/stack-states/sts-PrqektntTNJrAhCm",
+      "description": "/api/v2/stack-states/sts-PrqektntTNJrAhCm/description",
+      "stack-deployment": "/api/v2/stacks/st-VrqRktntTNJrAhBz/stack-deployments"
+    },
+    "relationships": {
+      "stack": {
+        "data": {
+          "id": "st-VrqRktntTNJrAhBz",
+          "type": "stacks"
+        }
+      },
+      "stack-deployment-run": {
+        "data": {
+          "id": "sdr-qB6dJk7G7r7icTE8",
+          "type": "stack-deployment-runs "
+        }
+      }
+    }
+  }
+}
+```
+
+## Show a stack state description
+
+This endpoint redirects to a download url for a stack state description.
+
+`GET /stack-states/:stack_state_id/description`
+
+| Parameter         | Description                                                       |
+|-------------------|-------------------------------------------------------------------|
+| `:stack_state_id` | The id of the stack state to get the stack state description for. |
+
+
+| Status  | Response                  | Reason                                                             |
+|---------|---------------------------|--------------------------------------------------------------------|
+| [204][] | No Content                | Responds with empty success when state has not yet been uploaded.  |
+| [302][] | [JSON API error object][] | Redirect client to temporary stack state description download URL. |
+| [404][] | [JSON API error object][] | Stack state not found, or user unauthorized to perform action.     |
+
+
+### Sample Request
+
+```shell
+$ curl\
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://app.terraform.io/api/v2/stack-states/sts-LSqektntTNJrAhCt/description
 ```


### PR DESCRIPTION
This PR adds API docs for stack states and stack approval.
https://hashicorp.atlassian.net/browse/TF-26298

NOTE: This PR will remain in draft as this cannot be merged before stacks goes GA.
The API documentation has been divided into multiple PRs to simplify the review process. As each of these PRs is approved, it will be merged into mr/stacks-api-ga branch.

API's introduced in this PR:

```
1. GET /stack-approvals/{stack_approval_id}
2. GET /stacks/{stack_id}/stack-states
3. GET /stack-states/{stack_state_id}
4. GET /stack-states/{stack_state_id}/description
```
