### PR TITLE
Docs/query data sources

### DIFF
--- a/content/terraform/v1.12.x/docs/language/data-sources/index.mdx
+++ b/content/terraform/v1.12.x/docs/language/data-sources/index.mdx
@@ -94,10 +94,7 @@ You can use many of the built-in Terrafrom arguments, referred to as [meta-argum
 
 ### Dependencies
 
-Add a [`depends_on` argument](/terraform/language/block/data#depends_on) to a `data` block to specify dependencies. The `depends_on` argument configures Terraform to defer querying the data source until after it finishes operations for the specified dependency. 
-
-To ensure that Terraform fetches the most up to date information from the data source, Terraform treats arguments that directly reference Terraform-managed resources the same as if the resource was listed in `depends_on`. To change this behavior, you can indirectly reference the managed resource values through a `local` value as long as the data resource does not contain [custom conditions](#custom-condition-checks).
-
+Terraform correctly detects dependencies in your configuration, even when indirectly reference a Terraform-managed resource values through a `local` value. There may be times when you want to ensure that Terraform creates resources in a specific order. In those cases, you can add a [`depends_on` argument](/terraform/language/block/data#depends_on) to a `data` block to modify the dependency graph. The `depends_on` argument configures Terraform to defer querying the data source until after it finishes operations for the specified dependency.
 
 ### Custom condition checks 
 


### PR DESCRIPTION
This PR updates the instructions for adding `data` blocks to your configuration to query external data sources. I did not change the file name or move the page during this phase, so the path is still `/terraform/language/data-sources`.  

Note that I originally did not plan on keeping the "Complete example" section at the end, but I reintroduced it while updating this page. We can remove it if we don't believe it's necessary.