### PR TITLE
Fix style guides violations in style guides

### DIFF
--- a/content/terraform/v1.10.x/docs/language/style.mdx
+++ b/content/terraform/v1.10.x/docs/language/style.mdx
@@ -355,20 +355,25 @@ variable "web_instances" {
     "metrics"
   ]
 }
+
 resource "aws_instance" "web" {
   for_each = toset(var.web_instances)
+
   ami           = data.aws_ami.webapp.id
   instance_type = "t3.micro"
+
   tags = {
     Name = "web_${each.key}"
   }
 }
+
 output "web_private_ips" {
   description = "Private IPs of the web instances"
   value = {
     for k, v in aws_instance.web : k => v.private_ip
   }
 }
+
 output "web_ui_public_ip" {
   description = "Public IP of the web UI instance"
   value       = aws_instance.web["ui"].public_ip
@@ -403,8 +408,8 @@ A common practice to conditionally create resources is to use the `count` meta-a
 
 ```hcl
 variable "enable_metrics" {
-  description = "True if the metrics server should be deployed"
   type        = bool
+  description = "True if the metrics server should be deployed"
   default     = true
 }
 

--- a/content/terraform/v1.11.x/docs/language/style.mdx
+++ b/content/terraform/v1.11.x/docs/language/style.mdx
@@ -355,20 +355,25 @@ variable "web_instances" {
     "metrics"
   ]
 }
+
 resource "aws_instance" "web" {
   for_each = toset(var.web_instances)
+
   ami           = data.aws_ami.webapp.id
   instance_type = "t3.micro"
+
   tags = {
     Name = "web_${each.key}"
   }
 }
+
 output "web_private_ips" {
   description = "Private IPs of the web instances"
   value = {
     for k, v in aws_instance.web : k => v.private_ip
   }
 }
+
 output "web_ui_public_ip" {
   description = "Public IP of the web UI instance"
   value       = aws_instance.web["ui"].public_ip
@@ -403,8 +408,8 @@ A common practice to conditionally create resources is to use the `count` meta-a
 
 ```hcl
 variable "enable_metrics" {
-  description = "True if the metrics server should be deployed"
   type        = bool
+  description = "True if the metrics server should be deployed"
   default     = true
 }
 

--- a/content/terraform/v1.12.x/docs/language/style.mdx
+++ b/content/terraform/v1.12.x/docs/language/style.mdx
@@ -355,20 +355,25 @@ variable "web_instances" {
     "metrics"
   ]
 }
+
 resource "aws_instance" "web" {
   for_each = toset(var.web_instances)
+
   ami           = data.aws_ami.webapp.id
   instance_type = "t3.micro"
+
   tags = {
     Name = "web_${each.key}"
   }
 }
+
 output "web_private_ips" {
   description = "Private IPs of the web instances"
   value = {
     for k, v in aws_instance.web : k => v.private_ip
   }
 }
+
 output "web_ui_public_ip" {
   description = "Public IP of the web UI instance"
   value       = aws_instance.web["ui"].public_ip
@@ -403,8 +408,8 @@ A common practice to conditionally create resources is to use the `count` meta-a
 
 ```hcl
 variable "enable_metrics" {
-  description = "True if the metrics server should be deployed"
   type        = bool
+  description = "True if the metrics server should be deployed"
   default     = true
 }
 

--- a/content/terraform/v1.2.x/docs/language/style.mdx
+++ b/content/terraform/v1.2.x/docs/language/style.mdx
@@ -355,20 +355,25 @@ variable "web_instances" {
     "metrics"
   ]
 }
+
 resource "aws_instance" "web" {
   for_each = toset(var.web_instances)
+
   ami           = data.aws_ami.webapp.id
   instance_type = "t3.micro"
+
   tags = {
     Name = "web_${each.key}"
   }
 }
+
 output "web_private_ips" {
   description = "Private IPs of the web instances"
   value = {
     for k, v in aws_instance.web : k => v.private_ip
   }
 }
+
 output "web_ui_public_ip" {
   description = "Public IP of the web UI instance"
   value       = aws_instance.web["ui"].public_ip
@@ -403,8 +408,8 @@ A common practice to conditionally create resources is to use the `count` meta-a
 
 ```hcl
 variable "enable_metrics" {
-  description = "True if the metrics server should be deployed"
   type        = bool
+  description = "True if the metrics server should be deployed"
   default     = true
 }
 

--- a/content/terraform/v1.3.x/docs/language/style.mdx
+++ b/content/terraform/v1.3.x/docs/language/style.mdx
@@ -355,20 +355,25 @@ variable "web_instances" {
     "metrics"
   ]
 }
+
 resource "aws_instance" "web" {
   for_each = toset(var.web_instances)
+
   ami           = data.aws_ami.webapp.id
   instance_type = "t3.micro"
+
   tags = {
     Name = "web_${each.key}"
   }
 }
+
 output "web_private_ips" {
   description = "Private IPs of the web instances"
   value = {
     for k, v in aws_instance.web : k => v.private_ip
   }
 }
+
 output "web_ui_public_ip" {
   description = "Public IP of the web UI instance"
   value       = aws_instance.web["ui"].public_ip
@@ -403,8 +408,8 @@ A common practice to conditionally create resources is to use the `count` meta-a
 
 ```hcl
 variable "enable_metrics" {
-  description = "True if the metrics server should be deployed"
   type        = bool
+  description = "True if the metrics server should be deployed"
   default     = true
 }
 

--- a/content/terraform/v1.4.x/docs/language/style.mdx
+++ b/content/terraform/v1.4.x/docs/language/style.mdx
@@ -355,20 +355,25 @@ variable "web_instances" {
     "metrics"
   ]
 }
+
 resource "aws_instance" "web" {
   for_each = toset(var.web_instances)
+
   ami           = data.aws_ami.webapp.id
   instance_type = "t3.micro"
+
   tags = {
     Name = "web_${each.key}"
   }
 }
+
 output "web_private_ips" {
   description = "Private IPs of the web instances"
   value = {
     for k, v in aws_instance.web : k => v.private_ip
   }
 }
+
 output "web_ui_public_ip" {
   description = "Public IP of the web UI instance"
   value       = aws_instance.web["ui"].public_ip
@@ -403,8 +408,8 @@ A common practice to conditionally create resources is to use the `count` meta-a
 
 ```hcl
 variable "enable_metrics" {
-  description = "True if the metrics server should be deployed"
   type        = bool
+  description = "True if the metrics server should be deployed"
   default     = true
 }
 

--- a/content/terraform/v1.6.x/docs/language/style.mdx
+++ b/content/terraform/v1.6.x/docs/language/style.mdx
@@ -355,20 +355,25 @@ variable "web_instances" {
     "metrics"
   ]
 }
+
 resource "aws_instance" "web" {
   for_each = toset(var.web_instances)
+
   ami           = data.aws_ami.webapp.id
   instance_type = "t3.micro"
+
   tags = {
     Name = "web_${each.key}"
   }
 }
+
 output "web_private_ips" {
   description = "Private IPs of the web instances"
   value = {
     for k, v in aws_instance.web : k => v.private_ip
   }
 }
+
 output "web_ui_public_ip" {
   description = "Public IP of the web UI instance"
   value       = aws_instance.web["ui"].public_ip
@@ -403,8 +408,8 @@ A common practice to conditionally create resources is to use the `count` meta-a
 
 ```hcl
 variable "enable_metrics" {
-  description = "True if the metrics server should be deployed"
   type        = bool
+  description = "True if the metrics server should be deployed"
   default     = true
 }
 

--- a/content/terraform/v1.7.x/docs/language/style.mdx
+++ b/content/terraform/v1.7.x/docs/language/style.mdx
@@ -355,20 +355,25 @@ variable "web_instances" {
     "metrics"
   ]
 }
+
 resource "aws_instance" "web" {
   for_each = toset(var.web_instances)
+
   ami           = data.aws_ami.webapp.id
   instance_type = "t3.micro"
+
   tags = {
     Name = "web_${each.key}"
   }
 }
+
 output "web_private_ips" {
   description = "Private IPs of the web instances"
   value = {
     for k, v in aws_instance.web : k => v.private_ip
   }
 }
+
 output "web_ui_public_ip" {
   description = "Public IP of the web UI instance"
   value       = aws_instance.web["ui"].public_ip
@@ -403,8 +408,8 @@ A common practice to conditionally create resources is to use the `count` meta-a
 
 ```hcl
 variable "enable_metrics" {
-  description = "True if the metrics server should be deployed"
   type        = bool
+  description = "True if the metrics server should be deployed"
   default     = true
 }
 

--- a/content/terraform/v1.8.x/docs/language/style.mdx
+++ b/content/terraform/v1.8.x/docs/language/style.mdx
@@ -355,20 +355,25 @@ variable "web_instances" {
     "metrics"
   ]
 }
+
 resource "aws_instance" "web" {
   for_each = toset(var.web_instances)
+
   ami           = data.aws_ami.webapp.id
   instance_type = "t3.micro"
+
   tags = {
     Name = "web_${each.key}"
   }
 }
+
 output "web_private_ips" {
   description = "Private IPs of the web instances"
   value = {
     for k, v in aws_instance.web : k => v.private_ip
   }
 }
+
 output "web_ui_public_ip" {
   description = "Public IP of the web UI instance"
   value       = aws_instance.web["ui"].public_ip
@@ -403,8 +408,8 @@ A common practice to conditionally create resources is to use the `count` meta-a
 
 ```hcl
 variable "enable_metrics" {
-  description = "True if the metrics server should be deployed"
   type        = bool
+  description = "True if the metrics server should be deployed"
   default     = true
 }
 

--- a/content/terraform/v1.9.x/docs/language/style.mdx
+++ b/content/terraform/v1.9.x/docs/language/style.mdx
@@ -355,20 +355,25 @@ variable "web_instances" {
     "metrics"
   ]
 }
+
 resource "aws_instance" "web" {
   for_each = toset(var.web_instances)
+
   ami           = data.aws_ami.webapp.id
   instance_type = "t3.micro"
+
   tags = {
     Name = "web_${each.key}"
   }
 }
+
 output "web_private_ips" {
   description = "Private IPs of the web instances"
   value = {
     for k, v in aws_instance.web : k => v.private_ip
   }
 }
+
 output "web_ui_public_ip" {
   description = "Public IP of the web UI instance"
   value       = aws_instance.web["ui"].public_ip
@@ -403,8 +408,8 @@ A common practice to conditionally create resources is to use the `count` meta-a
 
 ```hcl
 variable "enable_metrics" {
-  description = "True if the metrics server should be deployed"
   type        = bool
+  description = "True if the metrics server should be deployed"
   default     = true
 }
 


### PR DESCRIPTION
Ironically, the Style Guide page violates its own guides:

**Violation 1:**

Spacing between resource blocks, meta-arguments, and meta-argument blocks as per [Style Guide -> Code formatting](https://developer.hashicorp.com/terraform/language/style#code-formatting)

**Violation 2:**

`type` comes before `description` when defining variables as per [Style Guide -> Variables](https://developer.hashicorp.com/terraform/language/style#variables)