### PR TITLE
terraform/language: Mention provider-defined functions

### DIFF
--- a/content/terraform/v1.10.x/docs/language/functions/index.mdx
+++ b/content/terraform/v1.10.x/docs/language/functions/index.mdx
@@ -24,12 +24,14 @@ in the Expressions section.
 
 # Provider-defined Functions
 
-The Terraform language does not support _user_-defined functions.
-However [providers can implement functions](/terraform/plugin/framework/functions)
-which users can use.
+You cannot define your own functions in the Terraform configuration language, but
+you can develop your own providers that expose functions. Refer to
+[Provider-defined functions](/terraform/plugin/framework/functions)
+for information about defining functions in custom providers.
 
-The language requires such functions to use a prefix `provider::<local-name>::`
-where `<local-name>` corresponds with an entry in `required_providers` block.
+When using a provider-specific function, add the `provider::<local-name>::` where
+`<local-name>` corresponds with an entry in the `required_providers` block.
+The following example calls the `encoode_tvfars` function in the `terraform` provider:
 
 ```hcl
 provider::terraform::encode_tfvars({

--- a/content/terraform/v1.11.x/docs/language/functions/index.mdx
+++ b/content/terraform/v1.11.x/docs/language/functions/index.mdx
@@ -24,12 +24,14 @@ in the Expressions section.
 
 # Provider-defined Functions
 
-The Terraform language does not support _user_-defined functions.
-However [providers can implement functions](/terraform/plugin/framework/functions)
-which users can use.
+You cannot define your own functions in the Terraform configuration language, but
+you can develop your own providers that expose functions. Refer to
+[Provider-defined functions](/terraform/plugin/framework/functions)
+for information about defining functions in custom providers.
 
-The language requires such functions to use a prefix `provider::<local-name>::`
-where `<local-name>` corresponds with an entry in `required_providers` block.
+When using a provider-specific function, add the `provider::<local-name>::` where
+`<local-name>` corresponds with an entry in the `required_providers` block.
+The following example calls the `encoode_tvfars` function in the `terraform` provider:
 
 ```hcl
 provider::terraform::encode_tfvars({

--- a/content/terraform/v1.12.x/docs/language/functions/index.mdx
+++ b/content/terraform/v1.12.x/docs/language/functions/index.mdx
@@ -24,12 +24,14 @@ in the Expressions section.
 
 # Provider-defined Functions
 
-The Terraform language does not support _user_-defined functions.
-However [providers can implement functions](/terraform/plugin/framework/functions)
-which users can use.
+You cannot define your own functions in the Terraform configuration language, but
+you can develop your own providers that expose functions. Refer to
+[Provider-defined functions](/terraform/plugin/framework/functions)
+for information about defining functions in custom providers.
 
-The language requires such functions to use a prefix `provider::<local-name>::`
-where `<local-name>` corresponds with an entry in `required_providers` block.
+When using a provider-specific function, add the `provider::<local-name>::` where
+`<local-name>` corresponds with an entry in the `required_providers` block.
+The following example calls the `encoode_tvfars` function in the `terraform` provider:
 
 ```hcl
 provider::terraform::encode_tfvars({

--- a/content/terraform/v1.8.x/docs/language/functions/index.mdx
+++ b/content/terraform/v1.8.x/docs/language/functions/index.mdx
@@ -24,12 +24,14 @@ in the Expressions section.
 
 # Provider-defined Functions
 
-The Terraform language does not support _user_-defined functions.
-However [providers can implement functions](/terraform/plugin/framework/functions)
-which users can use.
+You cannot define your own functions in the Terraform configuration language, but
+you can develop your own providers that expose functions. Refer to
+[Provider-defined functions](/terraform/plugin/framework/functions)
+for information about defining functions in custom providers.
 
-The language requires such functions to use a prefix `provider::<local-name>::`
-where `<local-name>` corresponds with an entry in `required_providers` block.
+When using a provider-specific function, add the `provider::<local-name>::` where
+`<local-name>` corresponds with an entry in the `required_providers` block.
+The following example calls the `encoode_tvfars` function in the `terraform` provider:
 
 ```hcl
 provider::terraform::encode_tfvars({

--- a/content/terraform/v1.9.x/docs/language/functions/index.mdx
+++ b/content/terraform/v1.9.x/docs/language/functions/index.mdx
@@ -24,12 +24,14 @@ in the Expressions section.
 
 # Provider-defined Functions
 
-The Terraform language does not support _user_-defined functions.
-However [providers can implement functions](/terraform/plugin/framework/functions)
-which users can use.
+You cannot define your own functions in the Terraform configuration language, but
+you can develop your own providers that expose functions. Refer to
+[Provider-defined functions](/terraform/plugin/framework/functions)
+for information about defining functions in custom providers.
 
-The language requires such functions to use a prefix `provider::<local-name>::`
-where `<local-name>` corresponds with an entry in `required_providers` block.
+When using a provider-specific function, add the `provider::<local-name>::` where
+`<local-name>` corresponds with an entry in the `required_providers` block.
+The following example calls the `encoode_tvfars` function in the `terraform` provider:
 
 ```hcl
 provider::terraform::encode_tfvars({


### PR DESCRIPTION
We could add a warning box about the provider-defined functions being available only in Terraform 1.8+ but AFAICT we are trying to move away from such convention in favour of simply implying the version restrictions from versioned docs.

Happy to make adjustments though if that's not the case.