### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,26 +27,5 @@
 
 # Vault documentation ownership
 
-/content/vault/*/docs/plugins/                     @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
-/content/vault/docs/upgrading/plugins.mdx          @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
 /content/vault/                                    @hashicorp/vault-education-approvers
-/content/vault/*/docs/secrets/pki/                 @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/api-docs/secret/pki/                @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/api-docs/secret/pki.mdx             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/*/docs/auth/cert.mdx                @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/api-docs/auth/cert.mdx              @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/*/docs/secrets/ssh/                 @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/api-docs/secret/ssh.mdx             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/*/docs/secrets/transit/             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/api-docs/secret/transit.mdx         @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/*/docs/configuration/seal/          @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/*/docs/enterprise/sealwrap.mdx      @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/api-docs/system/sealwrap-rewrap.mdx @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/*/docs/secrets/transform/           @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/api-docs/secret/transform.mdx       @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/*/docs/secrets/kmip-profiles.mdx    @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/*/docs/secrets/kmip.mdx             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/api-docs/secret/kmip.mdx            @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/*/docs/enterprise/fips/             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/content/vault/*/docs/platform/k8s                 @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
-/content/vault/                                    @hashicorp/vault-customer-engineering @hashicorp/vault-education-approvers
+


### PR DESCRIPTION
Descriptions: 
CodeOwners updated with necessary groups

Why: 
Team is migrating Vault over and teams need to still have access to appropriate files and folders with notification of changes to repo

