### PR TITLE
Fix broken 'drift-and-opa' links in 'style.mdx' and 'govern.mdx'

### DIFF
--- a/content/terraform/v1.10.x/docs/intro/phases/govern.mdx
+++ b/content/terraform/v1.10.x/docs/intro/phases/govern.mdx
@@ -13,7 +13,7 @@ You can use policy as code to ensure your infrastructure meets your organization
 
 You can define policies that set standards for both your infrastructure configuration itself, and for the workflows around configuration deployment. Some examples of policy rules you can define include which ports are open in a firewall, the permitted sizes of virtual machines, or that deployments cannot take place on Fridays. In HCP Terraform and Terraform Enterprise you can use either [OPA](/terraform/cloud-docs/policy-enforcement/opa) or [Sentinel](https://www.hashicorp.com/sentinel) for your policy definitions. 
 
-Learn how to [write a Sentinel policy for a Terraform Deployment](/terraform/tutorials/policy/sentinel-policy) and how to [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa).
+Learn how to [write a Sentinel policy for a Terraform Deployment](/terraform/tutorials/policy/sentinel-policy) and how to [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy).
 
 ## Next steps
 

--- a/content/terraform/v1.10.x/docs/language/style.mdx
+++ b/content/terraform/v1.10.x/docs/language/style.mdx
@@ -672,7 +672,7 @@ Policies are rules that HCP Terraform enforces on Terraform runs. You can use po
 
 We recommend that you store policies in a separate VCS repository from your Terraform code.
 
-For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sentinel](/terraform/tutorials/policy) and [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa) tutorials.
+For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sentinel](/terraform/tutorials/policy) and [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy) tutorials.
 
 ## Next steps
 

--- a/content/terraform/v1.11.x/docs/intro/phases/govern.mdx
+++ b/content/terraform/v1.11.x/docs/intro/phases/govern.mdx
@@ -13,7 +13,7 @@ You can use policy as code to ensure your infrastructure meets your organization
 
 You can define policies that set standards for both your infrastructure configuration itself, and for the workflows around configuration deployment. Some examples of policy rules you can define include which ports are open in a firewall, the permitted sizes of virtual machines, or that deployments cannot take place on Fridays. In HCP Terraform and Terraform Enterprise you can use either [OPA](/terraform/cloud-docs/policy-enforcement/opa) or [Sentinel](https://www.hashicorp.com/sentinel) for your policy definitions. 
 
-Learn how to [write a Sentinel policy for a Terraform Deployment](/terraform/tutorials/policy/sentinel-policy) and how to [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa).
+Learn how to [write a Sentinel policy for a Terraform Deployment](/terraform/tutorials/policy/sentinel-policy) and how to [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy).
 
 ## Next steps
 

--- a/content/terraform/v1.11.x/docs/language/style.mdx
+++ b/content/terraform/v1.11.x/docs/language/style.mdx
@@ -672,7 +672,7 @@ Policies are rules that HCP Terraform enforces on Terraform runs. You can use po
 
 We recommend that you store policies in a separate VCS repository from your Terraform code.
 
-For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sentinel](/terraform/tutorials/policy) and [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa) tutorials.
+For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sentinel](/terraform/tutorials/policy) and [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy) tutorials.
 
 ## Next steps
 

--- a/content/terraform/v1.2.x/docs/language/style.mdx
+++ b/content/terraform/v1.2.x/docs/language/style.mdx
@@ -672,7 +672,7 @@ Policies are rules that Terraform Cloud enforces on Terraform runs. You can use 
 
 We recommend that you store policies in a separate VCS repository from your Terraform code.
 
-For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sential](/terraform/tutorials/policy) and [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa) tutorials.
+For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sential](/terraform/tutorials/policy) and [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy) tutorials.
 
 ## Next steps
 

--- a/content/terraform/v1.3.x/docs/language/style.mdx
+++ b/content/terraform/v1.3.x/docs/language/style.mdx
@@ -672,7 +672,7 @@ Policies are rules that Terraform Cloud enforces on Terraform runs. You can use 
 
 We recommend that you store policies in a separate VCS repository from your Terraform code.
 
-For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sential](/terraform/tutorials/policy) and [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa) tutorials.
+For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sential](/terraform/tutorials/policy) and [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy) tutorials.
 
 ## Next steps
 

--- a/content/terraform/v1.4.x/docs/language/style.mdx
+++ b/content/terraform/v1.4.x/docs/language/style.mdx
@@ -672,7 +672,7 @@ Policies are rules that Terraform Cloud enforces on Terraform runs. You can use 
 
 We recommend that you store policies in a separate VCS repository from your Terraform code.
 
-For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sential](/terraform/tutorials/policy) and [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa) tutorials.
+For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sential](/terraform/tutorials/policy) and [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy) tutorials.
 
 ## Next steps
 

--- a/content/terraform/v1.6.x/docs/language/style.mdx
+++ b/content/terraform/v1.6.x/docs/language/style.mdx
@@ -672,7 +672,7 @@ Policies are rules that Terraform Cloud enforces on Terraform runs. You can use 
 
 We recommend that you store policies in a separate VCS repository from your Terraform code.
 
-For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sential](/terraform/tutorials/policy) and [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa) tutorials.
+For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sential](/terraform/tutorials/policy) and [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy) tutorials.
 
 ## Next steps
 

--- a/content/terraform/v1.7.x/docs/language/style.mdx
+++ b/content/terraform/v1.7.x/docs/language/style.mdx
@@ -672,7 +672,7 @@ Policies are rules that Terraform Cloud enforces on Terraform runs. You can use 
 
 We recommend that you store policies in a separate VCS repository from your Terraform code.
 
-For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sential](/terraform/tutorials/policy) and [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa) tutorials.
+For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sential](/terraform/tutorials/policy) and [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy) tutorials.
 
 ## Next steps
 

--- a/content/terraform/v1.8.x/docs/intro/phases/govern.mdx
+++ b/content/terraform/v1.8.x/docs/intro/phases/govern.mdx
@@ -13,7 +13,7 @@ You can use policy as code to ensure your infrastructure meets your organization
 
 You can define policies that set standards for both your infrastructure configuration itself, and for the workflows around configuration deployment. Some examples of policy rules you can define include which ports are open in a firewall, the permitted sizes of virtual machines, or that deployments cannot take place on Fridays. In HCP Terraform and Terraform Enterprise you can use either [OPA](/terraform/cloud-docs/policy-enforcement/opa) or [Sentinel](https://www.hashicorp.com/sentinel) for your policy definitions. 
 
-Learn how to [write a Sentinel policy for a Terraform Deployment](/terraform/tutorials/policy/sentinel-policy) and how to [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa).
+Learn how to [write a Sentinel policy for a Terraform Deployment](/terraform/tutorials/policy/sentinel-policy) and how to [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy).
 
 ## Next steps
 

--- a/content/terraform/v1.8.x/docs/language/style.mdx
+++ b/content/terraform/v1.8.x/docs/language/style.mdx
@@ -672,7 +672,7 @@ Policies are rules that HCP Terraform enforces on Terraform runs. You can use po
 
 We recommend that you store policies in a separate VCS repository from your Terraform code.
 
-For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sentinel](/terraform/tutorials/policy) and [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa) tutorials.
+For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sentinel](/terraform/tutorials/policy) and [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy) tutorials.
 
 ## Next steps
 

--- a/content/terraform/v1.9.x/docs/intro/phases/govern.mdx
+++ b/content/terraform/v1.9.x/docs/intro/phases/govern.mdx
@@ -13,7 +13,7 @@ You can use policy as code to ensure your infrastructure meets your organization
 
 You can define policies that set standards for both your infrastructure configuration itself, and for the workflows around configuration deployment. Some examples of policy rules you can define include which ports are open in a firewall, the permitted sizes of virtual machines, or that deployments cannot take place on Fridays. In HCP Terraform and Terraform Enterprise you can use either [OPA](/terraform/cloud-docs/policy-enforcement/opa) or [Sentinel](https://www.hashicorp.com/sentinel) for your policy definitions. 
 
-Learn how to [write a Sentinel policy for a Terraform Deployment](/terraform/tutorials/policy/sentinel-policy) and how to [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa).
+Learn how to [write a Sentinel policy for a Terraform Deployment](/terraform/tutorials/policy/sentinel-policy) and how to [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy).
 
 ## Next steps
 

--- a/content/terraform/v1.9.x/docs/language/style.mdx
+++ b/content/terraform/v1.9.x/docs/language/style.mdx
@@ -672,7 +672,7 @@ Policies are rules that HCP Terraform enforces on Terraform runs. You can use po
 
 We recommend that you store policies in a separate VCS repository from your Terraform code.
 
-For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sentinel](/terraform/tutorials/policy) and [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa) tutorials.
+For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sentinel](/terraform/tutorials/policy) and [detect infrastructure drift and enforce policies](/terraform/tutorials/cloud/drift-and-policy) tutorials.
 
 ## Next steps
 


### PR DESCRIPTION
Noticed these broken links in the automated comments of other PRs that I raised:

* #537 
* #538 
* #539 
* #541 

"[drift-and-opa](https://developer.hashicorp.com/terraform/tutorials/cloud/drift-and-opa)" link is broken and "[drift-and-policy](https://developer.hashicorp.com/terraform/tutorials/cloud/drift-and-policy)" seems to be the correct one. "OPA" has also been removed from the link text itself in v1.12.x and v1.13.x which I applied here too.