### PR TITLE
Audit: Support audit log file rotation

### DIFF
--- a/content/vault/v1.20.x/content/docs/audit/best-practices.mdx
+++ b/content/vault/v1.20.x/content/docs/audit/best-practices.mdx
@@ -36,7 +36,9 @@ Vault does not respond to client requests it cannot log. Enabling at least two a
 
 If you enable a `file` audit device, use a dedicated volume or partition for Vault's audit logs to protect against other workloads on the system taking up the disk space intended for your log files.
 
-Additionally, establish a log rotation process that is appropriate for your organization, deployment, and policies, using a purpose-built system like *logrotate*. Configure your log rotation system to send Vault an `HUP` signal, which causes Vault to start writing audit log entries to the new log file.
+Additionally, establish a log rotation process that is appropriate for your organization, deployment, and policies, using `max_files`, `max_bytes` and `max_duration` configuration options.
+
+Alternatively, you can use a purpose-built system like *logrotate*. Configure your log rotation system to send Vault an `HUP` signal, which causes Vault to start writing audit log entries to the new log file.
 
 <Tip title="Logging with Kubernetes">
 

--- a/content/vault/v1.20.x/content/docs/audit/file.mdx
+++ b/content/vault/v1.20.x/content/docs/audit/file.mdx
@@ -9,12 +9,8 @@ description: The "file" audit device writes audit logs to a file.
 The `file` audit device writes audit logs to a file. This is a very simple audit
 device: it appends logs to a file.
 
-The device does not currently assist with any log rotation. There are very
-stable and feature-filled log rotation tools already, so we recommend using
-existing tools.
-
-Sending a `SIGHUP` to the Vault process will cause `file` audit devices to close
-and re-open their underlying file, which can assist with log rotation needs.
+By default, the log file is set to rotate every 24 hours, and all older log files
+are kept indefinitely.
 
 ## Examples
 
@@ -37,6 +33,25 @@ Enable logs on stdout. This is useful when running in a container:
 $ vault audit enable file file_path=stdout
 ```
 
+Enable log rotation every 24 hours, with a maximum of 5 older log file archives to keep:
+
+```shell-session
+$ vault audit enable file file_path=/var/log/vault_audit.log max_duration=24h max_files=5
+```
+
+Enable log rotation every 500 MB and never delete older log file archives:
+
+```shell-session
+$ vault audit enable file file_path=/var/log/vault_audit.log max_bytes=524288000 max_duration=0 max_files=0
+```
+
+Disable log rotation altogether:
+
+```shell-session
+$ vault audit enable file file_path=/var/log/vault_audit.log max_duration=0
+```
+
+
 ## Configuration
 
 Note the difference between `audit enable` command options and the `file` backend
@@ -58,6 +73,15 @@ these device-specific options:
   the bit pattern for the file mode, similar to `chmod`. Set to `"0000"` to
   prevent Vault from modifying the file mode.
 
-## Log file rotation
+- `max_files` `(int: 0)` - The maximum number of older audit log file archives to keep.
+  Defaults to `0` (no files are ever deleted). Set to `-1` to discard old audit log files
+  when a new one is created.
 
-To properly rotate Vault File Audit Device log files on BSD, Darwin, or Linux-based Vault servers, it is important that you configure your log rotation software to send the `vault` process a signal hang up / `SIGHUP` after each rotation of the log file.
+- `max_bytes` `(int: <unset>)` - The number of bytes that should be written to an audit log file
+  before it needs to be rotated. Unless specified, there is no limit to the number of bytes that
+  can be written to a log file.
+
+- `max_duration` `(string: "24h")` - The maximum duration an audit log file should be written to
+  before it needs to be rotated. Must be a duration value such as `"30s"`. Defaults to `"24h"`.
+  If no time unit is specified, the time duration number is assumed to be in seconds. Set to `0`
+  to disable time-based log file rotation.

--- a/content/vault/v1.20.x/content/docs/commands/audit/enable.mdx
+++ b/content/vault/v1.20.x/content/docs/commands/audit/enable.mdx
@@ -48,7 +48,10 @@ Each audit device type also has a set of configuration arguments:
 ```shell-session
 $ vault audit enable [flags] file [options] \
     file_path=<path/to/log/file>            \
-    [mode=<file_permissions>]
+    [mode=<file_permissions>]               \
+    [max_files=<number>]                    \
+    [max_bytes=<number>]                    \
+    [max_duration=<duration>]
 ```
 
 </CodeBlockConfig>
@@ -60,6 +63,18 @@ $ vault audit enable [flags] file [options] \
 <br /><hr /><br />
 
 @include 'cli/audit/args/file/mode.mdx'
+
+<br /><hr /><br />
+
+@include 'cli/audit/args/file/max_files.mdx'
+
+<br /><hr /><br />
+
+@include 'cli/audit/args/file/max_bytes.mdx'
+
+<br /><hr /><br />
+
+@include 'cli/audit/args/file/max_duration.mdx'
 
 </Tab>
 

--- a/content/vault/v1.20.x/content/partials/cli/audit/args/file/max_bytes.mdx
+++ b/content/vault/v1.20.x/content/partials/cli/audit/args/file/max_bytes.mdx
@@ -1,0 +1,9 @@
+<a id="audit-arg-file-max_bytes" />
+
+**`max_bytes (int : <unset>)`**
+
+File size, in bytes, after which audit log files must rotate. Leave `max_bytes`
+unset if you prefer not to limit audit log file size.
+
+**Example**: `max_bytes=1000000`
+

--- a/content/vault/v1.20.x/content/partials/cli/audit/args/file/max_duration.mdx
+++ b/content/vault/v1.20.x/content/partials/cli/audit/args/file/max_duration.mdx
@@ -1,0 +1,10 @@
+<a id="audit-arg-file-max_duration" />
+
+**`max_duration (string : "24h")`**
+
+Amount of time, in `<number>[s|m|h|d]` format, after which audit log files must
+rotate. If no time unit is specified, the time duration number is assumed to be
+in seconds. Set to `0` to disable time-based log file rotation.
+
+**Example**: `max_duration="2h"`
+

--- a/content/vault/v1.20.x/content/partials/cli/audit/args/file/max_files.mdx
+++ b/content/vault/v1.20.x/content/partials/cli/audit/args/file/max_files.mdx
@@ -1,0 +1,19 @@
+<a id="audit-arg-file-max_files" />
+
+**`max_files (int : 0)`**
+
+The number of audit log file archives to preserve over time.
+Must be one of the following:
+
+Value | Description
+----- | -----------
+`n`   | Preserve up to `n` archived logs
+`0`   | Never delete log archives
+`-1`  | Always delete log archives
+
+The archived name of rotated audit logs includes a timestamp indicating when
+the log rotated. For example, the file `/var/log/audit.log` archives to
+`/var/log/audit-{timestamp}.log` before resetting.
+
+**Example**: `max_files=5`
+


### PR DESCRIPTION
### Description
Allow to natively configure Vault file audit device log file rotation with the `audit enable` command by adding 3 new options to the file backend. These 3 new options and their default values are as follows:

- `max_files` : `(int: 0)` - The maximum number of older audit log file archives to keep. Defaults to `0` (no files are ever deleted). Set to `-1` to discard old audit log files when a new one is created.
- `max_bytes` : `(int: 0)` - The number of bytes that should be written to an audit log file before it needs to be rotated. Unless specified, there is no limit to the number of bytes that can be written to a log file.
- `max_duration` : `(string: "24h")` - The maximum duration an audit log file should be written to before it needs to be rotated. Must be a duration value such as `"30s"`. Defaults to `"24h"`. If no time unit is specified, the time duration number is assumed to be in seconds. Set to `0` to disable time-based log file rotation.

By default, audit log file rotation is set to occur every 24 hours, with no older log file ever removed. In order to revert to previous behavior, where log rotation was not handled by the Vault, the `max_duration` option must be set to `0`, as all other new options are already set to `0` by default.

See Vault PR [31213](https://github.com/hashicorp/vault/pull/31213).