### PR TITLE
Fix TFE_REDIS_USE_MTLS header level in configuration reference

### DIFF
--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/reference/configuration.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/reference/configuration.mdx
@@ -234,7 +234,7 @@ Must be `true` or `false`. `true` indicates Redis server is configured to use `T
 
 Must be `true` or `false`. `true` indicates to use TLS to access Redis. Defaults to `false`.
 
-## `TFE_REDIS_USE_MTLS`
+### `TFE_REDIS_USE_MTLS`
 
 Must be `true` or `false`. `true` indicates to use mutual TLS (mTLS) authentication for clients to access Redis with Redis standalone. Defaults to `false`. mTLS is not currently supported in Sentinel mode.
 
@@ -285,7 +285,7 @@ Redis server password. This value is required when `TFE_REDIS_SIDEKIQ_USE_AUTH` 
 
 ### `TFE_REDIS_SIDEKIQ_USE_MTLS`
 
-Must be `true` or `false`. `true` indicates to use mutual TLS (mTLS) authentication for clients to access Redis with Redis Enterprise. Defaults to `false`. 
+Must be `true` or `false`. `true` indicates to use mutual TLS (mTLS) authentication for clients to access Redis with Redis Enterprise. Defaults to `false`.
 
 ### `TFE_REDIS_SIDEKIQ_CLIENT_CERT_PATH`
 

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/reference/configuration.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/reference/configuration.mdx
@@ -183,7 +183,7 @@ Required when `TFE_DATABASE_USE_MTLS` is `true`.
 
 ### `TFE_DATABASE_PASSWORDLESS_AZURE_USE_MSI`
 
-Whether to use Managed Service Identity (MSI) for database authentication. 
+Whether to use Managed Service Identity (MSI) for database authentication.
 Defaults to `false`.
 
 ### `TFE_DATABASE_PASSWORDLESS_AZURE_CLIENT_ID`
@@ -244,7 +244,7 @@ Must be `true` or `false`. `true` indicates Redis server is configured to use `T
 
 Must be `true` or `false`. `true` indicates to use TLS to access Redis. Defaults to `false`.
 
-## `TFE_REDIS_USE_MTLS`
+### `TFE_REDIS_USE_MTLS`
 
 Must be `true` or `false`. `true` indicates to use mutual TLS (mTLS) authentication for clients to access Redis with Redis standalone. Defaults to `false`. mTLS is not currently supported in Sentinel mode.
 
@@ -295,7 +295,7 @@ Redis server password. This value is required when `TFE_REDIS_SIDEKIQ_USE_AUTH` 
 
 ### `TFE_REDIS_SIDEKIQ_USE_MTLS`
 
-Must be `true` or `false`. `true` indicates to use mutual TLS (mTLS) authentication for clients to access Redis with Redis Enterprise. Defaults to `false`. 
+Must be `true` or `false`. `true` indicates to use mutual TLS (mTLS) authentication for clients to access Redis with Redis Enterprise. Defaults to `false`.
 
 ### `TFE_REDIS_SIDEKIQ_CLIENT_CERT_PATH`
 


### PR DESCRIPTION
TFE_REDIS_USE_MTLS had a title level one higher than the other options

<img width="375" height="349" alt="image" src="https://github.com/user-attachments/assets/7d741b30-4293-4311-baeb-87784cdbd716" />
