### PR TITLE
chore: replicated-migration removal of support reference v202309-1 to…

### DIFF
--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -92,8 +92,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
-
 1. Create a directory at `/etc/terraform-enterprise` on the host.
 1. Create a `/etc/terraform-enterprise/docker-compose.yml` file. Start with the contents in [our mounted disk example](/terraform/enterprise/flexible-deployments/install/docker/install#mounted-disk)
 and adjust it for your host and environment. Pay close attention to how we use bind mounts in the volumes section. Many of the required values may be found in the replicated application configuration
@@ -220,8 +218,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
-
 1. Create a directory called `/etc/terraform-enterprise` on the host for your `docker-compose.yml`. [Refer to our example for guidance](/terraform/enterprise/flexible-deployments/install/docker/install#external-services).
 1. Place a `docker-compose.yml` file in your new directory and adjust it for your host and environment. Ensure that you update and verify the values below.
    * Hostname
@@ -253,8 +249,6 @@ Use the external services credentials from your Replicated installation for the 
   ```
 
 1. Create a new systemd service for Terraform Enterprise by creating a file named, `/etc/systemd/system/terraform-enterprise.service` with [these contents](/terraform/enterprise/flexible-deployments/install/docker/install#mounted-disk). If you changed the name of the directory holding your `docker-compose.yml`, update the systemd service file path to match.
-
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 #### Step 5: Stop Replicated and migrate
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -92,7 +92,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory at `/etc/terraform-enterprise` on the host.
 1. Create a `/etc/terraform-enterprise/docker-compose.yml` file. Start with the contents in [our mounted disk example](/terraform/enterprise/flexible-deployments/install/docker/install#mounted-disk)
@@ -220,7 +219,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory called `/etc/terraform-enterprise` on the host for your `docker-compose.yml`. [Refer to our example for guidance](/terraform/enterprise/flexible-deployments/install/docker/install#external-services).
 1. Place a `docker-compose.yml` file in your new directory and adjust it for your host and environment. Ensure that you update and verify the values below.
@@ -254,7 +252,6 @@ Use the external services credentials from your Replicated installation for the 
 
 1. Create a new systemd service for Terraform Enterprise by creating a file named, `/etc/systemd/system/terraform-enterprise.service` with [these contents](/terraform/enterprise/flexible-deployments/install/docker/install#mounted-disk). If you changed the name of the directory holding your `docker-compose.yml`, update the systemd service file path to match.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 #### Step 5: Stop Replicated and migrate
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -92,7 +92,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory at `/etc/terraform-enterprise` on the host.
 1. Create a `/etc/terraform-enterprise/docker-compose.yml` file. Start with the contents in [our mounted disk example](/terraform/enterprise/flexible-deployments/install/docker/install#mounted-disk)
@@ -220,7 +219,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory called `/etc/terraform-enterprise` on the host for your `docker-compose.yml`. [Refer to our example for guidance](/terraform/enterprise/flexible-deployments/install/docker/install#external-services).
 1. Place a `docker-compose.yml` file in your new directory and adjust it for your host and environment. Ensure that you update and verify the values below.
@@ -254,7 +252,6 @@ Use the external services credentials from your Replicated installation for the 
 
 1. Create a new systemd service for Terraform Enterprise by creating a file named, `/etc/systemd/system/terraform-enterprise.service` with [these contents](/terraform/enterprise/flexible-deployments/install/docker/install#mounted-disk). If you changed the name of the directory holding your `docker-compose.yml`, update the systemd service file path to match.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 #### Step 5: Stop Replicated and migrate
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -92,7 +92,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory at `/etc/terraform-enterprise` on the host.
 1. Create a `/etc/terraform-enterprise/docker-compose.yml` file. Start with the contents in [our mounted disk example](/terraform/enterprise/flexible-deployments/install/docker/install#mounted-disk)
@@ -220,7 +219,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory called `/etc/terraform-enterprise` on the host for your `docker-compose.yml`. [Refer to our example for guidance](/terraform/enterprise/flexible-deployments/install/docker/install#external-services).
 1. Complete the instructions for creating and applying TLS certificates described in [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#2-set-up). 
@@ -241,7 +239,6 @@ To make migration smoother and faster, we recommend using the same host as your 
   ```
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#systemd).
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 #### Step 5: Stop Replicated and migrate
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -92,7 +92,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory at `/etc/terraform-enterprise` on the host.
 1. Create a `/etc/terraform-enterprise/docker-compose.yml` file. Start with the contents in [our mounted disk example](/terraform/enterprise/flexible-deployments/install/docker/install#mounted-disk)
@@ -218,7 +217,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory called `/etc/terraform-enterprise` on the host for your `docker-compose.yml`. [Refer to our example for guidance](/terraform/enterprise/flexible-deployments/install/docker/install#external-services).
 1. Complete the instructions for creating and applying TLS certificates described in [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#2-set-up). 
@@ -239,7 +237,6 @@ To make migration smoother and faster, we recommend using the same host as your 
   ```
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#systemd).
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 #### Step 5: Stop Replicated and migrate
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/replicated-migration.mdx
@@ -93,7 +93,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory at `/etc/terraform-enterprise` on the host.
 1. Create a `/etc/terraform-enterprise/docker-compose.yml` file. Start with the contents in [our mounted disk example](/terraform/enterprise/flexible-deployments/install/docker/install#mounted-disk)
@@ -221,7 +220,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory called `/etc/terraform-enterprise` on the host for your `docker-compose.yml`. [Refer to our example for guidance](/terraform/enterprise/flexible-deployments/install/docker/install#external-services).
 1. Complete the instructions for creating and applying TLS certificates described in [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#2-set-up). 
@@ -242,7 +240,6 @@ To make migration smoother and faster, we recommend using the same host as your 
   ```
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#systemd).
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 #### Step 5: Stop Replicated and migrate
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -92,7 +92,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory at `/etc/terraform-enterprise` on the host.
 1. Create a `/etc/terraform-enterprise/docker-compose.yml` file. Start with the contents in [our mounted disk example](/terraform/enterprise/flexible-deployments/install/docker/install#mounted-disk)
@@ -218,7 +217,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory called `/etc/terraform-enterprise` on the host for your `docker-compose.yml`. [Refer to our example for guidance](/terraform/enterprise/flexible-deployments/install/docker/install#external-services).
 1. Complete the instructions for creating and applying TLS certificates described in [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#2-set-up). 
@@ -239,7 +237,6 @@ To make migration smoother and faster, we recommend using the same host as your 
   ```
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#systemd).
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 #### Step 5: Stop Replicated and migrate
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/replicated-migration.mdx
@@ -93,7 +93,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory at `/etc/terraform-enterprise` on the host.
 1. Create a `/etc/terraform-enterprise/docker-compose.yml` file. Start with the contents in [our mounted disk example](/terraform/enterprise/flexible-deployments/install/docker/install#mounted-disk)
@@ -221,7 +220,6 @@ If Docker Engine cannot be upgraded or installed in a supported docker configura
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Create a directory called `/etc/terraform-enterprise` on the host for your `docker-compose.yml`. [Refer to our example for guidance](/terraform/enterprise/flexible-deployments/install/docker/install#external-services).
 1. Complete the instructions for creating and applying TLS certificates described in [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#2-set-up). 
@@ -242,7 +240,6 @@ To make migration smoother and faster, we recommend using the same host as your 
   ```
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#systemd).
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 #### Step 5: Stop Replicated and migrate
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -110,7 +110,6 @@ Your saved output should resemble the configuration file in [our mounted disk ex
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -249,7 +248,6 @@ To convert your existing configuration into a Docker Compose format on your curr
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Complete the instructions for creating and applying TLS certificates described in [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#2-set-up).
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -274,7 +272,6 @@ To make migration smoother and faster, we recommend using the same host as your 
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#systemd).
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -465,7 +462,6 @@ The minimum Terraform Enterprise version necessary for Podman is [v202404-1](/te
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/replicated-migration.mdx
@@ -119,7 +119,6 @@ Terraform Enterprise may generate a configuration that contains errors. Manually
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -268,7 +267,6 @@ Terraform Enterprise may generate a configuration that contains errors. Manually
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Complete the instructions for creating and applying TLS certificates described in [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#2-set-up).
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -293,7 +291,6 @@ To make migration smoother and faster, we recommend using the same host as your 
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#systemd).
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -488,7 +485,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -119,7 +119,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -268,7 +267,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Complete the instructions for creating and applying TLS certificates described in [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#2-set-up).
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -293,7 +291,6 @@ To make migration smoother and faster, we recommend using the same host as your 
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#systemd).
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -488,7 +485,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -123,7 +123,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -272,7 +271,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Complete the instructions for creating and applying TLS certificates described in [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#2-set-up).
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -297,7 +295,6 @@ To make migration smoother and faster, we recommend using the same host as your 
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#systemd).
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -491,7 +488,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -123,7 +123,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -272,7 +271,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).
 
 1. Complete the instructions for creating and applying TLS certificates described in [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#2-set-up).
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -297,7 +295,6 @@ To make migration smoother and faster, we recommend using the same host as your 
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [step two of the Docker installation set up documentation](/terraform/enterprise/flexible-deployments/install/docker/install#systemd).
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -491,7 +488,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -305,7 +303,6 @@ To make migration smoother and faster, we recommend using the same host as your 
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -498,7 +495,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -116,7 +116,6 @@ Your saved output should resemble the configuration file in [the example `disk` 
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -261,7 +260,6 @@ To convert your existing configuration into a Docker Compose format on your curr
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -286,7 +284,6 @@ To make migration smoother and faster, we recommend using the same host as your 
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -476,7 +473,6 @@ The minimum Terraform Enterprise version necessary for Podman is [v202404-1](/te
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated-migration.mdx
@@ -116,7 +116,6 @@ Your saved output should resemble the configuration file in [the example `disk` 
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -261,7 +260,6 @@ To convert your existing configuration into a Docker Compose format on your curr
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -286,7 +284,6 @@ To make migration smoother and faster, we recommend using the same host as your 
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -476,7 +473,6 @@ The minimum Terraform Enterprise version necessary for Podman is [v202404-1](/te
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -305,7 +303,6 @@ To make migration smoother and faster, we recommend using the same host as your 
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -498,7 +495,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -305,7 +303,6 @@ To make migration smoother and faster, we recommend using the same host as your 
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -498,7 +495,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host(s) as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -307,7 +305,6 @@ To make migration smoother and faster, we recommend using the same host(s) as yo
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -505,7 +502,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host(s) as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -307,7 +305,6 @@ To make migration smoother and faster, we recommend using the same host(s) as yo
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -505,7 +502,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host(s) as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -307,7 +305,6 @@ To make migration smoother and faster, we recommend using the same host(s) as yo
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -505,7 +502,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host(s) as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -307,7 +305,6 @@ To make migration smoother and faster, we recommend using the same host(s) as yo
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -505,7 +502,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host(s) as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -307,7 +305,6 @@ To make migration smoother and faster, we recommend using the same host(s) as yo
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -505,7 +502,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host(s) as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -307,7 +305,6 @@ To make migration smoother and faster, we recommend using the same host(s) as yo
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -505,7 +502,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host(s) as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -307,7 +305,6 @@ To make migration smoother and faster, we recommend using the same host(s) as yo
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -505,7 +502,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host(s) as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -307,7 +305,6 @@ To make migration smoother and faster, we recommend using the same host(s) as yo
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -505,7 +502,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host(s) as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -307,7 +305,6 @@ To make migration smoother and faster, we recommend using the same host(s) as yo
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -505,7 +502,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -125,7 +125,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Review the configuration file from the previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
 
@@ -280,7 +279,6 @@ Terraform Enterprise may generate a configuration that contains errors.  Manuall
 
 To make migration smoother and faster, we recommend using the same host(s) as your current Replicated instance.
 
--> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/deploy/troubleshoot/contact-support).
 
 1. Complete the instructions for creating and applying TLS certificates. Refer to [Create TLS certificates](/terraform/enterprise/deploy/prepare-host#create-tls-certificates) and [Set up installation folders and files](/terraform/enterprise/deploy/docker#set-up-installation-folders-and-files) for instructions.
 1. Review the configuration file from previous step. Update any values as needed before moving on to the next step. Pay special attention to placeholder values enclosed in `<>`, such as `image` and `TFE_LICENSE`, and replace them with your actual values.
@@ -307,7 +305,6 @@ To make migration smoother and faster, we recommend using the same host(s) as yo
 
 1. Optionally create a new systemd service for Terraform Enterprise. Refer to [Manage the Docker service](/terraform/enterprise/deploy/docker#manage-the-docker-service) for instructions.
 
-   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance.
 
 #### Step 6: Stop Replicated and migrate
 
@@ -505,7 +502,6 @@ When Terraform Enterprise is operating in `active-active` mode, you can scale di
 
 We recommend deploying Terraform Enterprise to the same host as your current Replicated instance.
 
-[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.
 
 1. We recommend reusing your Replicated certificate to minimize the upgrade's effect on your other stack components.
 


### PR DESCRIPTION
Removing implicating statements that advise customers to issue a ticket with support to receive "alternative" instruction besides what is already available on developer.hashicorp.com . 

We do not have alternative instructions and these "contact HashiCorp support" comments blocks were not from a support initiative. Customers that review documentation, attempt their migration inline with their planned migration pattern who experience issues during migration should open a support ticket.

The support perspective is Break-Fix. The comments made in this documentation are closer to our consulting services or solutioning services, which have their own independent funnels.
https://www.hashicorp.com/en/technical-support-services-and-policies

Removed terms include:
-> **Note**: If you want to use a separate host for your new docker-based Terraform Enterprise, we can provide alternative steps. [Reach out to support for assistance](/terraform/enterprise/support).

   -> **Note**: If you want to use a separate host for your new Docker-based Terraform Enterprise deployment, [contact HashiCorp support](/terraform/enterprise/support) for assistance.

[Contact HashiCorp support](/terraform/enterprise/deploy/troubleshoot/contact-support) for assistance migrating your Terraform Enterprise installation to a separate host.

[Contact HashiCorp support](/terraform/enterprise/support) for assistance migrating your Terraform Enterprise installation to a separate host.
