### PR TITLE
Agent injector webhook no longer intercepts UPDATE events

### DIFF
--- a/content/vault/v1.17.x/content/docs/platform/k8s/injector/index.mdx
+++ b/content/vault/v1.17.x/content/docs/platform/k8s/injector/index.mdx
@@ -24,8 +24,8 @@ project and can be automatically installed and configured using the
 
 ## Overview
 
-The Vault Agent Injector works by intercepting pod `CREATE` and `UPDATE`
-events in Kubernetes. The controller parses the event and looks for the metadata
+The Vault Agent Injector works by intercepting the pod `CREATE` event in
+Kubernetes. The controller parses the event and looks for the metadata
 annotation `vault.hashicorp.com/agent-inject: true`. If found, the controller will
 alter the pod specification based on other annotations present.
 

--- a/content/vault/v1.18.x/content/docs/platform/k8s/injector/index.mdx
+++ b/content/vault/v1.18.x/content/docs/platform/k8s/injector/index.mdx
@@ -23,8 +23,8 @@ project and can be automatically installed and configured using the
 
 ## Overview
 
-The Vault Agent Injector works by intercepting pod `CREATE` and `UPDATE`
-events in Kubernetes. The controller parses the event and looks for the metadata
+The Vault Agent Injector works by intercepting the pod `CREATE` event in
+Kubernetes. The controller parses the event and looks for the metadata
 annotation `vault.hashicorp.com/agent-inject: true`. If found, the controller will
 alter the pod specification based on other annotations present.
 

--- a/content/vault/v1.19.x/content/docs/deploy/kubernetes/injector/index.mdx
+++ b/content/vault/v1.19.x/content/docs/deploy/kubernetes/injector/index.mdx
@@ -25,8 +25,8 @@ project and can be automatically installed and configured using the
 
 ## Overview
 
-The Vault Agent Injector works by intercepting pod `CREATE` and `UPDATE`
-events in Kubernetes. The controller parses the event and looks for the metadata
+The Vault Agent Injector works by intercepting the pod `CREATE` event in
+Kubernetes. The controller parses the event and looks for the metadata
 annotation `vault.hashicorp.com/agent-inject: true`. If found, the controller will
 alter the pod specification based on other annotations present.
 

--- a/content/vault/v1.20.x/content/docs/deploy/kubernetes/injector/index.mdx
+++ b/content/vault/v1.20.x/content/docs/deploy/kubernetes/injector/index.mdx
@@ -25,8 +25,8 @@ project and can be automatically installed and configured using the
 
 ## Overview
 
-The Vault Agent Injector works by intercepting pod `CREATE` and `UPDATE`
-events in Kubernetes. The controller parses the event and looks for the metadata
+The Vault Agent Injector works by intercepting the pod `CREATE` event in 
+Kubernetes. The controller parses the event and looks for the metadata
 annotation `vault.hashicorp.com/agent-inject: true`. If found, the controller will
 alter the pod specification based on other annotations present.
 


### PR DESCRIPTION
It was removed in version 0.28.1 of the Helm chart which was the released with version 1.17 which is why I updated the docs going back to that point.  The Helm chart isn't really tied to a specific vault version though so just let me know if you'd like to see the same change in more (or less) of the versions.