### PR TITLE
[VAULT DOCS] Fix enterprise tag

### DIFF
--- a/content/vault/v1.20.x/content/api-docs/secret/transit.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/transit.mdx
@@ -70,7 +70,7 @@ values set here cannot be changed after key creation.
   - `aes256-cmac` - AES-256 CMAC (CMAC generation, verification) <EnterpriseAlert inline="true" />
   - `ml-dsa` - ML-DSA (asymmetric) (experimental) <EnterpriseAlert inline="true" />
   - `hybrid` - hybrid signatures combining a post-quantum algorithm and an elliptic curve algorithm (asymmetric) (experimental) <EnterpriseAlert inline="true" />
-  - `slh-dsa` - SLH-DSA (asymmetric) (experimental) <EnterpriseAlert inline="true">
+  - `slh-dsa` - SLH-DSA (asymmetric) (experimental) <EnterpriseAlert inline="true" />
 
   ~> **Note**: In FIPS 140-3 mode, the following algorithms are not certified
      and thus should not be used: `chacha20-poly1305`.


### PR DESCRIPTION
Fixes malformed `<EnterpriseAlert inline="true">` tag 