### PR TITLE
Add role count product usage metrics

### DIFF
--- a/content/vault/v1.20.x/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v1.20.x/content/docs/license/product-usage-reporting.mdx
@@ -169,9 +169,15 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.secret.engine.activedirectory.count`                         | The total number of Active Directory secret engines in Vault.                                              |
 | `vault.secret.engine.alicloud.count`                                | The total number of Alicloud secret engines in Vault.                                                      |
 | `vault.secret.engine.aws.count`                                     | The total number of AWS secret engines in Vault.                                                           |
+| `vault.secret.engine.aws.dynamic.role.count`                        | The total number of AWS dynamic roles in Vault.                                                            |
+| `vault.secret.engine.aws.static.role.count`                         | The total number of AWS static roles in Vault.                                                             |
 | `vault.secret.engine.azure.count`                                   | The total number of Azure secret engines in Vault.                                                         |
+| `vault.secret.engine.azure.dynamic.role.count`                      | The total number of Azure dynamic roles in Vault.                                                          |
 | `vault.secret.engine.consul.count`                                  | The total number of Consul secret engines in Vault.                                                        |
 | `vault.secret.engine.gcp.count`                                     | The total number of GCP secret engines in Vault.                                                           |
+| `vault.secret.engine.gcp.impersonated.account.count`                | The total number of GCP impersonated accounts in Vault.                                                    |
+| `vault.secret.engine.gcp.roleset.count`                             | The total number of GCP rolesets in Vault.                                                                 |
+| `vault.secret.engine.gcp.static.role.count`                         | The total number of GCP static roles in Vault.                                                             |
 | `vault.secret.engine.gcpkms.count`                                  | The total number of GCPKMS secret engines in Vault.                                                        |
 | `vault.secret.engine.kubernetes.count`                              | The total number of Kubernetes secret engines in Vault.                                                    |
 | `vault.secret.engine.cassandra.count`                               | The total number of Cassandra secret engines in Vault.                                                     |
@@ -181,11 +187,15 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.secret.engine.mongodb.count`                                 | The total number of MongoDB secret engines in Vault.                                                       |
 | `vault.secret.engine.mongodbatlas.count`                            | The total number of MongoDBAtlas secret engines in Vault.                                                  |
 | `vault.secret.engine.mssql.count`                                   | The total number of MSSql secret engines in Vault.                                                         |
-| `vault.secret.engine.mysql.count`                                   | The total number of MySQL secret engines in Vault. |
+| `vault.secret.engine.mysql.count`                                   | The total number of MySQL secret engines in Vault.                                                         |
 | `vault.secret.engine.postgresql.count`                              | The total number of Postgresql secret engines in Vault.                                                    |
 | `vault.secret.engine.nomad.count`                                   | The total number of Nomad secret engines in Vault.                                                         |
 | `vault.secret.engine.ldap.count`                                    | The total number of LDAP secret engines in Vault.                                                          |
+| `vault.secret.engine.ldap.dynamic.role.count`                       | The total number of LDAP dynamic roles in Vault.                                                           |
+| `vault.secret.engine.ldap.static.role.count`                        | The total number of LDAP static roles in Vault.                                                            |
 | `vault.secret.engine.openldap.count`                                | The total number of OpenLDAP secret engines in Vault.                                                      |
+| `vault.secret.engine.openldap.dynamic.role.count`                   | The total number of OpenLDAP dynamic roles in Vault.                                                       |
+| `vault.secret.engine.openldap.static.role.count`                    | The total number of OpenLDAP static roles in Vault.                                                        |
 | `vault.secret.engine.pki.count`                                     | The total number of PKI secret engines in Vault.                                                           |
 | `vault.secret.engine.rabbitmq.count`                                | The total number of RabbitMQ secret engines in Vault.                                                      |
 | `vault.secret.engine.ssh.count`                                     | The total number of SSH secret engines in Vault.                                                           |
@@ -194,6 +204,8 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.secret.engine.transform.count`                               | The total number of Transform secret engines in Vault.                                                     |
 | `vault.secret.engine.transit.count`                                 | The total number of Transit secret engines in Vault.                                                       |
 | `vault.secret.engine.database.count`                                | The total number of Database secret engines in Vault.                                                      |
+| `vault.secret.engine.database.dynamic.role.count`                   | The total number of Database dynamic roles in Vault.                                                       |
+| `vault.secret.engine.database.static.role.count`                    | The total number of Database static roles in Vault.                                                        |
 | `vault.secret.engine.plugin.count`                                  | The total number of custom plugin secret engines in Vault.                                                 |
 | `vault.secretsync.sources.count`                                    | The total number of secret sources configured for secret sync.                                             |
 | `vault.secretsync.destinations.count`                               | The total number of secret destinations configured for secret sync.                                        |


### PR DESCRIPTION
We recently added a few more product usage metrics related to the number of dynamic and static roles. These need to be documented. 