### PR TITLE
import an existing resource docs

### DIFF
--- a/content/terraform/v1.12.x/data/language-nav-data.json
+++ b/content/terraform/v1.12.x/data/language-nav-data.json
@@ -344,7 +344,7 @@
       "routes": [
        { "title": "Import a resource", "path": "import" },
        {
-         "title": "Generate destination resource configuration",
+         "title": "Generate resource configuration",
          "path": "import/generating-configuration"
        }
     ]

--- a/content/terraform/v1.12.x/docs/language/import/index.mdx
+++ b/content/terraform/v1.12.x/docs/language/import/index.mdx
@@ -72,7 +72,7 @@ Refer to the [`import` block reference](/terraform/language/block/import) for de
 
 ### Import multiple instances
 
-You can configure the destination `resource` block to manage multiple instances of resource using the `count` and `for_each` [meta-arguments](/terraform/language/meta-arguments).  You can add a parameter to the value of the `to` argument to specify which instance of the destination resource to import to. 
+You can configure the destination `resource` block to manage multiple instances of resource using the `count` and `for_each` [meta-arguments](/terraform/language/meta-arguments). You can add a parameter to the value of the `to` argument to specify which instance of the destination resource to import to. 
 
 For example, the `count` block in the destination `resource` block configuration instructs Terraform to import a set number of resource instances. As a result, you can include an index to the `to` argument value to specify which instance to import the resource to. 
 
@@ -111,7 +111,7 @@ resource "aws_instance" "example" {
 
 ### Import using a custom resource provider
 
-By default, Terraform automatically selects a provider based on the resource type, but you can configure multiple instances of the same provider with aliases and use a non-default configuration to import specific resources. In the following example, Terraform imports to a destination `resource` block that contains multiple instances according to the `europe` provider configuration:
+By default, Terraform automatically selects the default provider configuration based on the resource type, but you can configure multiple instances of the same provider with aliases and use a non-default provider configuration to import specific resources. In the following example, Terraform imports to a destination `resource` block that contains multiple instances according to the `europe` provider configuration:
 
 ```hcl
 provider "aws" {
@@ -164,7 +164,7 @@ resource "aws_instance" "example" {
 
 ## Plan and apply an import
 
-After configuring the destination `resource` block and the `import` block, run `terraform plan` and review the proposed plan. If Terraform proposes any unexpected changes to the resource, update configuration until it matches your intended settings. When satisfied with the plan, run `terraform apply` to import the resources and update your state. 
+After configuring the destination `resource` block and the `import` block, run `terraform plan` and review the proposed plan. If Terraform proposes any unexpected changes to the resource, update its configuration until it matches your intended settings. When satisfied with the plan, run `terraform apply` to import the resources and update your state. 
 
 When you apply a configuration with `import` blocks, Terraform records that it imported the resources and that it did not create them. 
 


### PR DESCRIPTION
This PR replaces the existing content in import/index.mdx with a usage topic. 

Note that we will implement additional changes in a later phase. The changes are tied to the search functionality and will result in the following structure:

Import existing resources
- overview
- import a resource (this page)
- import resources in bulk (search; working title)
