### PR TITLE
Remove sleep from PR Preview workflow

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -225,10 +225,8 @@ jobs:
           shell: bash
           timeout_minutes: 10
           max_attempts: 2
-          # remove sleep before merge
           command: |
             cd unified-docs-frontend-preview
-            sleep 300
             vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts and Set GitHub Outputs


### PR DESCRIPTION
Seems like a sleep command got into our PR Preview workflow, let's remove that.