### PR TITLE
Correct helm installation command for HCP Terraform Operator

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/integrations/kubernetes/setup.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/integrations/kubernetes/setup.mdx
@@ -71,12 +71,12 @@ The HCP Terraform Operator for Kubernetes supports the following versions:
 1.  Install the [HCP Terraform Operator for Kubernetes with Helm](https://github.com/hashicorp/hcp-terraform-operator). By default, the operator communicates with HCP Terraform at `app.terraform.io`. The following example command installs the Helm chart for HCP Terraform:
 
       ```shell-session
-      $ helm install --namespace ${RELEASE_NAMESPACE} tfc-operator hashicorp/hcp-terraform-operator
+      $ helm install --namespace ${NAMESPACE} tfc-operator hashicorp/hcp-terraform-operator
       ```
    When deploying in self-managed Terraform Enterprise, you must set the `operator.tfeAddress` to the specific hostname of the Terraform Enterprise instance:
 
       ```shell-session
-      $ helm install --namespace ${RELEASE_NAMESPACE} tfc-operator hashicorp/hcp-terraform-operator \
+      $ helm install --namespace ${NAMESPACE} tfc-operator hashicorp/hcp-terraform-operator \
       --set operator.tfeAddress="TERRAFORM_ENTERPRISE_HOSTNAME"
       ```
 
@@ -100,5 +100,5 @@ The HCP Terraform Operator for Kubernetes supports the following versions:
 When a new version of the HCP Terraform Operator for Kubernetes Helm Chart is available from the HashiCorp Helm repository, you can upgrade with the following command.
 
 ```shell-session
-$ helm upgrade --namespace ${RELEASE_NAMESPACE} hashicorp/hcp-terraform-operator tfc-operator
+$ helm upgrade --namespace ${NAMESPACE} hashicorp/hcp-terraform-operator tfc-operator
 ```


### PR DESCRIPTION
While following the steps in this document I discovered an error. As written, the helm install command will yield the following error:
```
ubuntu@ip-172-31-91-54:~$ helm install --namespace hcpt-operator hashicorp/hcp-terraform-operator hcp-terraform-operator
Error: INSTALLATION FAILED: non-absolute URLs should be in form of repo_name/path_to_chart, got: hcp-terraform-operator
```

The correct syntax is `helm install [NAME] [CHART] [flags]`; in this instance the CHART is `hashicorp/hcp-terraform-operator` ([reference](https://helm.sh/docs/helm/helm_install/)).

Working example:
```
ubuntu@ip-172-31-91-54:~$ helm install --namespace hcpt-agents hcp-terraform-operator hashicorp/hcp-terraform-operator
NAME: hcp-terraform-operator
LAST DEPLOYED: Mon Aug 18 14:58:46 2025
NAMESPACE: hcpt-agents
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing HashiCorp HCP Terraform Operator!

Documentation:
 - https://github.com/hashicorp/hcp-terraform-operator

Your release is named hcp-terraform-operator.

To get the release status, run:
  $ helm --namespace hcpt-agents status hcp-terraform-operator

To get the release values, run:
  $ helm --namespace hcpt-agents get values hcp-terraform-operator

To read this notes again, run:
  $ helm --namespace hcpt-agents get notes hcp-terraform-operator
```