### PR TITLE
VAULT-37634, VAULT-36946: Census metrics for recover capability and auto snapshot config counts

### DIFF
--- a/content/vault/v1.21.x (rc)/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v1.21.x (rc)/content/docs/license/product-usage-reporting.mdx
@@ -109,140 +109,145 @@ HashiCorp collects the following product usage metrics as part of the `metrics` 
 [JSON payload that it collects for licence utilization](/vault/docs/enterprise/license/utilization-reporting#example-payloads).
 All of these metrics are numerical, and contain no sensitive values or additional metadata:
 
-| Metric Name                                                         | Description                                                                                                |
-|---------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
-| `vault.namespaces.count`                                            | Total number of namespaces.                                                                                |
-| `vault.leases.count`                                                | Total number of leases within Vault.                                                                       |
-| `vault.quotas.ratelimit.count`                                      | Total number of rate limit quotas within Vault, considering any group_by modes.                            |
-| `vault.quotas.ratelimit.ip.count`                                   | Total number of rate limit quotas using "ip" group_by mode within Vault.                                   |
-| `vault.quotas.ratelimit.none.count`                                 | Total number of rate limit quotas using "none" group_by mode within Vault.                                 |
-| `vault.quotas.ratelimit.entity_then_ip.count`                       | Total number of rate limit quotas using "entity_then_ip" group_by mode within Vault.                       |
-| `vault.quotas.ratelimit.entity_then_ip_with_secondary_rate.count`   | Total number of rate limit quotas using "entity_then_ip" group_by mode with secondary rate within Vault.   |
-| `vault.quotas.ratelimit.entity_then_none.count`                     | Total number of rate limit quotas using "entity_then_none" group_by mode within Vault.                     |
-| `vault.quotas.ratelimit.entity_then_none_with_secondary_rate.count` | Total number of rate limit quotas using "entity_then_none" group_by mode with secondary rate within Vault. |
-| `vault.quotas.leasecount.count`                                     | Total number of lease count quotas within Vault.                                                           |
-| `vault.kv.version1.secrets.count`                                   | Total number of KVv1 secrets within Vault.                                                                 |
-| `vault.kv.version2.secrets.count`                                   | Total number of KVv2 secrets within Vault.                                                                 |
-| `vault.kv.version1.secrets.namespace.max`                           | The highest number of KVv1 secrets in a namespace in Vault, e.g. `1000`.                                   |
-| `vault.kv.version2.secrets.namespace.max`                           | The highest number of KVv2 secrets in a namespace in Vault, e.g. `1000`.                                   |
-| `vault.kv.version1.secrets.namespace.min`                           | The lowest number of KVv1 secrets in a namespace in Vault, e.g. `2`.                                       |
-| `vault.kv.version2.secrets.namespace.min`                           | The highest number of KVv2 secrets in a namespace in Vault, e.g. `1000`.                                   |
-| `vault.kv.version1.secrets.namespace.mean`                          | The mean number of KVv1 secrets in namespaces in Vault, e.g. `52.8`.                                       |
-| `vault.kv.version2.secrets.namespace.mean`                          | The mean number of KVv2 secrets in namespaces in Vault, e.g. `52.8`.                                       |
-| `vault.auth.method.approle.count`                                   | The total number of Approle auth mounts in Vault.                                                          |
-| `vault.auth.method.alicloud.count`                                  | The total number of Alicloud auth mounts in Vault.                                                         |
-| `vault.auth.method.aws.count`                                       | The total number of AWS auth mounts in Vault.                                                              |
-| `vault.auth.method.appid.count`                                     | The total number of App ID auth mounts in Vault.                                                           |
-| `vault.auth.method.azure.count`                                     | The total number of Azure auth mounts in Vault.                                                            |
-| `vault.auth.method.cloudfoundry.count`                              | The total number of Cloud Foundry auth mounts in Vault.                                                    |
-| `vault.auth.method.github.count`                                    | The total number of GitHub auth mounts in Vault.                                                           |
-| `vault.auth.method.gcp.count`                                       | The total number of GCP auth mounts in Vault.                                                              |
-| `vault.auth.method.jwt.count`                                       | The total number of JWT auth mounts in Vault.                                                              |
-| `vault.auth.method.kerberos.count`                                  | The total number of Kerberos auth mounts in Vault.                                                         |
-| `vault.auth.method.kubernetes.count`                                | The total number of Kubernetes auth mounts in Vault.                                                       |
-| `vault.auth.method.ldap.count`                                      | The total number of LDAP auth mounts in Vault.                                                             |
-| `vault.auth.method.oci.count`                                       | The total number of OCI auth mounts in Vault.                                                              |
-| `vault.auth.method.okta.count`                                      | The total number of Okta auth mounts in Vault.                                                             |
-| `vault.auth.method.pcf.count`                                       | The total number of PCF auth mounts in Vault.                                                              |
-| `vault.auth.method.radius.count`                                    | The total number of Radius auth mounts in Vault.                                                           |
-| `vault.auth.method.saml.count`                                      | The total number of SAML auth mounts in Vault.                                                             |
-| `vault.auth.method.cert.count`                                      | The total number of Cert auth mounts in Vault.                                                             |
-| `vault.auth.method.oidc.count`                                      | The total number of OIDC auth mounts in Vault.                                                             |
-| `vault.auth.method.token.count`                                     | The total number of Token auth mounts in Vault.                                                            |
-| `vault.auth.method.userpass.count`                                  | The total number of Userpass auth mounts in Vault.                                                         |
-| `vault.auth.method.plugin.count`                                    | The total number of custom plugin auth mounts in Vault.                                                    |
-| `vault.db.cassandra.plugin.count`                                   | The total number of Cassandra database plugin connections in Vault.                                        |
-| `vault.db.couchbase.plugin.count`                                   | The total number of Couchbase database plugin connections in Vault.                                        |
-| `vault.db.elasticsearch.plugin.count`                               | The total number of Elasticsearch database plugin connections in Vault.                                    |
-| `vault.db.hana.plugin.count`                                        | The total number of Hana database plugin connections in Vault.                                             |
-| `vault.db.influxdb.plugin.count`                                    | The total number of InfluxDB database plugin connections in Vault.                                         |
-| `vault.db.mongodb.plugin.count`                                     | The total number of MongoDB database plugin connections in Vault.                                          |
-| `vault.db.mongodbatlas.plugin.count`                                | The total number of MongoDB Atlas database plugin connections in Vault.                                    |
-| `vault.db.mssql.plugin.count`                                       | The total number of MSSQL database plugin connections in Vault.                                            |
-| `vault.db.mysql.plugin.count`                                       | The total number of MySQL database plugin connections in Vault.                                            |
-| `vault.db.postgres.plugin.count`                                    | The total number of Postgres databse plugin connections in Vault.                                          |
-| `vault.db.redshift.plugin.count`                                    | The total number of Redshift database plugin connections in Vault.                                         |
-| `vault.db.redis.plugin.count`                                       | The total number of Redis database plugin connections in Vault.                                            |
-| `vault.db.rediselasticache.plugin.count`                            | The total number of Redis Elasticache database plugin connections in Vault.                                |
-| `vault.db.snowflake.plugin.count`                                   | The total number of Snowflake database plugin connections in Vault.                                        |
-| `vault.db.unknown.plugin.count`                                     | The total number of custom or unknown database plugin connections in Vault.                                |
-| `vault.secret.engine.activedirectory.count`                         | The total number of Active Directory secret engines in Vault.                                              |
-| `vault.secret.engine.alicloud.count`                                | The total number of Alicloud secret engines in Vault.                                                      |
-| `vault.secret.engine.aws.count`                                     | The total number of AWS secret engines in Vault.                                                           |
-| `vault.secret.engine.azure.count`                                   | The total number of Azure secret engines in Vault.                                                         |
-| `vault.secret.engine.consul.count`                                  | The total number of Consul secret engines in Vault.                                                        |
-| `vault.secret.engine.gcp.count`                                     | The total number of GCP secret engines in Vault.                                                           |
-| `vault.secret.engine.gcpkms.count`                                  | The total number of GCPKMS secret engines in Vault.                                                        |
-| `vault.secret.engine.kubernetes.count`                              | The total number of Kubernetes secret engines in Vault.                                                    |
-| `vault.secret.engine.cassandra.count`                               | The total number of Cassandra secret engines in Vault.                                                     |
-| `vault.secret.engine.keymgmt.count`                                 | The total number of Keymgmt secret engines in Vault.                                                       |
-| `vault.secret.engine.kv.count`                                      | The total number of KV secret engines in Vault.                                                            |
-| `vault.secret.engine.kmip.count`                                    | The total number of KMIP secret engines in Vault.                                                          |
-| `vault.secret.engine.mongodb.count`                                 | The total number of MongoDB secret engines in Vault.                                                       |
-| `vault.secret.engine.mongodbatlas.count`                            | The total number of MongoDBAtlas secret engines in Vault.                                                  |
-| `vault.secret.engine.mssql.count`                                   | The total number of MSSql secret engines in Vault.                                                         |
-| `vault.secret.engine.mysql.count`                                   | The total number of MySQL secret engines in Vault. |
-| `vault.secret.engine.postgresql.count`                              | The total number of Postgresql secret engines in Vault.                                                    |
-| `vault.secret.engine.nomad.count`                                   | The total number of Nomad secret engines in Vault.                                                         |
-| `vault.secret.engine.ldap.count`                                    | The total number of LDAP secret engines in Vault.                                                          |
-| `vault.secret.engine.openldap.count`                                | The total number of OpenLDAP secret engines in Vault.                                                      |
-| `vault.secret.engine.pki.count`                                     | The total number of PKI secret engines in Vault.                                                           |
-| `vault.secret.engine.rabbitmq.count`                                | The total number of RabbitMQ secret engines in Vault.                                                      |
-| `vault.secret.engine.ssh.count`                                     | The total number of SSH secret engines in Vault.                                                           |
-| `vault.secret.engine.terraform.count`                               | The total number of Terraform secret engines in Vault.                                                     |
-| `vault.secret.engine.totp.count`                                    | The total number of TOTP secret engines in Vault.                                                          |
-| `vault.secret.engine.transform.count`                               | The total number of Transform secret engines in Vault.                                                     |
-| `vault.secret.engine.transit.count`                                 | The total number of Transit secret engines in Vault.                                                       |
-| `vault.secret.engine.database.count`                                | The total number of Database secret engines in Vault.                                                      |
-| `vault.secret.engine.plugin.count`                                  | The total number of custom plugin secret engines in Vault.                                                 |
-| `vault.secretsync.sources.count`                                    | The total number of secret sources configured for secret sync.                                             |
-| `vault.secretsync.destinations.count`                               | The total number of secret destinations configured for secret sync.                                        |
-| `vault.secretsync.destinations.aws-sm.count`                        | The total number of AWS-SM secret destinations configured for secret sync.                                 |
-| `vault.secretsync.destinations.azure-kv.count`                      | The total number of Azure-KV secret destinations configured for secret sync.                               |
-| `vault.secretsync.destinations.gcp-sm.count`                        | The total number of secret sync destinations to GCP-SM configured. |
-| `vault.secretsync.destinations.gh.count`                            | The total number of GH secret destinations configured for secret sync.                                     |
-| `vault.secretsync.destinations.vault.count`                         | The total number of Vault secret destinations configured for secret sync.                                  |
-| `vault.secretsync.destinations.vercel-project.count`                | The total number of Vercel Project secret destinations configured for secret sync.                         |
-| `vault.secretsync.destinations.terraform.count`                     | The total number of Terraform secret destinations configured for secret sync.                              |
-| `vault.secretsync.destinations.gitlab.count`                        | The total number of GitLab secret destinations configured for secret sync.                                 |
-| `vault.secretsync.destinations.inmem.count`                         | The total number of InMem secret destinations configured for secret sync.                                  |
-| `vault.pki.roles.count`                                             | The total roles in all PKI mounts across all namespaces.                                                   |
-| `vault.pki.issuers.count`                                           | The total issuers from all PKI mounts across all namespaces.                                               |
-| `vault.identity.case_sensitive_mode`                                | Whether or not the cluster is using case-sensitive identity name matching caused by historical duplicates. |
-| `vault.identity.force_deduplication_activated`                      | Whether or not the cluster has had the force_identity_deduplication activation flag activated.             |
-| `vault.ui.enabled`                                                  | Whether or not the UI is enabled for the cluster.                                                          |
-| `vault.ui.custom_banners.authenticated`                             | How many authenticated custom banners have been enabled across all namespaces.                             |
-| `vault.ui.custom_banners.unauthenticated`                           | How many unauthenticated custom banners have been enabled across all namespaces.                           |
-| `vault.storage.max_entry_size`                                      | The value of `max_entry_size` parameter for the storage stanza in the config.                              |
-| `vault.storage.max_mount_and_namespace_table_entry_size`            | The value of `max_mount_and_namespace_table_entry_size` parameter for the storage stanza in the config.    |
-| `vault.operator.import.kv.version2.secrets.source.vault.count`      | The total number of secrets imported from Vault using operator import command.                             |
-| `vault.operator.import.kv.version2.secrets.source.aws.count`        | The total number of secrets imported from AWS using operator import command.                               |
-| `vault.operator.import.kv.version2.secrets.source.gcp.count`        | The otal number of secrets imported from GCP using operator import command.                                |
-| `vault.operator.import.kv.version2.secrets.source.azure.count`      | The total number of secrets imported from Azure using operator import command.                             |
-| `vault.operator.import.kv.version2.secrets.count`                   | The total number of secrets imported from using operator import command.                                   |
-| `vault.telemetry.stanzas.count`                                     | The count of telemetry stanzas configured in this cluster.                                                 |
-| `vault.telemetry.filters.count`                                     | The count of metric prefix filters specified in the telemetry stanza in config file.                       |
-| `vault.replication.secret.non_local_mounts`                         | The number of replicated secret mounts on Enterprise clusters.                                             |
-| `vault.replication.secret.local_mounts`                             | The number of local secret mounts on Enterprise clusters.                                                  |
-| `vault.replication.auth.local_mounts`                               | The number of local auth mounts on Enterprise clusters.                                                    |
-| `vault.replication.auth.non_local_mounts`                           | The number of replicated auth mounts on Enterprise clusters.                                               |
-| `vault.replication.num_nodes`                                       | The number of nodes in a HA cluster.                                                                       |
-| `vault.adaptive_overload_protection_enabled`                        | Whether or not Adaptive Overload Protection is enabled for the cluster.                                    |
-| `vault.policies.egp.count`                                          | The total number of Enterprise Governance Policies (EGP) across all namespaces in Vault.                   |
-| `vault.policies.rgp.count`                                          | The total number of Replication Governance Policies (RGP) across all namespaces in Vault.                  |
-| `vault.policies.acl.count`                                          | The total number of Access Control List (ACL) policies across all namespaces in Vault.                     |
-| `vault.policies.acl.control_group.count`                            | The total number of control groups in this cluster.                                                        |
-| `vault.autopilot_upgrade_enabled`                                   | Whether or not Autopilot Upgrade is enabled for the cluster.                                               |
-| `vault.audit.device.file.count`                                     | The total number of audit devices of type file configured for this cluster.                                |
-| `vault.audit.device.syslog.count`                                   | The total total number of audit devices of type syslog configured for this cluster.                        |
-| `vault.audit.device.socket.udp.count`                               | The total total number of audit devices of type UDP socket configured for this cluster.                    |
-| `vault.audit.device.socket.tcp.count`                               | The total total number of audit devices of type TCP socket configured for this cluster.                    |
-| `vault.audit.device.socket.unix.count`                              | The total total number of audit devices of type UNIX socket configured for this cluster.                   |
-| `vault.audit.exclusion.stanza.count`                                | The total number of audit exclusion stanzas in the HCL configuration for this cluster.                     |
-| `vault.loadedsnapshots.manual.count`                                | The total number of manual (local) snapshots loaded for recovery.                                          |
-| `vault.loadedsnapshots.cloud.google-gcs.count`                      | The total number of Google GCS snapshots loaded for recovery.                                              |
-| `vault.loadedsnapshots.cloud.aws-s3.count`                          | The total number of AWS S3 snapshots loaded for recovery.                                                  |
-| `vault.loadedsnapshots.cloud.azure-blob.count`                      | The total number of Azure Blob snapshots loaded for recovery.                                              |
+| Metric Name                                                         | Description                                                                                                      |
+|---------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| `vault.namespaces.count`                                            | Total number of namespaces.                                                                                      |
+| `vault.leases.count`                                                | Total number of leases within Vault.                                                                             |
+| `vault.quotas.ratelimit.count`                                      | Total number of rate limit quotas within Vault, considering any group_by modes.                                  |
+| `vault.quotas.ratelimit.ip.count`                                   | Total number of rate limit quotas using "ip" group_by mode within Vault.                                         |
+| `vault.quotas.ratelimit.none.count`                                 | Total number of rate limit quotas using "none" group_by mode within Vault.                                       |
+| `vault.quotas.ratelimit.entity_then_ip.count`                       | Total number of rate limit quotas using "entity_then_ip" group_by mode within Vault.                             |
+| `vault.quotas.ratelimit.entity_then_ip_with_secondary_rate.count`   | Total number of rate limit quotas using "entity_then_ip" group_by mode with secondary rate within Vault.         |
+| `vault.quotas.ratelimit.entity_then_none.count`                     | Total number of rate limit quotas using "entity_then_none" group_by mode within Vault.                           |
+| `vault.quotas.ratelimit.entity_then_none_with_secondary_rate.count` | Total number of rate limit quotas using "entity_then_none" group_by mode with secondary rate within Vault.       |
+| `vault.quotas.leasecount.count`                                     | Total number of lease count quotas within Vault.                                                                 |
+| `vault.kv.version1.secrets.count`                                   | Total number of KVv1 secrets within Vault.                                                                       |
+| `vault.kv.version2.secrets.count`                                   | Total number of KVv2 secrets within Vault.                                                                       |
+| `vault.kv.version1.secrets.namespace.max`                           | The highest number of KVv1 secrets in a namespace in Vault, e.g. `1000`.                                         |
+| `vault.kv.version2.secrets.namespace.max`                           | The highest number of KVv2 secrets in a namespace in Vault, e.g. `1000`.                                         |
+| `vault.kv.version1.secrets.namespace.min`                           | The lowest number of KVv1 secrets in a namespace in Vault, e.g. `2`.                                             |
+| `vault.kv.version2.secrets.namespace.min`                           | The highest number of KVv2 secrets in a namespace in Vault, e.g. `1000`.                                         |
+| `vault.kv.version1.secrets.namespace.mean`                          | The mean number of KVv1 secrets in namespaces in Vault, e.g. `52.8`.                                             |
+| `vault.kv.version2.secrets.namespace.mean`                          | The mean number of KVv2 secrets in namespaces in Vault, e.g. `52.8`.                                             |
+| `vault.auth.method.approle.count`                                   | The total number of Approle auth mounts in Vault.                                                                |
+| `vault.auth.method.alicloud.count`                                  | The total number of Alicloud auth mounts in Vault.                                                               |
+| `vault.auth.method.aws.count`                                       | The total number of AWS auth mounts in Vault.                                                                    |
+| `vault.auth.method.appid.count`                                     | The total number of App ID auth mounts in Vault.                                                                 |
+| `vault.auth.method.azure.count`                                     | The total number of Azure auth mounts in Vault.                                                                  |
+| `vault.auth.method.cloudfoundry.count`                              | The total number of Cloud Foundry auth mounts in Vault.                                                          |
+| `vault.auth.method.github.count`                                    | The total number of GitHub auth mounts in Vault.                                                                 |
+| `vault.auth.method.gcp.count`                                       | The total number of GCP auth mounts in Vault.                                                                    |
+| `vault.auth.method.jwt.count`                                       | The total number of JWT auth mounts in Vault.                                                                    |
+| `vault.auth.method.kerberos.count`                                  | The total number of Kerberos auth mounts in Vault.                                                               |
+| `vault.auth.method.kubernetes.count`                                | The total number of Kubernetes auth mounts in Vault.                                                             |
+| `vault.auth.method.ldap.count`                                      | The total number of LDAP auth mounts in Vault.                                                                   |
+| `vault.auth.method.oci.count`                                       | The total number of OCI auth mounts in Vault.                                                                    |
+| `vault.auth.method.okta.count`                                      | The total number of Okta auth mounts in Vault.                                                                   |
+| `vault.auth.method.pcf.count`                                       | The total number of PCF auth mounts in Vault.                                                                    |
+| `vault.auth.method.radius.count`                                    | The total number of Radius auth mounts in Vault.                                                                 |
+| `vault.auth.method.saml.count`                                      | The total number of SAML auth mounts in Vault.                                                                   |
+| `vault.auth.method.cert.count`                                      | The total number of Cert auth mounts in Vault.                                                                   |
+| `vault.auth.method.oidc.count`                                      | The total number of OIDC auth mounts in Vault.                                                                   |
+| `vault.auth.method.token.count`                                     | The total number of Token auth mounts in Vault.                                                                  |
+| `vault.auth.method.userpass.count`                                  | The total number of Userpass auth mounts in Vault.                                                               |
+| `vault.auth.method.plugin.count`                                    | The total number of custom plugin auth mounts in Vault.                                                          |
+| `vault.db.cassandra.plugin.count`                                   | The total number of Cassandra database plugin connections in Vault.                                              |
+| `vault.db.couchbase.plugin.count`                                   | The total number of Couchbase database plugin connections in Vault.                                              |
+| `vault.db.elasticsearch.plugin.count`                               | The total number of Elasticsearch database plugin connections in Vault.                                          |
+| `vault.db.hana.plugin.count`                                        | The total number of Hana database plugin connections in Vault.                                                   |
+| `vault.db.influxdb.plugin.count`                                    | The total number of InfluxDB database plugin connections in Vault.                                               |
+| `vault.db.mongodb.plugin.count`                                     | The total number of MongoDB database plugin connections in Vault.                                                |
+| `vault.db.mongodbatlas.plugin.count`                                | The total number of MongoDB Atlas database plugin connections in Vault.                                          |
+| `vault.db.mssql.plugin.count`                                       | The total number of MSSQL database plugin connections in Vault.                                                  |
+| `vault.db.mysql.plugin.count`                                       | The total number of MySQL database plugin connections in Vault.                                                  |
+| `vault.db.postgres.plugin.count`                                    | The total number of Postgres databse plugin connections in Vault.                                                |
+| `vault.db.redshift.plugin.count`                                    | The total number of Redshift database plugin connections in Vault.                                               |
+| `vault.db.redis.plugin.count`                                       | The total number of Redis database plugin connections in Vault.                                                  |
+| `vault.db.rediselasticache.plugin.count`                            | The total number of Redis Elasticache database plugin connections in Vault.                                      |
+| `vault.db.snowflake.plugin.count`                                   | The total number of Snowflake database plugin connections in Vault.                                              |
+| `vault.db.unknown.plugin.count`                                     | The total number of custom or unknown database plugin connections in Vault.                                      |
+| `vault.secret.engine.activedirectory.count`                         | The total number of Active Directory secret engines in Vault.                                                    |
+| `vault.secret.engine.alicloud.count`                                | The total number of Alicloud secret engines in Vault.                                                            |
+| `vault.secret.engine.aws.count`                                     | The total number of AWS secret engines in Vault.                                                                 |
+| `vault.secret.engine.azure.count`                                   | The total number of Azure secret engines in Vault.                                                               |
+| `vault.secret.engine.consul.count`                                  | The total number of Consul secret engines in Vault.                                                              |
+| `vault.secret.engine.gcp.count`                                     | The total number of GCP secret engines in Vault.                                                                 |
+| `vault.secret.engine.gcpkms.count`                                  | The total number of GCPKMS secret engines in Vault.                                                              |
+| `vault.secret.engine.kubernetes.count`                              | The total number of Kubernetes secret engines in Vault.                                                          |
+| `vault.secret.engine.cassandra.count`                               | The total number of Cassandra secret engines in Vault.                                                           |
+| `vault.secret.engine.keymgmt.count`                                 | The total number of Keymgmt secret engines in Vault.                                                             |
+| `vault.secret.engine.kv.count`                                      | The total number of KV secret engines in Vault.                                                                  |
+| `vault.secret.engine.kmip.count`                                    | The total number of KMIP secret engines in Vault.                                                                |
+| `vault.secret.engine.mongodb.count`                                 | The total number of MongoDB secret engines in Vault.                                                             |
+| `vault.secret.engine.mongodbatlas.count`                            | The total number of MongoDBAtlas secret engines in Vault.                                                        |
+| `vault.secret.engine.mssql.count`                                   | The total number of MSSql secret engines in Vault.                                                               |
+| `vault.secret.engine.mysql.count`                                   | The total number of MySQL secret engines in Vault.                                                               |
+| `vault.secret.engine.postgresql.count`                              | The total number of Postgresql secret engines in Vault.                                                          |
+| `vault.secret.engine.nomad.count`                                   | The total number of Nomad secret engines in Vault.                                                               |
+| `vault.secret.engine.ldap.count`                                    | The total number of LDAP secret engines in Vault.                                                                |
+| `vault.secret.engine.openldap.count`                                | The total number of OpenLDAP secret engines in Vault.                                                            |
+| `vault.secret.engine.pki.count`                                     | The total number of PKI secret engines in Vault.                                                                 |
+| `vault.secret.engine.rabbitmq.count`                                | The total number of RabbitMQ secret engines in Vault.                                                            |
+| `vault.secret.engine.ssh.count`                                     | The total number of SSH secret engines in Vault.                                                                 |
+| `vault.secret.engine.terraform.count`                               | The total number of Terraform secret engines in Vault.                                                           |
+| `vault.secret.engine.totp.count`                                    | The total number of TOTP secret engines in Vault.                                                                |
+| `vault.secret.engine.transform.count`                               | The total number of Transform secret engines in Vault.                                                           |
+| `vault.secret.engine.transit.count`                                 | The total number of Transit secret engines in Vault.                                                             |
+| `vault.secret.engine.database.count`                                | The total number of Database secret engines in Vault.                                                            |
+| `vault.secret.engine.plugin.count`                                  | The total number of custom plugin secret engines in Vault.                                                       |
+| `vault.secretsync.sources.count`                                    | The total number of secret sources configured for secret sync.                                                   |
+| `vault.secretsync.destinations.count`                               | The total number of secret destinations configured for secret sync.                                              |
+| `vault.secretsync.destinations.aws-sm.count`                        | The total number of AWS-SM secret destinations configured for secret sync.                                       |
+| `vault.secretsync.destinations.azure-kv.count`                      | The total number of Azure-KV secret destinations configured for secret sync.                                     |
+| `vault.secretsync.destinations.gcp-sm.count`                        | The total number of secret sync destinations to GCP-SM configured.                                               |
+| `vault.secretsync.destinations.gh.count`                            | The total number of GH secret destinations configured for secret sync.                                           |
+| `vault.secretsync.destinations.vault.count`                         | The total number of Vault secret destinations configured for secret sync.                                        |
+| `vault.secretsync.destinations.vercel-project.count`                | The total number of Vercel Project secret destinations configured for secret sync.                               |
+| `vault.secretsync.destinations.terraform.count`                     | The total number of Terraform secret destinations configured for secret sync.                                    |
+| `vault.secretsync.destinations.gitlab.count`                        | The total number of GitLab secret destinations configured for secret sync.                                       |
+| `vault.secretsync.destinations.inmem.count`                         | The total number of InMem secret destinations configured for secret sync.                                        |
+| `vault.pki.roles.count`                                             | The total roles in all PKI mounts across all namespaces.                                                         |
+| `vault.pki.issuers.count`                                           | The total issuers from all PKI mounts across all namespaces.                                                     |
+| `vault.identity.case_sensitive_mode`                                | Whether or not the cluster is using case-sensitive identity name matching caused by historical duplicates.       |
+| `vault.identity.force_deduplication_activated`                      | Whether or not the cluster has had the force_identity_deduplication activation flag activated.                   |
+| `vault.ui.enabled`                                                  | Whether or not the UI is enabled for the cluster.                                                                |
+| `vault.ui.custom_banners.authenticated`                             | How many authenticated custom banners have been enabled across all namespaces.                                   |
+| `vault.ui.custom_banners.unauthenticated`                           | How many unauthenticated custom banners have been enabled across all namespaces.                                 |
+| `vault.storage.max_entry_size`                                      | The value of `max_entry_size` parameter for the storage stanza in the config.                                    |
+| `vault.storage.max_mount_and_namespace_table_entry_size`            | The value of `max_mount_and_namespace_table_entry_size` parameter for the storage stanza in the config.          |
+| `vault.operator.import.kv.version2.secrets.source.vault.count`      | The total number of secrets imported from Vault using operator import command.                                   |
+| `vault.operator.import.kv.version2.secrets.source.aws.count`        | The total number of secrets imported from AWS using operator import command.                                     |
+| `vault.operator.import.kv.version2.secrets.source.gcp.count`        | The otal number of secrets imported from GCP using operator import command.                                      |
+| `vault.operator.import.kv.version2.secrets.source.azure.count`      | The total number of secrets imported from Azure using operator import command.                                   |
+| `vault.operator.import.kv.version2.secrets.count`                   | The total number of secrets imported from using operator import command.                                         |
+| `vault.telemetry.stanzas.count`                                     | The count of telemetry stanzas configured in this cluster.                                                       |
+| `vault.telemetry.filters.count`                                     | The count of metric prefix filters specified in the telemetry stanza in config file.                             |
+| `vault.replication.secret.non_local_mounts`                         | The number of replicated secret mounts on Enterprise clusters.                                                   |
+| `vault.replication.secret.local_mounts`                             | The number of local secret mounts on Enterprise clusters.                                                        |
+| `vault.replication.auth.local_mounts`                               | The number of local auth mounts on Enterprise clusters.                                                          |
+| `vault.replication.auth.non_local_mounts`                           | The number of replicated auth mounts on Enterprise clusters.                                                     |
+| `vault.replication.num_nodes`                                       | The number of nodes in a HA cluster.                                                                             |
+| `vault.adaptive_overload_protection_enabled`                        | Whether or not Adaptive Overload Protection is enabled for the cluster.                                          |
+| `vault.policies.egp.count`                                          | The total number of Enterprise Governance Policies (EGP) across all namespaces in Vault.                         |
+| `vault.policies.rgp.count`                                          | The total number of Replication Governance Policies (RGP) across all namespaces in Vault.                        |
+| `vault.policies.acl.count`                                          | The total number of Access Control List (ACL) policies across all namespaces in Vault.                           |
+| `vault.policies.acl.control_group.count`                            | The total number of control groups in this cluster.                                                              |
+| `vault.policies.acl.recover.count`                                  | The total number of Access Control List (ACL) policies with a recover capability across all namesapces in Vault. |
+| `vault.autopilot_upgrade_enabled`                                   | Whether or not Autopilot Upgrade is enabled for the cluster.                                                     |
+| `vault.audit.device.file.count`                                     | The total number of audit devices of type file configured for this cluster.                                      |
+| `vault.audit.device.syslog.count`                                   | The total total number of audit devices of type syslog configured for this cluster.                              |
+| `vault.audit.device.socket.udp.count`                               | The total total number of audit devices of type UDP socket configured for this cluster.                          |
+| `vault.audit.device.socket.tcp.count`                               | The total total number of audit devices of type TCP socket configured for this cluster.                          |
+| `vault.audit.device.socket.unix.count`                              | The total total number of audit devices of type UNIX socket configured for this cluster.                         |
+| `vault.audit.exclusion.stanza.count`                                | The total number of audit exclusion stanzas in the HCL configuration for this cluster.                           |
+| `vault.loadedsnapshots.manual.count`                                | The total number of manual (local) snapshots loaded for recovery.                                                |
+| `vault.loadedsnapshots.cloud.google-gcs.count`                      | The total number of Google GCS snapshots loaded for recovery.                                                    |
+| `vault.loadedsnapshots.cloud.aws-s3.count`                          | The total number of AWS S3 snapshots loaded for recovery.                                                        |
+| `vault.loadedsnapshots.cloud.azure-blob.count`                      | The total number of Azure Blob snapshots loaded for recovery.                                                    |
+| `vault.autosnapshots.local.count`                                   | The total number of automated snapshot configurations with storage type local.                                   |
+| `vault.autosnapshots.google-gcs.count`                              | The total of automated snapshot configurations with storage type Google GCS.                                     |
+| `vault.autosnapshots.aws-s3.count`                                  | The total number of automated snapshot configurations with storage type AWS S3.                                  |
+| `vault.autosnapshots.azure-blob.count`                              | The total number of automated snapshot configurations with storage type Azure Blob.                              |
 
 ## Usage metadata list
 


### PR DESCRIPTION
Add the new census metrics to the list in the documentation. The new metrics are:
* `vault.policies.acl.recover.count`
* `vault.autosnapshots.local.count`     
* `vault.autosnapshots.google-gcs.count`
* `vault.autosnapshots.aws-s3.count`    
* `vault.autosnapshots.azure-blob.count`

Jiras:
https://hashicorp.atlassian.net/browse/VAULT-36946
https://hashicorp.atlassian.net/browse/VAULT-37634