### PR TITLE
terraform: Update machine-readable docs for `terraform query` output (TF-28527)

### DIFF
--- a/content/terraform/v1.14.x (beta)/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.14.x (beta)/docs/internals/machine-readable-ui.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Machine-readable UI Output Reference
 
-This topic provides reference information about the machine-readable output Terraform prints. 
+This topic provides reference information about the machine-readable output Terraform prints.
 
 ## Introduction
 
@@ -24,8 +24,7 @@ value `"1.0"`. The semantics of this version are:
   backward-compatible. Reject any input which reports an unsupported major
   version.
 
-Refer to 
-[Terraform 1.0 Compatibility Promises](/terraform/language/v1-compatibility-promises) for additional information.
+Refer to [Terraform 1.0 Compatibility Promises](/terraform/language/v1-compatibility-promises) for additional information.
 
 ## Sample JSON Output
 
@@ -1110,5 +1109,75 @@ Finally, the `planned` field contains any resources that were in the process of 
     ]
   },
   "type": "test_interrupt"
+}
+```
+
+
+## List Start
+
+The `terraform query` command emits a `list_start` message for each `list` block that Terraform is about to execute.
+
+### Example
+
+```json
+{
+  "@level": "info",
+  "@message": "list.random_pet.pets: Starting query...",
+  "@module": "terraform.ui",
+  "@timestamp": "2025-08-29T14:07:26.954999+02:00",
+  "list_start": {
+    "address": "list.random_pet.pets",
+    "resource_type": "random_pet"
+  },
+  "type": "list_start"
+}
+```
+
+
+## List Resource Found
+
+The `terraform query` command emits a `list_resource_found` for each resource that is found during the execution of a `list` block.
+
+### Example
+
+```json
+{
+  "@level": "info",
+  "@message": "list.random_pet.pets: Result found",
+  "@module": "terraform.ui",
+  "@timestamp": "2025-08-29T14:07:26.955529+02:00",
+  "list_resource_found": {
+    "address": "list.random_pet.pets",
+    "display_name": "This is a charming-beagle",
+    "identity": {
+      "id": "charming-beagle",
+      "legs": 3
+    },
+    "identity_version": 0,
+    "resource_type": "random_pet"
+  },
+  "type": "list_resource_found"
+}
+```
+
+
+## List Complete
+
+The `terraform query` command emits a `list_complete` message after all results of a `list` block are emitted.
+
+### Example
+
+```json
+{
+  "@level": "info",
+  "@message": "list.random_pet.pets: List complete",
+  "@module": "terraform.ui",
+  "@timestamp": "2025-08-29T14:07:26.955538+02:00",
+  "list_complete": {
+    "address": "list.random_pet.pets",
+    "resource_type": "random_pet",
+    "total": 5
+  },
+  "type": "list_complete"
 }
 ```


### PR DESCRIPTION
This PR adds the three new messages that are introduced by `terraform query` to the 1.14 machine-readable UI docs