### PR TITLE
[Vault] Fix 'all metrics' page missing response status codes

### DIFF
--- a/content/vault/v1.20.x/content/docs/internals/telemetry/metrics/all.mdx
+++ b/content/vault/v1.20.x/content/docs/internals/telemetry/metrics/all.mdx
@@ -188,6 +188,8 @@ alphabetic order by name.
 
 @include 'telemetry-metrics/vault/core/in_flight_requests.mdx'
 
+@include 'telemetry-metrics/vault/core/response_status_code.mdx'
+
 @include 'telemetry-metrics/vault/core/leadership_lost.mdx'
 
 @include 'telemetry-metrics/vault/core/leadership_setup_failed.mdx'


### PR DESCRIPTION
This was missed when adding these docs here: https://github.com/hashicorp/vault/pull/30396/files#diff-c2fa7a4904d8db4a41868bed086733239c6e7b5197616d92dc882810d2a2f0dc

and has been a point of confusion since. This addresses the issue.