### PR TITLE
add details about identity arg in import ref

### DIFF
--- a/content/terraform/v1.12.x/docs/language/block/import.mdx
+++ b/content/terraform/v1.12.x/docs/language/block/import.mdx
@@ -14,7 +14,7 @@ An `import` block supports the following configuration:
 
 - [`import`](#import) &nbsp block
   - [`to`](#to) &nbsp address | required
-  - [`id`](#id) &nbsp string   
+  - [`id`](#id) &nbsp string | mutually exclusive with `identity`
   - [`identity`](#identity) &nbsp map | mutually exclusive with `id`
   - [`for_each`](#for_each) &nbsp map or set of strings
   - [`provider`](#provider) &nbsp reference
@@ -119,7 +119,7 @@ import {
 }
 ```
 
-The specific attributes are specific to the resource type and provider. You can only import resources that are supported by the provider. Refer to your provider documentation for details.  
+The keys of the `identity` argument are specific to the resource type and provider. You can only import resources that are supported by the provider. Refer to your provider documentation for details.  
 
 You cannot use the `identity` argument and [`id` argument](#id) in the same `import` block.
 
@@ -202,7 +202,7 @@ The following examples show how to write configuration for common use cases.
 
 ### Import a single resource
 
-You can import an individual resource by specifying its ID in `id` argument or by specifying the set of identifying attributes in the `identity` argument.  
+You can import an individual resource by specifying its ID with the `id` argument or by specifying the set of identifying attributes in the `identity` argument.  
 
 <Tabs>
 

--- a/content/terraform/v1.13.x/docs/language/block/import.mdx
+++ b/content/terraform/v1.13.x/docs/language/block/import.mdx
@@ -14,7 +14,7 @@ An `import` block supports the following configuration:
 
 - [`import`](#import) &nbsp block
   - [`to`](#to) &nbsp address | required
-  - [`id`](#id) &nbsp string   
+  - [`id`](#id) &nbsp string | mutually exclusive with `identity`
   - [`identity`](#identity) &nbsp map | mutually exclusive with `id`
   - [`for_each`](#for_each) &nbsp map or set of strings
   - [`provider`](#provider) &nbsp reference
@@ -119,7 +119,7 @@ import {
 }
 ```
 
-The specific attributes are specific to the resource type and provider. You can only import resources that are supported by the provider. Refer to your provider documentation for details.  
+The keys of the `identity` argument are specific to the resource type and provider. You can only import resources that are supported by the provider. Refer to your provider documentation for details.  
 
 You cannot use the `identity` argument and [`id` argument](#id) in the same `import` block.
 


### PR DESCRIPTION
We commented out the `identity` argument when we rewrote the `import` block reference because it hadn't yet been adopted by provider developers, which was leading to confusion. This PR re-adds the argument and provides an example. 