### PR TITLE
db/snowflake: clarify `connection_url` format when using keypair authentication

### DIFF
--- a/content/vault/v1.16.x/content/api-docs/secret/databases/snowflake.mdx
+++ b/content/vault/v1.16.x/content/api-docs/secret/databases/snowflake.mdx
@@ -44,7 +44,7 @@ has a number of parameters to further configure a connection.
 - `connection_url` `(string: <required>)` - Specifies the Snowflake DSN. This field
   can be templated and supports passing the username and password
   parameters in the format `{{field_name}}` when you use password authentication.
-  If root credential rotation for passwords, you must provide a templated
+  If you use root credential rotation for passwords, you must provide a templated
   connection URL. Refer to the
   [Snowflake secrets engine docs](/vault/docs/secrets/databases/snowflake#setup)
   for more information on the connection URL format requirements for different

--- a/content/vault/v1.16.x/content/docs/secrets/databases/snowflake.mdx
+++ b/content/vault/v1.16.x/content/docs/secrets/databases/snowflake.mdx
@@ -102,7 +102,7 @@ The Snowflake database secrets engine uses
     ```
 
 
-~> **Note:** You must provide Vault with a Snowflake user that has `ACCOUNT_ADMIN` privileges. We
+You must provide Vault with a Snowflake user that has `ACCOUNT_ADMIN` privileges. We
 strongly recommend using a unique user account for Vault access so Vault can
 rotate the associated root credentials without disrupting the account associated
 with your Snowflake account or other Snowflake users on the account.

--- a/content/vault/v1.17.x/content/api-docs/secret/databases/snowflake.mdx
+++ b/content/vault/v1.17.x/content/api-docs/secret/databases/snowflake.mdx
@@ -43,8 +43,12 @@ has a number of parameters to further configure a connection.
 
 - `connection_url` `(string: <required>)` - Specifies the Snowflake DSN. This field
   can be templated and supports passing the username and password
-  parameters in the following format `{{field_name}}`. A templated connection URL is
-  required when using root credential rotation.
+  parameters in the format `{{field_name}}` when you use password authentication.
+  If you use root credential rotation for passwords, you must provide a templated
+  connection URL. Refer to the
+  [Snowflake secrets engine docs](/vault/docs/secrets/databases/snowflake#setup)
+  for more information on the connection URL format requirements for different
+  authentication methods.
 
 - `max_open_connections` `(int: 4)` - Specifies the maximum number of open
   connections to the database.

--- a/content/vault/v1.17.x/content/docs/secrets/databases/snowflake.mdx
+++ b/content/vault/v1.17.x/content/docs/secrets/databases/snowflake.mdx
@@ -86,8 +86,7 @@ The Snowflake database secrets engine uses
         private_key=@key.pem
     ```
 
-    The connection URL must include the following parameters in addition to any
-    optional query parameters:
+    The connection URL must include the following parameters (additional query parameters are not supported in Vault 1.17):
 
     - `account` - your Snowflake account identifier. Refer to the
       [`server` section](https://docs.snowflake.com/en/user-guide/odbc-parameters.html#connection-parameters)
@@ -102,7 +101,7 @@ The Snowflake database secrets engine uses
     ```
 
 
-~> **Note:** You must provide Vault with a Snowflake user that has `ACCOUNT_ADMIN` privileges. We
+You must provide Vault with a Snowflake user that has `ACCOUNT_ADMIN` privileges. We
 strongly recommend using a unique user account for Vault access so Vault can
 rotate the associated root credentials without disrupting the account associated
 with your Snowflake account or other Snowflake users on the account.

--- a/content/vault/v1.18.x/content/api-docs/secret/databases/snowflake.mdx
+++ b/content/vault/v1.18.x/content/api-docs/secret/databases/snowflake.mdx
@@ -44,7 +44,7 @@ has a number of parameters to further configure a connection.
 - `connection_url` `(string: <required>)` - Specifies the Snowflake DSN. This field
   can be templated and supports passing the username and password
   parameters in the format `{{field_name}}` when you use password authentication.
-  If root credential rotation for passwords, you must provide a templated
+  If you use root credential rotation for passwords, you must provide a templated
   connection URL. Refer to the
   [Snowflake secrets engine docs](/vault/docs/secrets/databases/snowflake#setup)
   for more information on the connection URL format requirements for different

--- a/content/vault/v1.18.x/content/docs/secrets/databases/snowflake.mdx
+++ b/content/vault/v1.18.x/content/docs/secrets/databases/snowflake.mdx
@@ -102,7 +102,7 @@ The Snowflake database secrets engine uses
     ```
 
 
-~> **Note:** You must provide Vault with a Snowflake user that has `ACCOUNT_ADMIN` privileges. We
+You must provide Vault with a Snowflake user that has `ACCOUNT_ADMIN` privileges. We
 strongly recommend using a unique user account for Vault access so Vault can
 rotate the associated root credentials without disrupting the account associated
 with your Snowflake account or other Snowflake users on the account.

--- a/content/vault/v1.19.x/content/api-docs/secret/databases/snowflake.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/databases/snowflake.mdx
@@ -44,7 +44,7 @@ has a number of parameters to further configure a connection.
 - `connection_url` `(string: <required>)` - Specifies the Snowflake DSN. This field
   can be templated and supports passing the username and password
   parameters in the format `{{field_name}}` when you use password authentication.
-  If root credential rotation for passwords, you must provide a templated
+  If you use root credential rotation for passwords, you must provide a templated
   connection URL. Refer to the
   [Snowflake secrets engine docs](/vault/docs/secrets/databases/snowflake#setup)
   for more information on the connection URL format requirements for different

--- a/content/vault/v1.19.x/content/docs/secrets/databases/snowflake.mdx
+++ b/content/vault/v1.19.x/content/docs/secrets/databases/snowflake.mdx
@@ -102,7 +102,7 @@ The Snowflake database secrets engine uses
     ```
 
 
-~> **Note:** You must provide Vault with a Snowflake user that has `ACCOUNT_ADMIN` privileges. We
+You must provide Vault with a Snowflake user that has `ACCOUNT_ADMIN` privileges. We
 strongly recommend using a unique user account for Vault access so Vault can
 rotate the associated root credentials without disrupting the account associated
 with your Snowflake account or other Snowflake users on the account.

--- a/content/vault/v1.20.x/content/api-docs/secret/databases/snowflake.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/databases/snowflake.mdx
@@ -44,7 +44,7 @@ has a number of parameters to further configure a connection.
 - `connection_url` `(string: <required>)` - Specifies the Snowflake DSN. This field
   can be templated and supports passing the username and password
   parameters in the format `{{field_name}}` when you use password authentication.
-  If root credential rotation for passwords, you must provide a templated
+  If you use root credential rotation for passwords, you must provide a templated
   connection URL. Refer to the
   [Snowflake secrets engine docs](/vault/docs/secrets/databases/snowflake#setup)
   for more information on the connection URL format requirements for different

--- a/content/vault/v1.20.x/content/docs/secrets/databases/snowflake.mdx
+++ b/content/vault/v1.20.x/content/docs/secrets/databases/snowflake.mdx
@@ -102,7 +102,7 @@ The Snowflake database secrets engine uses
     ```
 
 
-~> **Note:** You must provide Vault with a Snowflake user that has `ACCOUNT_ADMIN` privileges. We
+You must provide Vault with a Snowflake user that has `ACCOUNT_ADMIN` privileges. We
 strongly recommend using a unique user account for Vault access so Vault can
 rotate the associated root credentials without disrupting the account associated
 with your Snowflake account or other Snowflake users on the account.


### PR DESCRIPTION
Makes documentation explicitly clear on how to format the `connection_url` when using keypair authentication. Mainly explicitly calling out the following:
- users should not prepend or include any `username:password` information (templated or hard-coded) in the connection URL submitted to Vault
- users can supply optional query parameters if they wish to do so

Other changes:
- Adds missing documentation from 1.18 and 1.16 branches. While the feature was backported to those versions, looks like the documentation was not backported to those branches at the time.