### PR TITLE
docs(http backend): warn against using skip_cert_verification in production; surface mTLS alternatives

### DIFF
--- a/content/terraform/v1.13.x/docs/language/backend/http.mdx
+++ b/content/terraform/v1.13.x/docs/language/backend/http.mdx
@@ -40,6 +40,13 @@ data "terraform_remote_state" "foo" {
 
 ## Configuration Variables
 
+> **Security warning**
+> `skip_cert_verification` disables TLS certificate verification and should **not** be used in production.
+> Prefer configuring proper trust or **mTLS** instead. The HTTP backend already supports:
+> - `client_certificate_pem` and `client_private_key_pem` for client authentication
+> - `client_ca_certificate_pem` for server certificate validation
+> See [Credentials and Sensitive Data](/terraform/language/backend#credentials-and-sensitive-data) for handling secrets.
+
 !> **Warning:**  We recommend using environment variables to supply credentials and other sensitive data. If you use `-backend-config` or hardcode these values directly in your configuration, Terraform will include these values in both the `.terraform` subdirectory and in plan files. Refer to [Credentials and Sensitive Data](/terraform/language/backend#credentials-and-sensitive-data) for details.
 
 The following configuration options / environment variables are supported:
@@ -60,7 +67,7 @@ The following configuration options / environment variables are supported:
 - `password` / `TF_HTTP_PASSWORD` - (Optional) The password for HTTP basic
   authentication
 - `skip_cert_verification` - (Optional) Whether to skip TLS verification.
-  Defaults to `false`.
+  Defaults to `false`. **Not recommended for production.**
 - `retry_max` / `TF_HTTP_RETRY_MAX` – (Optional) The number of HTTP request
   retries. Defaults to `2`.
 - `retry_wait_min` / `TF_HTTP_RETRY_WAIT_MIN` – (Optional) The minimum time in
@@ -68,7 +75,7 @@ The following configuration options / environment variables are supported:
 - `retry_wait_max` / `TF_HTTP_RETRY_WAIT_MAX` – (Optional) The maximum time in
   seconds to wait between HTTP request attempts. Defaults to `30`.
 
-For mTLS authentication, the following three options may be set:
+For **mTLS** authentication (recommended in production over `skip_cert_verification`), the following three options may be set:
 
  - `client_certificate_pem` / `TF_HTTP_CLIENT_CERTIFICATE_PEM` - (Optional) A PEM-encoded certificate used by the server to verify the client during mutual TLS (mTLS) authentication.
  - `client_private_key_pem` /`TF_HTTP_CLIENT_PRIVATE_KEY_PEM` - (Optional) A PEM-encoded private key, required if client_certificate_pem is specified.


### PR DESCRIPTION
Docs-only hardening; no behavior change.

- Add a visible warning that `skip_cert_verification` disables TLS verification and is not appropriate for production.
- Point readers to mTLS options already supported by the HTTP backend (`client_certificate_pem`, `client_private_key_pem`, `client_ca_certificate_pem`).
- Nudge readers to use proper trust configuration and to handle secrets per "Credentials and Sensitive Data".

Related to hashicorp/terraform#37568.