### PR TITLE
docs(s3 backend): add caution around skip_* flags; clarify testing/compat intent

### DIFF
--- a/content/terraform/v1.13.x/docs/language/backend/s3.mdx
+++ b/content/terraform/v1.13.x/docs/language/backend/s3.mdx
@@ -196,6 +196,11 @@ data.terraform_remote_state.network:
 
 This backend requires the configuration of the AWS Region and S3 state storage. Other configuration, such as enabling state locking, is optional.
 
+> **Caution (testing/compat only)**
+> The following flags exist primarily for **testing** or **S3-compatible** implementations and may bypass standard AWS validations or metadata checks.
+> Do **not** enable them in production unless you fully understand the implications and have equivalent controls in place.
+> Prefer using standard AWS mechanisms (IAM, STS) and validated TLS, and provide credentials via environment variables or a secret manager.
+
 ### Credentials and Shared Configuration
 
 !> **Warning:**  We recommend using environment variables to supply credentials and other sensitive data. If you use `-backend-config` or hardcode these values directly in your configuration, Terraform will include these values in both the `.terraform` subdirectory and in plan files. Refer to [Credentials and Sensitive Data](/terraform/language/backend#credentials-and-sensitive-data) for details.
@@ -239,11 +244,11 @@ The following configuration is optional:
 * `shared_credentials_file`  - (Optional, **Deprecated**, use `shared_credentials_files` instead) Path to the AWS shared credentials file. Defaults to `~/.aws/credentials`.
 * `shared_credentials_files`  - (Optional) List of paths to AWS shared credentials files. Defaults to `~/.aws/credentials`.
 * `skip_credentials_validation` - (Optional) Skip credentials validation via the STS API.
-  Useful for testing and for AWS API implementations that do not have STS available.
+  Useful for testing and for AWS API implementations that do not have STS available. **Not recommended for production.**
 * `skip_region_validation` - (Optional) Skip validation of provided region name.
 * `skip_requesting_account_id` - (Optional) Whether to skip requesting the account ID.
-  Useful for AWS API implementations that do not have the IAM, STS API, or metadata API.
-* `skip_metadata_api_check` - (Optional) Skip usage of EC2 Metadata API.
+  Useful for AWS API implementations that do not have the IAM, STS API, or metadata API. **Not recommended for production.**
+* `skip_metadata_api_check` - (Optional) Skip usage of EC2 Metadata API. **Not recommended for production.**
 * `skip_s3_checksum` - (Optional) Do not include checksum when uploading S3 Objects.
   Useful for some S3-Compatible APIs.
 * `sts_endpoint` - (Optional, **Deprecated**) Custom endpoint URL for the AWS Security Token Service (STS) API.


### PR DESCRIPTION
Docs-only hardening; no behavior change.

- Add a caution block explaining that skip_* flags (skip_credentials_validation, skip_requesting_account_id, skip_metadata_api_check) are primarily intended for testing or S3-compatible implementations and may bypass AWS validations and metadata checks.
- Mark these options as "Not recommended for production".
- Encourage use of standard AWS mechanisms (IAM, STS) and validated TLS, and advise providing credentials via environment variables or secret managers.

Related to hashicorp/terraform#37568.