### PR TITLE
db/snowflake: clarify `connection_url` format when using keypair authentication in 1.21 documentation

### DIFF
--- a/content/vault/v1.21.x (rc)/content/api-docs/secret/databases/snowflake.mdx
+++ b/content/vault/v1.21.x (rc)/content/api-docs/secret/databases/snowflake.mdx
@@ -43,8 +43,12 @@ has a number of parameters to further configure a connection.
 
 - `connection_url` `(string: <required>)` - Specifies the Snowflake DSN. This field
   can be templated and supports passing the username and password
-  parameters in the following format `{{field_name}}`. A templated connection URL is
-  required when using root credential rotation.
+  parameters in the format `{{field_name}}` when you use password authentication.
+  If you use root credential rotation for passwords, you must provide a templated
+  connection URL. Refer to the
+  [Snowflake secrets engine docs](/vault/docs/secrets/databases/snowflake#setup)
+  for more information on the connection URL format requirements for different
+  authentication methods.
 
 - `max_open_connections` `(int: 4)` - Specifies the maximum number of open
   connections to the database.

--- a/content/vault/v1.21.x (rc)/content/docs/secrets/databases/snowflake.mdx
+++ b/content/vault/v1.21.x (rc)/content/docs/secrets/databases/snowflake.mdx
@@ -75,30 +75,35 @@ The Snowflake database secrets engine uses
     from the root user you were provided when making your Snowflake account. This allows you to rotate
     the root credentials and still be able to access your account.
 
-1.  Configure Vault with keypair authentication:
+1.  Configure Vault with keypair authentication. Do not provide templated or
+    hard-coded username or password information in the connection URL if you use
+    key-pair authentication. The Snowflake plugin appropriately constructs the
+    full DSN using the provided `username` and `private_key` to authenticate to
+    Snowflake:
 
     ```shell-session
     $ vault write database/config/my-snowflake-database \
         plugin_name=snowflake-database-plugin \
         allowed_roles="my-role" \
-        connection_url="ecxxxx.west-us-1.azure.snowflakecomputing.com/db_name" \
+        connection_url="<account>.west-us-1.azure.snowflakecomputing.com/<db_name>" \
         username="vaultuser" \
         private_key=@key.pem
     ```
 
-You must provide properly formatted data source names (DSN) when you configure
-the database in the following format. When using key-pair authentication, do not
-provide any templates in the DSN:
+    The connection URL must include the following parameters in addition to any
+    optional query parameters:
 
-```shell-session
-<account>.snowflakecomputing.com/<db_name>
-```
+    - `account` - your Snowflake account identifier. Refer to the
+      [`server` section](https://docs.snowflake.com/en/user-guide/odbc-parameters.html#connection-parameters)
+      of the connection parameters for Snowflake ODBC configuration details.
 
-- `account` - your Snowflake account identifier. Refer to the
-[`server` section](https://docs.snowflake.com/en/user-guide/odbc-parameters.html#connection-parameters)
-of the connection parameters for Snowflake ODBC configuration for further details.
+    - `db_name` the name of a database in your Snowflake instance.
 
-- `db_name` the name of a database in your Snowflake instance.
+    For example:
+
+    ```text
+    ecxxxx.west-us-1.azure.snowflakecomputing.com/my_app_data
+    ```
 
 You must provide Vault with a Snowflake user that has `ACCOUNT_ADMIN` privileges. We
 strongly recommend using a unique user account for Vault access so Vault can


### PR DESCRIPTION
Makes same changes as #940 but for the 1.21 release.