### PR TITLE
Format & style fixes for PR 948

### DIFF
--- a/content/vault/v1.20.x/content/docs/mcp-server/prompt-model.mdx
+++ b/content/vault/v1.20.x/content/docs/mcp-server/prompt-model.mdx
@@ -8,7 +8,7 @@ description: |-
 
 This topic provides example prompts for helping you manage HashiCorp Vault after installing the Vault model context protocol (MCP) server. Refer to [Deploy the Vault MCP server](/vault/docs/tools/mcp-server/deploy) for instructions on how to deploy the server.
 
-@include 'beta.mdx'
+@include 'alerts/beta.mdx'
 
 ## Overview
 
@@ -80,6 +80,8 @@ The server performs the following operations:
 
 #### Sample response
 
+<CodeBlockConfig hideClipboard>
+
 ```text
 Successfully stored database credentials in Vault:
 
@@ -95,6 +97,8 @@ or by reading the secret directly from Vault.
 **Security Note**: Ensure your application has appropriate Vault policies 
 to read from this path while following the principle of least privilege.
 ```
+
+</CodeBlockConfig>
 
 ### Set up PKI certificate authority
 
@@ -148,6 +152,8 @@ The server performs multiple coordinated operations:
 
 #### PKI setup response
 
+<CodeBlockConfig hideClipboard>
+
 ```text
 Successfully configured PKI infrastructure for example.com:
 
@@ -176,6 +182,8 @@ The PKI infrastructure is ready to issue certificates for:
 - Custom TTL up to 1 year
 - Both server and client authentication use cases
 ```
+
+</CodeBlockConfig>
 
 ### List and audit secrets
 
@@ -206,6 +214,8 @@ mounts exist and list the secrets in the main KV store.
 ```
 
 #### Audit response
+
+<CodeBlockConfig hideClipboard>
 
 ```text
 # Vault Security Audit Report
@@ -240,6 +250,8 @@ secret/
 **Mount Health**: All mounts operational ✅
 ```
 
+</CodeBlockConfig>
+
 ### Issue SSL certificates for applications
 
 The following prompt demonstrates certificate lifecycle management:
@@ -269,6 +281,8 @@ the existing PKI role.
 ```
 
 #### Certificate response
+
+<CodeBlockConfig hideClipboard>
 
 ```text
 Successfully issued SSL certificate for api.internal.example.com:
@@ -308,6 +322,8 @@ MIIEvgIBADANBgkqhkiG9w0BAQ...
 Certificate expires in 30 days - set up renewal automation.
 ```
 
+</CodeBlockConfig>
+
 ### Delete and cleanup secrets
 
 The following prompt demonstrates secure cleanup operations:
@@ -342,6 +358,8 @@ the entire legacy mount if it's empty.
 
 #### Cleanup response
 
+<CodeBlockConfig hideClipboard>
+
 ```text
 Cleanup operations completed successfully:
 
@@ -364,23 +382,25 @@ Would you like me to remove the empty legacy path structure
 or keep it for future use?
 ```
 
-## Best Practices for Vault MCP Prompts
+</CodeBlockConfig>
 
-### Effective Prompt Structure
+## Best practices for Vault MCP prompts
+
+### Effective prompt structure
 
 - **Be Specific**: Use exact mount paths and secret names
 - **Include Context**: Mention the purpose (app credentials, certificates, etc.)
 - **Specify Requirements**: TTL values, certificate parameters, security policies
 - **Request Validation**: Ask for confirmation of operations before execution
 
-### Security Considerations
+### Security considerations
 
 - **Principle of Least Privilege**: Request minimal necessary permissions
 - **Audit Trail**: Ensure operations are logged and traceable
 - **Secret Lifecycle**: Consider rotation, expiration, and cleanup
 - **Access Patterns**: Design secrets structure for application access patterns
 
-### Common Use Cases
+### Common use cases
 
 - **Application Secrets**: Database credentials, API keys, service tokens
 - **PKI Management**: Certificate authorities, SSL certificates, key rotation

--- a/content/vault/v1.20.x/content/docs/mcp-server/reference.mdx
+++ b/content/vault/v1.20.x/content/docs/mcp-server/reference.mdx
@@ -57,7 +57,7 @@ You can set one of the following transport protocols when starting the MCP serve
 | `stdio`          | Local development and direct integration with MCP clients       | Uses standard input/output for JSON-RPC message communication                                 | Automatically used when no specific transport mode is configured |
 | `streamable-http`| Distributed setups, internal environments                       | HTTP-based transport with support for both direct HTTP requests                               | Enable by setting `TRANSPORT_MODE=streamable-http`               |
 
-## HTTP Mode Configuration
+## HTTP mode configuration
 
 At this stage, the MCP server is intended for local use only. If using the StreamableHTTP transport in production, always configure the MCP_ALLOWED_ORIGINS environment variable to restrict access to trusted origins only.
 This helps prevent DNS rebinding attacks and other cross-origin vulnerabilities.
@@ -72,7 +72,7 @@ In HTTP mode, Vault configuration can be provided through multiple methods (**in
 
 You can set the following environment variables to configure the server behavior.
 
-| Variable                 | Purpose                                                      | Default Value             | Example                        | Options                                 |
+| Variable                 | Purpose                                                      | Default value             | Example                        | Options                                 |
 |--------------------------|--------------------------------------------------------------|---------------------------|--------------------------------|-----------------------------------------|
 | `VAULT_ADDR`             | Vault server address                                         | `http://127.0.0.1:8200`   | `http://vault.example.com:8200`| Any valid Vault server address          |
 | `VAULT_TOKEN`            | Vault authentication token (required)                        | —                         | `hvs.xxxxxxxx`                 | Any valid Vault token                   |

--- a/content/vault/v1.20.x/data/docs-nav-data.json
+++ b/content/vault/v1.20.x/data/docs-nav-data.json
@@ -1981,11 +1981,11 @@
         "path": "mcp-server/overview"
       },
       {
-        "title": "Deploy Server",
+        "title": "Deploy server",
         "path": "mcp-server/deploy"
       },
       {
-        "title": "Prompt Model",
+        "title": "Prompt model",
         "path": "mcp-server/prompt-model"
       },
       {
@@ -1993,7 +1993,7 @@
         "path": "mcp-server/reference"
       },
       {
-        "title": "Security Model",
+        "title": "Security model",
         "path": "mcp-server/security-model"
       }
     ]


### PR DESCRIPTION
This PR makes minor fixes to https://github.com/hashicorp/web-unified-docs/pull/948:

- Use sentence case for titles
- `@include 'beta.mdx'` --> `@include 'alerts/beta.mdx'`


🔍 [Deploy preview](https://unified-docs-frontend-preview-lhgs7rwwp-hashicorp.vercel.app/vault/docs/mcp-server/overview)