### PR TITLE
manually sync with PR in internal

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/prewritten-sentinel.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/prewritten-sentinel.mdx
@@ -3,7 +3,7 @@ page_title: Run pre-written Sentinel policies
 description: Learn how to download and install pre-written Sentinel policies created and maintained by HashiCorp.
 ---
 
-# Run pre-written Sentinel policies
+# Run pre-written Sentinel policies 
 
 This topic describes how to run Sentinel policies created and maintained by HashiCorp. For instructions about how to create your own custom Sentinel policies, refer to [Define custom Sentinel policies](/terraform/cloud-docs/policy-enforcement/define-policies/custom-sentinel).
 
@@ -13,10 +13,10 @@ Pre-written Sentinel policy libraries streamline your compliance processes and e
 
 Complete the following steps to implement pre-written Sentinel policies in your workspaces:
 
-1. Obtain the policies you want to implement. Download policies directly into your repository or create a fork of the HashiCorp repositories.
+1. Obtain the policies you want to implement. Download policies directly into your repository or create a fork of the HashiCorp repositories. 
 1. Connect policies to your workspace. After you download policies or fork policy repositories, you must connect them to your HCP Terraform or Terraform Enterprise workspaces.
 
-Refer to the [Sentinel documentation](/sentinel/docs) for information about the Sentinel language.
+Refer to the [Sentinel documentation](/sentinel/docs) for information about the Sentinel language. 
 
 ## Requirements
 
@@ -40,23 +40,22 @@ You must have a GitHub account connected to HCP Terraform or Terraform Enterpris
 
 Refer to the [pre-written policy library reference](/terraform/cloud-docs/policy-enforcement/prewritten-library) for a complete list of available policy sets. Use one of the following methods to get pre-written policies:
 
-- **Download policies from the registry**: Use this method if you want to assemble custom policy sets without customizing policies.
-- **Fork the HashiCorp policy GitHub repository**: Use this method if you intend to customize the policies.
-- **Add the Terraform module to your configuration**: Use this method to implement specific versions of the policies as-is. This method also connects the policies to workspaces in the Terraform configuration file instead of connecting them as a separate step.
+- **Download policies from the registry**: Use this method if you want to assemble custom policy sets without customizing policies.  
+- **Fork the HashiCorp policy GitHub repository**: Use this method if you intend to customize the policies. 
 
 <Tabs>
 
 <Tab heading="Download from the registry">
 
-Complete the following steps to download policies from the registry and apply them directly to your workspaces.
+Complete the following steps to download policies from the registry and apply them directly to your workspaces. 
 
 1. Browse the policy libraries available in the [Terraform registry](https://registry.terraform.io/search/policies?q=Pre-written).
 1. Click on a policy library and click **Choose policies**.
 1. Select the policies you want to implement. The registry generates code in the **USAGE INSTRUCTIONS** box.
-1. Click **Copy Code Snippet** to copy the code to your clipboard.
+1. Click **Copy Code Snippet** to copy the code to your clipboard. 
 1. Create a GitHub repository to store the policies and the policy set configuration file.
-1. Create a file called `sentinel.hcl` in the repository.
-1. Paste the code from your clipboard into `sentinel.hcl` and commit your changes.
+1. Create a file called `sentinel.hcl` in the repository. 
+1. Paste the code from your clipboard into `sentinel.hcl` and commit your changes. 
 1. Complete the instructions for [connecting the policies to your workspace](#connect-policies-to-your-workspace).
 
 </Tab>
@@ -76,44 +75,9 @@ After forking the repository, complete the instructions for [connecting the poli
 
 </Tab>
 
-This method enables you to connect the policies to workspaces in the Terraform configuration file. As a result, you can skip the instructions described in [Connect policies to your workspaces](#connect-policies-to-your-workspaces).
-
-By default, the module supports policies stored in the following repositories:
-
-- [`policy-library-CIS-Policy-Set-for-AWS-Terraform`](https://github.com/hashicorp/policy-library-CIS-Policy-Set-for-AWS-Terraform)
-- [`policy-library-FSBP-Policy-Set-for-AWS-Terraform`](https://github.com/hashicorp/policy-library-FSBP-Policy-Set-for-AWS-Terraform/)
-
-Refer to the instructions in the [terraform-AWS-Prewritten-Policy-Set](https://github.com/hashicorp/terraform-AWS-Prewritten-Policy-Set/tree/main) GitHub repository for additional information about using the module, including how to modify or extend the default repositories.
-
-1. Go to the [module in the Terraform registry](https://registry.terraform.io/modules/hashicorp/Prewritten-Policy-Set/AWS/latest) and copy the code generated in the **Provision Instructions** tile.
-1. Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Enterprise API token. You can use your token or an organization token.
-1. Add the `module` block to your Terraform configuration and define the following arguments:
-   - `source`: Specify the path to the module you downloaded.
-   - `tfe_organization`: Specify the name of your organization on Terraform Enterprise or HCP Terraform.
-   - `policy_set_workspace_names`: Specify a list of workspace names that you want to apply the policies to.
-   - `name`: Specifies a name for your policy set.
-
-   The following example configuration applies invokes the module for `target_workspace_1`:
-
-   ```hcl
-   module "policy_set" {
-      source = "./prewritten-policy"
-      name                             = "<your-policy-set>"
-      tfe_organization                 = "<your-organization>"
-      policy_set_workspace_names       = ["target_workspace_1"]
-      name                             = "<name-for-your-policy-set>"
-   }
-   ```
-
-1. Run `terraform plan` to view the plan.
-1. Run `terraform apply` to apply the changes. After running the command, Terraform will evaluate Sentinel policies for each following run of the workspaces you specified.
-
-</Tab>
 </Tabs>
 
 ## Connect policies to your workspace
-
-Skip this step if you [added the Terraform module](#add-the-terraform-module-to-your-configuration) to your configuration. When you use the module, the `policy_set_workspace_names` argument instructs Terraform to connect the policies to the HCP Terraform workspaces specified in the configuration.
 
 1. Sign in to [HCP Terraform](https://app.terraform.io/) or Terraform Enterprise and navigate to the organization with workspaces you want to connect policies to.
 1. Choose **Settings** from the sidebar.
@@ -122,15 +86,15 @@ Skip this step if you [added the Terraform module](#add-the-terraform-module-to-
 1. Enable the **Sentinel** option as the policy framework.
 1. Specify a name and description for the set.
 1. Configure any additional options for the policy set and click **Next**.
-1. Choose the GitHub connection type, then choose the repository you created in [Set up a repository for the policies](#set-up-a-repository-for-the-policies).
+1. Choose the GitHub connection type, then choose the repository you created in [Set up a repository for the policies](#set-up-a-repository-for-the-policies). 
 1. If the `sentinel.hcl` policy set file is stored in a subfolder, specify the path to the file in the **Policies path** field. The default is the root directory.
 1. If you want to apply updated policy sets to the workspace from a specific branch, specify the name in the **VCS branch** field. The default is the default branch configured for the repository.
-1. Click **Next** and specify any additional parameters you want to pass to the Sentinel runtime and click **Connect policy set** to finish applying the policies to the workspace.
+1. Click **Next** and specify any additional parameters you want to pass to the Sentinel runtime and click **Connect policy set** to finish applying the policies to the workspace. 
 
-Run a plan in the workspace to trigger the connected policies. Refer to [Start a Terraform run](/terraform/cloud-docs/workspaces/run/remote-operations#starting-runs) for additional information.
+Run a plan in the workspace to trigger the connected policies. Refer to [Start a Terraform run](/terraform/cloud-docs/run/remote-operations#starting-runs) for additional information.
 
 ## Next steps
 
 - Group your policies into sets and apply them to your workspaces. Refer to [Create policy sets](/terraform/cloud-docs/policy-enforcement/manage-policy-sets#create-policy-sets) for additional information.
 - View results and address Terraform runs that do not comply with your policies. Refer to [View results](/terraform/cloud-docs/policy-enforcement/view-results) for additional information.
-- You can also view Sentinel policy results in JSON format. Refer to [View Sentinel JSON results](/terraform/cloud-docs/policy-enforcement/view-results/json) for additional information.
+- You can also view Sentinel policy results in JSON format. Refer to [View Sentinel JSON results](/terraform/cloud-docs/policy-enforcement/view-results/json) for additional information. 


### PR DESCRIPTION
This PR fixes the topic on running prewritten Sentinel policies. There was a problem during the sync with the internal repository and the page was only partially updated. 