### PR TITLE
Docs/add terraform destroy best practices

### DIFF
--- a/content/terraform/v1.9.x/docs/cli/commands/destroy-best-practices.mdx
+++ b/content/terraform/v1.9.x/docs/cli/commands/destroy-best-practices.mdx
@@ -14,5 +14,55 @@ Follow these best practices to ensure safe and controlled destruction of infrast
 ## Use `-target` Carefully
 
 If you only want to destroy specific resources, you can use the `-target` flag:
+
 ```bash
 terraform destroy -target=aws_instance.example
+```
+
+Using `-target` can lead to inconsistent state if dependencies exist between resources.
+
+## Always Review the Plan First
+
+Before running a full destroy, generate and inspect the plan:
+
+```bash
+terraform plan -destroy
+```
+
+This shows exactly what resources will be removed, helping you avoid surprises.
+
+## Protect Critical Resources
+
+For resources that should never be destroyed (e.g., databases, production load balancers), use the `prevent_destroy` lifecycle rule in your configuration:
+
+```hcl
+resource "aws_db_instance" "prod" {
+  # ...
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+This ensures Terraform fails if you try to destroy these resources.
+
+## Back Up State Files
+
+Always back up your state files before running `terraform destroy`.
+You can use remote backends like S3 with DynamoDB locking to protect state consistency.
+
+## Use Workspaces for Isolation
+
+Separate environments (e.g., dev, staging, prod) with workspaces:
+
+```bash
+terraform workspace new dev
+terraform workspace select dev
+```
+
+This prevents accidental destruction of production infrastructure when testing.
+
+## Confirm with Your Team
+
+If you work in a shared environment, never run `terraform destroy` without alignment.
+Coordinate with your team to avoid unexpected downtime.


### PR DESCRIPTION
## Description

This PR adds a new "Destroy Best Practices" documentation page to the Terraform CLI commands section.

## What's included

The new documentation provides guidance for safely using `terraform destroy` to help users avoid accidental data loss and ensure controlled infrastructure destruction. The guide covers:

- Using `-target` carefully and understanding dependency risks
- Reviewing plans before destruction with `terraform plan -destroy`
- Protecting critical resources using `prevent_destroy` lifecycle rules
- Backing up state files before destructive operations
- Using workspaces for environment isolation
- Team coordination and communication guidelines

## Location

The documentation is placed at `content/terraform/v1.9.x/docs/cli/commands/destroy-best-practices.mdx` to complement the existing `destroy.mdx` command reference.

## Checklist

- [x] Content follows the style guide
- [x] Proper MDX frontmatter included
- [x] Code blocks have appropriate language tags
- [x] Active voice used throughout
- [x] No unofficial abbreviations (TF, TFC, etc.)