### PR TITLE
Fix formatting in state show command examples

### DIFF
--- a/content/terraform/v1.13.x/docs/cli/commands/state/show.mdx
+++ b/content/terraform/v1.13.x/docs/cli/commands/state/show.mdx
@@ -79,7 +79,7 @@ $ terraform state show 'packet_device.worker["example"]'
 PowerShell:
 
 ```shell
-$ terraform state show 'packet_device.worker[\"example\"]'
+$ terraform state show 'packet_device.worker["example"]'
 ```
 
 Windows `cmd.exe`:


### PR DESCRIPTION
Fixing typo in powershell state show for for_each resources
--> what is documented don't work:
```
terraform state show 'module.demoaas.module.vmclient[\"rayt\"].null_resource.image_version_tracker'
Error parsing instance address: module.demoaas.module.vmclient[\"rayt\"].null_resource.image_version_tracker

This command requires that the address references one specific instance.
To view the available instances, use "terraform state list". Please modify
the address to reference a specific instance.
```

--> the fix
```
terraform state show 'module.demoaas.module.vmclient["rayt"].null_resource.image_version_tracker'
# module.demoaas.module.vmclient["rayt"].null_resource.image_version_tracker:
resource "null_resource" "image_version_tracker" {
    id       = "7983134432509615754"
    triggers = {
        "image_version" = "1.0.0"
    }
}
```