### PR TITLE
Update Azure Static Roles Metadata Docs

### DIFF
--- a/content/vault/v1.21.x (rc)/content/api-docs/secret/azure.mdx
+++ b/content/vault/v1.21.x (rc)/content/api-docs/secret/azure.mdx
@@ -465,12 +465,13 @@ Create or update static role definitions used to manage pre-existing
    as time suffixed strings (`"1h"`) or an integer number of
    seconds. Leave `ttl` unset or set to `0` to use the default value
    of 2 years (`17520h`).
-- `metadata` (`map[string]any: {}`) - A map of string to key/value pairs that will be stored
+- `metadata` (`map[string]string: {}`) - A map of string to string key/value pairs that will be stored
   as metadata for the mount. This can be used to store additional information about the
-  mount for reference purposes. The data stored here is displayed in the response of 
-  `/azure/static-creds/:name` in the `metadata` field when reading the credential.
+  mount for reference purposes. The data stored here is displayed in the response of
+  `/azure/static-roles/:name` and `/azure/static-creds/:name` in the `metadata` field.
   When also setting the `metadata` parameter on `/azure/static-creds/:name`, the two
-  maps will be merged, with the values from `/azure/static-roles/:name` taking precedence in the event of key collisions.
+  maps will be merged in the response of `/azure/static-creds/:name`, with the values from `/azure/static-roles/:name`
+  taking precedence in the event of key collisions.
 - `secret_id` (`string: ""`) - The secret ID of the Azure password credential you want to import.
    Required if you provide `client_secret` or `expiration`.
 - `client_secret` (`string: ""`) - The plaintext secret value of the credential you want to import.
@@ -486,7 +487,11 @@ Create or update static role definitions used to manage pre-existing
 ```json
 {
   "application_object_id": "408bf248-dd4e-4be5-919a-7f6207a307ab",
-  "ttl": "8760h"
+  "ttl": "8760h",
+  "metadata": {
+    "team": "engineering",
+    "environment": "development"
+  }
 }
 ```
 
@@ -530,6 +535,10 @@ $ curl \
     "application_object_id": "408bf248-dd4e-4be5-919a-7f6207a307ab",
     "ttl": 8760,
   },
+  "metadata": {
+    "team": "engineering",
+    "environment": "development"
+  }
   ...
 }
 ```
@@ -591,11 +600,13 @@ Generate credentials associated with the named static role.
 ### Path parameters
 
 - `name` `(string: <required>)` – Name of the static role to get credentials for.
-- `metadata` (`map[string]any: {}`) - A map of string to key/value pairs that will be stored
+- `metadata` (`map[string]any: {}`) -  A map of string to string key/value pairs that will be stored
   as metadata for the mount. This can be used to store additional information about the
-  mount for reference purposes. The data provided here will displayed in the metadata field as part of the response.
-  When also setting the `metadata` parameter on `/azure/static-roles/:name`, the two maps will be merged, with
-  the values from `/azure/static-roles/:name` taking precedence in the event of key collisions.
+  mount for reference purposes. The data stored here is displayed in the response of
+  `/azure/static-roles/:name` and `/azure/static-creds/:name` in the `metadata` field.
+  When also setting the `metadata` parameter on `/azure/static-creds/:name`, the two
+  maps will be merged in the response of `/azure/static-creds/:name`, with the values from `/azure/static-roles/:name`
+  taking precedence in the event of key collisions.
 
 ### Sample request
 


### PR DESCRIPTION
Gives a more accurate description of the metadata field that's used in Azure static roles.