### PR TITLE
Vault docs: remove deprecated tutorial reference

### DIFF
--- a/content/vault/v1.16.x/content/docs/secrets/databases/db2.mdx
+++ b/content/vault/v1.16.x/content/docs/secrets/databases/db2.mdx
@@ -5,25 +5,16 @@ description: |-
   Manage credentials for IBM Db2 using Vault's LDAP secrets engine.
 ---
 
-# IBM db2
+# IBM Db2
 
-Access to Db2 is managed by facilities that reside outside the Db2 database system. By
-default, user authentication is completed by a security facility that relies on operating
-system based authentication of users and passwords. This means that the lifecycle of user
-identities in Db2 aren't capable of being managed using SQL statements and Vault's
-database secrets engine.
+External facilities outside the Db2 database system manage access to Db2. By default, a security facility authenticates users by relying on operating system-based authentication of users and passwords. This means you cannot manage the user identities lifecycle in Db2 using SQL statements with Vault's database secrets engine.
 
 To provide flexibility in accommodating authentication needs, Db2 ships with authentication
 [plugin modules](https://www.ibm.com/docs/en/db2/11.5?topic=ins-ldap-based-authentication-group-lookup-support)
 for Lightweight Directory Access Protocol (LDAP). This enables the Db2 database manager to
 authenticate users and obtain group membership defined in an LDAP directory, removing the
-requirement that users and groups be defined to the operating system.
+requirement to define users and groups in the operating system.
 
-Vault's [LDAP secrets engine](/vault/docs/secrets/ldap) can be used to manage the lifecycle
-of credentials for Db2 environments that have been configured to delegate user authentication
+You can use Vault's [LDAP secrets engine](/vault/docs/secrets/ldap) to manage the lifecycle
+of credentials for Db2 environments configured to delegate user authentication
 and group membership to an LDAP server.
-
-## Tutorial
-
-Refer to the [IBM Db2 Credential Management](/vault/tutorials/secrets-management/ibm-db2-openldap)
-tutorial to learn how to use Vault to manage both static and dynamic credentials for access to Db2.


### PR DESCRIPTION
- Remove the deprecated Db2 tutorial reference and link
- Update copy for grammar and passive voice