### PR TITLE
Fix scope example in Sentinel for loops [IPE-1316]

### DIFF
--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/loops.mdx
@@ -72,6 +72,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -89,5 +92,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/loops.mdx
@@ -72,6 +72,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -89,5 +92,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/loops.mdx
@@ -72,6 +72,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -89,5 +92,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/loops.mdx
@@ -72,6 +72,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -89,5 +92,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/loops.mdx
@@ -72,6 +72,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -89,5 +92,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/loops.mdx
@@ -71,6 +71,9 @@ The body of a `for` statement creates a new
 [scope](/sentinel/language/scope). If a variable is assigned within
 the body of a for statement that isn't assigned in a parent scope,
 that variable will only exist for the duration of the body execution.
+If the variable exists in the parent scope, assigning the variable a
+value in the body of a `for` statement updates it in the parent
+scope.
 
 Example:
 
@@ -88,5 +91,5 @@ for list as value {
 	a = 42
 }
 
-print(a) // 18
+print(a) // 42
 ```


### PR DESCRIPTION
Fix incorrect example of variable scope in loops for Sentinel, clarify the relation of variables through different scopes. Test behavior back to pre-0.10 versions of Sentinel for verification.

:mag: [Deploy preview](https://unified-docs-frontend-preview-afr5iyoie-hashicorp.vercel.app/sentinel/docs/language/loops#scoping)