### PR TITLE
Remove accidentally added self-enrollment references from the Enterprise Step-up MFA page

### DIFF
--- a/content/vault/v1.21.x (rc)/content/docs/enterprise/mfa/index.mdx
+++ b/content/vault/v1.21.x (rc)/content/docs/enterprise/mfa/index.mdx
@@ -20,7 +20,7 @@ MFA in Vault can be of the following types.
 - **Time-based One-time Password (TOTP)** - If configured and enabled on a path,
   this would require a TOTP passcode along with Vault token, to be presented
   while invoking the API request. The passcode will be validated against the
-  TOTP key present in the identity of the caller in Vault. TOTP supports [self-enrollment](#self-enroll-mfa-totp).
+  TOTP key present in the identity of the caller in Vault.
 
 - **Okta** - If Okta push is configured and enabled on a path, then the enrolled
   device of the user will get a push notification to approve or deny the access
@@ -42,19 +42,6 @@ MFA in Vault can be of the following types.
 MFA methods are globally managed within the `System Backend` using the HTTP API.
 Please see [MFA API](/vault/api-docs/system/mfa) for details on how to configure an MFA
 method.
-
-## Self-enroll MFA TOTP
-
-The TOTP method supports self-enrollment so users can generate their own QR codes without admin assistance.
-
-```text
-$ vault write sys/mfa/method/totp/my_self_enroll_totp \
-    issuer=Vault \
-    period=30 \
-    key_size=30 \
-    algorithm=SHA256 \
-    enable_self_enrollment=true
-```
 
 ## MFA methods in policies
 


### PR DESCRIPTION
In https://github.com/hashicorp/web-unified-docs/pull/1041, we've accidentally added self-enrollment content to the Enterprise Step-up MFA pages, which are a separate feature from Login MFA. This PR fixes that.