### PR TITLE
[ServiceNow] [Service ctalog] Update documentation for supported var types

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -13,7 +13,7 @@ using the information found in this document.
 ServiceNow has the concept of a Variable Set which is a collection of ServiceNow
 Variables that can be referenced in a Flow from a Service Catalog item. The
 Terraform Integration codebase can create [Terraform Variables and Terraform
-Environment Variables](/terraform/cloud-docs/workspaces/variables) via the API using the
+Environment Variables](/terraform/cloud-docs/variables) via the API using the
 `tf_variable.createVariablesFromSet()` function.
 
 This function looks for variables following these conventions:


### PR DESCRIPTION
Our app supports variables starting with `tf_var_hcl_` and `sensitive_tf_var_hcl_`, documentation needs to be updated to reflect this accordingly. 