### PR TITLE
Fix typo and duplicated bullet within SPIFFE api docs

### DIFF
--- a/content/vault/v1.21.x (rc)/content/api-docs/auth/spiffe.mdx
+++ b/content/vault/v1.21.x (rc)/content/api-docs/auth/spiffe.mdx
@@ -30,8 +30,6 @@ error and rolls back any configuration changes.
 
 - `trust_domain` `(string: <required>)` - The SPIFFE trust domain used by the
   plugin. You can omit the `spiffe://` prefix.
-- `profile` `(string: <required>)` - The profile to use to fetch the trust bundle, see profile section below
-for associated parameters based on the selected profile. Valid values are `static`,
 - `profile` `(string: <required>)` - Set the profile type and fetch mechanism
   for the profile used to fetch the trust bundle. Must be one of:
     - `https_spiffe_bundle` - fetch the trust bundle in JWKS format from a
@@ -40,7 +38,7 @@ for associated parameters based on the selected profile. Valid values are `stati
       endpoint.
     - `https_web_pem` - fetch a valid X.509 certificate as the trust bundle
       from an HTTPS endpoint.
-    - `static` - use the trust bundle explicilty configured in the profile
+    - `static` - use the trust bundle explicitly configured in the profile
       definition.
 - `audience` `(array: [])` - A list of allowed audience values for JWT based
   SVIDs. Vault rejects any JWT-based SVIDS not provided in the audience list.
@@ -151,8 +149,8 @@ Different roles may not have the same workload ID patterns. Vault uses standard
 to determine the appropriate role when there  are overlapping patterns across
 different roles (e.g. role1 has `team1/*` and role2 has `team1/service1`).
 
-| Method | Path                       |
-|:-------|:---------------------------|
+| Method | Path                      |
+|:-------|:--------------------------|
 | `POST` | `/auth/spiffe/role/:name` |
 
 ### Path parameters


### PR DESCRIPTION
Fix up a typo and the duplicated `profile` bullet within the SPIFFE 1.21.x API docs page.