### PR TITLE
Fixed typo in language/modules/configuration.

### DIFF
--- a/content/terraform/v1.13.x/docs/language/modules/configuration.mdx
+++ b/content/terraform/v1.13.x/docs/language/modules/configuration.mdx
@@ -66,7 +66,7 @@ Add the `depth` query parameter to the `source` URL and specify how many commits
 
 The following module sources support shallow clones:
 
-- [GitHub repositoris](/terraform/language/block/module#github-repository)
+- [GitHub repositories](/terraform/language/block/module#github-repository)
 - [Git repositories](/terraform/language/block/module#git-repository)
 - [BitBucket repositories](/terraform/language/block/module#bitbucket-repository)
 


### PR DESCRIPTION
GitHub repositoris > GitHub repositories.