### PR TITLE
Update restricted-endpoints.mdx

### DIFF
--- a/content/vault/v1.20.x/content/partials/api/restricted-endpoints.mdx
+++ b/content/vault/v1.20.x/content/partials/api/restricted-endpoints.mdx
@@ -54,7 +54,7 @@ API path                                    | Root | Admin
 `sys/sealwrap/rewrap`                       | YES  | NO
 `sys/step-down`                             | YES  | NO
 `sys/storage`                               | YES  | NO
-`sys/sync/config                            | YES  | YES
+`sys/sync/config`                           | YES  | YES
 `sys/unseal`                                | YES  | NO
 
 Privileged CLI commands without public API endpoints:


### PR DESCRIPTION
A small format fix for the restricted-endpoints.mdx endpoint, missing "`" breaks the formats of the table