### PR TITLE
Update all references for key-pair root rotation availability in snowflake

### DIFF
--- a/content/vault/v1.16.x/content/api-docs/secret/databases/snowflake.mdx
+++ b/content/vault/v1.16.x/content/api-docs/secret/databases/snowflake.mdx
@@ -12,16 +12,7 @@ description: >-
 
   [Snowflake is disabling password authentication for all users](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification) in
   November of 2025. HashiCorp has added support for key pair authentication in
-  place of passwords.
-
-  Vault currently does not support rotate root for key pairs. To manually rotate
-  key pairs, users can:
-
-  - update the root configuration in Vault with the new private key
-  - update the public key associated with the user in Snowflake
-
-  For more information on rotating key pairs, please refer to the official
-  [Snowflake documentation](https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-rotation).
+  place of passwords, including root-rotation.
 
 </Warning>
 

--- a/content/vault/v1.16.x/content/docs/secrets/databases/snowflake.mdx
+++ b/content/vault/v1.16.x/content/docs/secrets/databases/snowflake.mdx
@@ -12,7 +12,7 @@ description: |-
 <Warning title="Password authentication removal">
     Snowflake is disabling password authentication for all users in&nbsp;
     <a href="https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification">November of 2025.</a>
-    &nbsp;HashiCorp has added support for key pair authentication in place of passwords.
+    &nbsp;HashiCorp has added support for key pair authentication in place of passwords, including root-rotation.
 </Warning>
 
 Snowflake is one of the supported plugins for the database secrets engine. This plugin

--- a/content/vault/v1.16.x/content/partials/deprecation/snowflake-password-auth.mdx
+++ b/content/vault/v1.16.x/content/partials/deprecation/snowflake-password-auth.mdx
@@ -2,8 +2,8 @@
 
 | Announced | Expected end of support | Expected removal |
 | :-------: | :---------------------: | :--------------: |
-| APR 2025  | NOV 2025                | N/A
+| APR 2025  | NOV 2025                | NOV 2025			|
 
 Snowflake is disabling password authentication for all users in [November of 2025](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification).
-HashiCorp is working to support key pair authentication in place of passwords
-for this database secrets engine.
+HashiCorp has added support for key pair authentication in
+place of passwords, including root-rotation.

--- a/content/vault/v1.19.x/content/api-docs/secret/databases/snowflake.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/databases/snowflake.mdx
@@ -12,16 +12,7 @@ description: >-
 
   [Snowflake is disabling password authentication for all users](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification) in
   November of 2025. HashiCorp has added support for key pair authentication in
-  place of passwords.
-
-  Vault currently does not support rotate root for key pairs. To manually rotate
-  key pairs, users can:
-
-  - update the root configuration in Vault with the new private key
-  - update the public key associated with the user in Snowflake
-
-  For more information on rotating key pairs, please refer to the official
-  [Snowflake documentation](https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-rotation).
+  place of passwords, including root-rotation.
 
 </Warning>
 

--- a/content/vault/v1.19.x/content/docs/secrets/databases/index.mdx
+++ b/content/vault/v1.19.x/content/docs/secrets/databases/index.mdx
@@ -218,7 +218,7 @@ and private key pair to authenticate.
 | [Redis](/vault/docs/secrets/databases/redis)                        | No         | Yes                      | Yes           | Yes          | No                     | password                     |
 | [Redis ElastiCache](/vault/docs/secrets/databases/rediselasticache) | No         | No                       | No            | Yes          | No                     | password                     |
 | [Redshift](/vault/docs/secrets/databases/redshift)                  | No         | Yes                      | Yes           | Yes          | Yes (1.8+)             | password                     |
-| [Snowflake](/vault/docs/secrets/databases/snowflake)                | No         | Password-only            | Yes           | Yes          | Yes (1.8+)             | password(deprecated), rsa_private_key    |
+| [Snowflake](/vault/docs/secrets/databases/snowflake)                | No         | Yes                      | Yes           | Yes          | Yes (1.8+)             | password(deprecated), rsa_private_key    |
 
 ## Custom plugins
 

--- a/content/vault/v1.19.x/content/docs/secrets/databases/snowflake.mdx
+++ b/content/vault/v1.19.x/content/docs/secrets/databases/snowflake.mdx
@@ -12,7 +12,7 @@ description: >-
 <Warning title="Password authentication removal">
     Snowflake is disabling password authentication for all users in&nbsp;
     <a href="https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification">November of 2025.</a>
-    &nbsp;HashiCorp has added support for key pair authentication in place of passwords.
+    &nbsp;HashiCorp has added support for key pair authentication in place of passwords, including root-rotation.
 </Warning>
 
 Snowflake is one of the supported plugins for the database secrets engine. This plugin

--- a/content/vault/v1.19.x/content/partials/deprecation/snowflake-password-auth.mdx
+++ b/content/vault/v1.19.x/content/partials/deprecation/snowflake-password-auth.mdx
@@ -2,8 +2,8 @@
 
 | Announced | Expected end of support | Expected removal |
 | :-------: | :---------------------: | :--------------: |
-| APR 2025  | NOV 2025                | N/A
+| APR 2025  | NOV 2025                | NOV 2025			|
 
 Snowflake is disabling password authentication for all users in [November of 2025](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification).
-HashiCorp is working to support key pair authentication in place of passwords
-for this database secrets engine.
+HashiCorp has added support for key pair authentication in
+place of passwords, including root-rotation.

--- a/content/vault/v1.20.x/content/api-docs/secret/databases/snowflake.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/databases/snowflake.mdx
@@ -12,16 +12,7 @@ description: >-
 
   [Snowflake is disabling password authentication for all users](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification) in
   November of 2025. HashiCorp has added support for key pair authentication in
-  place of passwords.
-
-  Vault currently does not support rotate root for key pairs. To manually rotate
-  key pairs, users can:
-
-  - update the root configuration in Vault with the new private key
-  - update the public key associated with the user in Snowflake
-
-  For more information on rotating key pairs, please refer to the official
-  [Snowflake documentation](https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-rotation).
+  place of passwords, including root-rotation.
 
 </Warning>
 

--- a/content/vault/v1.20.x/content/docs/secrets/databases/index.mdx
+++ b/content/vault/v1.20.x/content/docs/secrets/databases/index.mdx
@@ -304,7 +304,7 @@ and private key pair to authenticate.
 | [Redis](/vault/docs/secrets/databases/redis)                        | No         | Yes                      | Yes           | Yes          | No                     | password                     |
 | [Redis ElastiCache](/vault/docs/secrets/databases/rediselasticache) | No         | No                       | No            | Yes          | No                     | password                     |
 | [Redshift](/vault/docs/secrets/databases/redshift)                  | No         | Yes                      | Yes           | Yes          | Yes (1.8+)             | password                     |
-| [Snowflake](/vault/docs/secrets/databases/snowflake)                | No         | Password-only            | Yes           | Yes          | Yes (1.8+)             | password(deprecated), rsa_private_key    |
+| [Snowflake](/vault/docs/secrets/databases/snowflake)                | No         | Yes                      | Yes           | Yes          | Yes (1.8+)             | password(deprecated), rsa_private_key    |
 
 ## Custom plugins
 

--- a/content/vault/v1.20.x/content/docs/secrets/databases/snowflake.mdx
+++ b/content/vault/v1.20.x/content/docs/secrets/databases/snowflake.mdx
@@ -12,7 +12,7 @@ description: >-
 <Warning title="Password authentication removal">
     Snowflake is disabling password authentication for all users in&nbsp;
     <a href="https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification">November of 2025.</a>
-    &nbsp;HashiCorp has added support for key pair authentication in place of passwords.
+    &nbsp;HashiCorp has added support for key pair authentication in place of passwords, including root-rotation.
 </Warning>
 
 Snowflake is one of the supported plugins for the database secrets engine. This plugin

--- a/content/vault/v1.20.x/content/partials/deprecation/snowflake-password-auth.mdx
+++ b/content/vault/v1.20.x/content/partials/deprecation/snowflake-password-auth.mdx
@@ -2,8 +2,8 @@
 
 | Announced | Expected end of support | Expected removal |
 | :-------: | :---------------------: | :--------------: |
-| APR 2025  | NOV 2025                | N/A
+| APR 2025  | NOV 2025                | NOV 2025			|
 
 Snowflake is disabling password authentication for all users in [November of 2025](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification).
-HashiCorp is working to support key pair authentication in place of passwords
-for this database secrets engine.
+HashiCorp has added support for key pair authentication in
+place of passwords, including root-rotation.

--- a/content/vault/v1.21.x (rc)/content/api-docs/secret/databases/snowflake.mdx
+++ b/content/vault/v1.21.x (rc)/content/api-docs/secret/databases/snowflake.mdx
@@ -12,16 +12,7 @@ description: >-
 
   [Snowflake is disabling password authentication for all users](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification) in
   November of 2025. HashiCorp has added support for key pair authentication in
-  place of passwords.
-
-  Vault currently does not support rotate root for key pairs. To manually rotate
-  key pairs, users can:
-
-  - update the root configuration in Vault with the new private key
-  - update the public key associated with the user in Snowflake
-
-  For more information on rotating key pairs, please refer to the official
-  [Snowflake documentation](https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-rotation).
+  place of passwords, including root-rotation.
 
 </Warning>
 

--- a/content/vault/v1.21.x (rc)/content/docs/secrets/databases/index.mdx
+++ b/content/vault/v1.21.x (rc)/content/docs/secrets/databases/index.mdx
@@ -304,7 +304,7 @@ and private key pair to authenticate.
 | [Redis](/vault/docs/secrets/databases/redis)                        | No         | Yes                      | Yes           | Yes          | No                     | password                     |
 | [Redis ElastiCache](/vault/docs/secrets/databases/rediselasticache) | No         | No                       | No            | Yes          | No                     | password                     |
 | [Redshift](/vault/docs/secrets/databases/redshift)                  | No         | Yes                      | Yes           | Yes          | Yes (1.8+)             | password                     |
-| [Snowflake](/vault/docs/secrets/databases/snowflake)                | No         | Password-only            | Yes           | Yes          | Yes (1.8+)             | password(deprecated), rsa_private_key    |
+| [Snowflake](/vault/docs/secrets/databases/snowflake)                | No         | Yes                      | Yes           | Yes          | Yes (1.8+)             | password(deprecated), rsa_private_key    |
 
 ## Custom plugins
 

--- a/content/vault/v1.21.x (rc)/content/docs/secrets/databases/snowflake.mdx
+++ b/content/vault/v1.21.x (rc)/content/docs/secrets/databases/snowflake.mdx
@@ -12,7 +12,7 @@ description: >-
 <Warning title="Password authentication removal">
     Snowflake is disabling password authentication for all users in&nbsp;
     <a href="https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification">November of 2025.</a>
-    &nbsp;HashiCorp has added support for key pair authentication in place of passwords.
+    &nbsp;HashiCorp has added support for key pair authentication in place of passwords, including root-rotation.
 </Warning>
 
 Snowflake is one of the supported plugins for the database secrets engine. This plugin

--- a/content/vault/v1.21.x (rc)/content/partials/deprecation/snowflake-password-auth.mdx
+++ b/content/vault/v1.21.x (rc)/content/partials/deprecation/snowflake-password-auth.mdx
@@ -2,8 +2,8 @@
 
 | Announced | Expected end of support | Expected removal |
 | :-------: | :---------------------: | :--------------: |
-| APR 2025  | NOV 2025                | N/A
+| APR 2025  | NOV 2025                | NOV 2025			|
 
 Snowflake is disabling password authentication for all users in [November of 2025](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification).
-HashiCorp is working to support key pair authentication in place of passwords
-for this database secrets engine.
+HashiCorp has added support for key pair authentication in
+place of passwords, including root-rotation.


### PR DESCRIPTION
Updates references in the Vault docs to reflect root-rotation support in Snowflake DB secrets when using key-pair auth configs.