### PR TITLE
New version pinning for OPA

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
@@ -181,7 +181,7 @@ For OPA and Sentinel policy sets using agents, we recommend choosing a specific 
 
 <Note>
 
-HCP Terraform no longer supports the `latest` tag for OPA policy sets. By default, OPA policy sets using the `latest` tag are pinned to v0.61.x. To upgrade to a newer OPA runtime version, specify a version in your policy set settings.
+HCP Terraform and Terraform Enterprise no longer supports the `latest` tag for OPA policy sets. By default, OPA policy sets using the `latest` tag are pinned to the most recently supported version. To upgrade to a newer OPA runtime version, specify a version in your policy set settings.
 
 </Note>
 


### PR DESCRIPTION
Jira ticket: https://hashicorp.atlassian.net/browse/IPE-1326?atlOrigin=eyJpIjoiY2QxNTE5ZDIxODA5NGY0ODk0ZmMwZTE1YzNhNWRhODUiLCJwIjoiaiJ9

I also cleaned up a few little things:
1. The previous "Tip" should have been a note since it's related to a feature not working for specific versions. 
2. There was a link to a `tfe` provider resource that said it was `(Sentinel only)`, but it's not anymore. It supports both OPA and sentinel.
3. Telling people that we recommend they specify a runtime version for Sentinel or OPA.
4. Adding the specific callout about how we no longer support `latest`, and `latest` for OPA policies is now tied down to v0.61.x.