### PR TITLE
Stacks: fix broken link

### DIFF
--- a/content/terraform/v1.13.x/docs/language/stacks/design.mdx
+++ b/content/terraform/v1.13.x/docs/language/stacks/design.mdx
@@ -64,4 +64,4 @@ Additionally, using meta-arguments like `for_each` in your configuration can hel
 
 ## Next steps
 
-After planning out your Stack, learn how to make your design a reality by [defining a component configuration](/terraform/language/stack/components/config).
+After planning out your Stack, learn how to make your design a reality by [defining a component configuration](/terraform/language/stacks/component/config).


### PR DESCRIPTION
The current link to Next Steps in "Design a Stack" gives a 404. The correct link should be:

https://developer.hashicorp.com/terraform/language/stacks/component/config

which is "Define configuration", the first page in what is now a "Create a Stack" section.

Please go to the `Preview` tab and select the appropriate template:

* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
