### PR TITLE
Update CODEOWNERS for HCP Vault

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,29 +27,27 @@
 
 /content/terraform-enterprise @hashicorp/team-docs-packer-and-terraform @hashicorp/ptfe-review
 
-
 # Vault documentation ownership
-
 /content/vault/                                    @hashicorp/vault-education-approvers
 
 # Sentinel documentation ownership
 /content/sentinel/ @hashicorp/team-docs-packer-and-terraform @hashicorp/tf-compliance
 
 # Well-architected framework
-
 /content/well-architected-framework/ @hashicorp/well-architected-education-approvers
 
-
 # HCP-docs documentation ownership
+/content/hcp-docs/* @hashicorp/education
+
 # HCP Consul Docs
 /content/hcp-docs/content/docs/consul/* @hashicorp/consul-docs
 
-# HCP Vault & HCP Vault Secrets docs
-/content/hcp-docs/content/docs/vault/*          @hashicorp/vault-education-approvers
-/content/hcp-docs/content/docs/vault-secrets/*  @hashicorp/vault-education-approvers
+# HCP Vault & HCP Vault Radar docs
+/content/hcp-docs/content/docs/vault* @hashicorp/vault-education-approvers
+/content/hcp-docs/content/partials/vault* @hashicorp/vault-education-approvers
 
 # HCP Boundary docs
-/content/hcp-docs/content/docs/boundary/*       @hashicorp/boundary-education-approvers
+/content/hcp-docs/content/docs/boundary/* @hashicorp/boundary-education-approvers
 
 #HCP IAM
 /content/hcp-docs/content/partials/hcp-administration/* @hashicorp/cloud-access-control @hashicorp/cloud-identity


### PR DESCRIPTION
Update CODEOWNERS to make vault-education-approvers default for HCP Vault* docs and partials
