### PR TITLE
Fix typos in documentation for data sources

### DIFF
--- a/content/terraform/v1.13.x/docs/language/data-sources/index.mdx
+++ b/content/terraform/v1.13.x/docs/language/data-sources/index.mdx
@@ -68,7 +68,7 @@ data "aws_ami" "example" {
 }
 ```
 
-The `data` block instructs Terraform to read from the `aws_ami` data source and export the result to an object named `example`. To reference the returned data, use the `data.<TYPE>.<LABEL>.<ATTRIBUTE>` syntax, for example, `data.aws_ami.example.id`. Refer to [Reference queried data](#referenece-queried-data) for more information.
+The `data` block instructs Terraform to read from the `aws_ami` data source and export the result to an object named `example`. To reference the returned data, use the `data.<TYPE>.<LABEL>.<ATTRIBUTE>` syntax, for example, `data.aws_ami.example.id`. Refer to [Reference queried data](#reference-queried-data) for more information.
 
 ## Configure query constraints
 
@@ -113,7 +113,7 @@ data "aws_ami" "example" {
 }
 ```
 
-Custom conditions return useful information about errors earlier and in context so that you can more easily diagnose configuration issues. They also help future maintainers understand the configuration design and intent. Refer to [Custom Condition Checks](/terraform/language/expressions/custom-conditions#preconditions-and-postconditions) for more details.
+Custom conditions return useful information about errors earlier and in context so that you can more easily diagnose configuration issues. They also help future maintainers understand the configuration design and intent. Refer to [Custom Condition Checks](/terraform/language/expressions/conditionals#conditions) for more details.
 
 ### Multiple instances
 


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
