### PR TITLE
Fix tiny typo in “Design a Stack” page

### DIFF
--- a/content/terraform/v1.13.x/docs/language/stacks/design.mdx
+++ b/content/terraform/v1.13.x/docs/language/stacks/design.mdx
@@ -27,7 +27,7 @@ Before writing your component configuration, we recommend assessing your current
 
 Each Stack should represent a single system or application with a shared lifecycle. Start by analyzing your current infrastructure and identifying the components HCP Terraform should manage together. Components are typically groups of related resources, such as an application’s backend, frontend, or database layer, deployed and scaled together.
 
-We recommend structuring your Stacks along technical boundaries to keep them modular and manageable. For example, you can create a dedicated Stack for shared services, such as networking infrastructure for VPCs, subnets, or routing tables, and separate Stacks for application components that consume those shared services. This separation lets you to manage shared services independently while passing information between Stacks. For more details, refer to [Pass data from one Stack to another](/terraform/language/stacks/deploy/pass-data).
+We recommend structuring your Stacks along technical boundaries to keep them modular and manageable. For example, you can create a dedicated Stack for shared services, such as networking infrastructure for VPCs, subnets, or routing tables, and separate Stacks for application components that consume those shared services. This separation lets you manage shared services independently while passing information between Stacks. For more details, refer to [Pass data from one Stack to another](/terraform/language/stacks/deploy/pass-data).
 
 ### Sketch out your configuration
 


### PR DESCRIPTION
## Description

A very very tiny typo.

### Requested review scope:

- [x] Content touched by the PR _only_ (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

### Review urgency:

- [ ] ASAP (bug fixes, broken content, imminent releases)
- [ ] 3 days (small changes, easy reviews)
- [ ] 1 week (default)
- [x] Best effort (very non-urgent)

## All updates:

I have:

- [ ] Verified that all status checks have passed
- [ ] Verified that preview environment has successfully deployed
- [x] Verified appropriate `label` applied (`hcp` + `product name`)
- [x] Added all required reviewers (code owners and external)