### PR TITLE
Fix transit key types in docs

### DIFF
--- a/content/vault/v1.20.x/content/docs/secrets/transit/index.mdx
+++ b/content/vault/v1.20.x/content/docs/secrets/transit/index.mdx
@@ -93,6 +93,7 @@ types also generate separate HMAC keys):
 - `aes256-cmac`: CMAC with a 256-bit AES key; supporting CMAC generation and verification. <EnterpriseAlert inline="true" />
 - `ml-dsa` - ML-DSA; supports signing and signature verification (experimental) <EnterpriseAlert inline="true" />
 - `hybrid` - combination of two signature algorithms; supports signing and signature verification (experimental) <EnterpriseAlert inline="true" />
+- `slh-dsa` - SLH-DSA (asymmetric) (experimental) <EnterpriseAlert inline="true" />
 
 ~> **Note**: In FIPS 140-3 mode, the following algorithms are not certified
 and thus should not be used: `chacha20-poly1305` and `ed25519`.

--- a/content/vault/v1.21.x/content/api-docs/secret/transit.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/transit.mdx
@@ -71,8 +71,8 @@ values set here cannot be changed after key creation.
   - `ml-dsa` - ML-DSA (asymmetric) (experimental) <EnterpriseAlert inline="true" />
   - `hybrid` - hybrid signatures combining a post-quantum algorithm and an elliptic curve algorithm (asymmetric) (experimental) <EnterpriseAlert inline="true" />
    - `slh-dsa` - SLH-DSA (asymmetric) (experimental) <EnterpriseAlert inline="true" />
-  - `aes128-cbc` - AES-128 in CBC mode (symmetric, supports derivation and convergent encryption)
-  - `aes256-cbc` - AES-256 in CBC mode (symmetric, supports derivation and convergent encryption)
+  - `aes128-cbc` - AES-128 in CBC mode (symmetric, supports derivation and convergent encryption) <EnterpriseAlert inline="true" />
+  - `aes256-cbc` - AES-256 in CBC mode (symmetric, supports derivation and convergent encryption) <EnterpriseAlert inline="true" />
 
   ~> **Note**: In FIPS 140-3 mode, the following algorithms are not certified
      and thus should not be used: `chacha20-poly1305`.

--- a/content/vault/v1.21.x/content/docs/secrets/transit/index.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/transit/index.mdx
@@ -93,6 +93,9 @@ types also generate separate HMAC keys):
 - `aes256-cmac`: CMAC with a 256-bit AES key; supporting CMAC generation and verification. <EnterpriseAlert inline="true" />
 - `ml-dsa` - ML-DSA; supports signing and signature verification (experimental) <EnterpriseAlert inline="true" />
 - `hybrid` - combination of two signature algorithms; supports signing and signature verification (experimental) <EnterpriseAlert inline="true" />
+- `slh-dsa` - SLH-DSA (asymmetric) (experimental) <EnterpriseAlert inline="true" />
+- `aes128-cbc` - AES-128 in CBC mode (symmetric, supports derivation and convergent encryption) <EnterpriseAlert inline="true" />
+- `aes256-cbc` - AES-256 in CBC mode (symmetric, supports derivation and convergent encryption) <EnterpriseAlert inline="true" />
 
 ~> **Note**: In FIPS 140-3 mode, the following algorithms are not certified
 and thus should not be used: `chacha20-poly1305` and `ed25519`.


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
