### PR TITLE
Readability changes for VSO CSI Helm docs

### DIFF
--- a/content/vault/v1.21.x/content/docs/deploy/kubernetes/vso/helm.mdx
+++ b/content/vault/v1.21.x/content/docs/deploy/kubernetes/vso/helm.mdx
@@ -762,6 +762,8 @@ Use these links to navigate to a particular top-level stanza.
 
 ### csi ((#h-csi))
 
+<EnterpriseAlert inline="true" />
+
 - `csi` ((#v-csi))
 
   - `enabled` ((#v-csi-enabled)) (`boolean: false`) - Only supports Vault Enterprise servers.


### PR DESCRIPTION
@schavis gave feedback on our Helm chart doc changes in https://github.com/hashicorp/vault-secrets-operator/pull/1120 , on the VSO repo, which I addressed and we merged there, but we forgot to generate the actual website docs off of them afterward, so that's what this PR is.

This is mostly important to get in so that the next PR with generated Helm docs from VSO doesn't have a bunch of these unrelated VSO CSI driver changes.