### PR TITLE
[Vault] Add the 'Ent' badge

### DIFF
--- a/content/vault/v1.19.x/data/docs-nav-data.json
+++ b/content/vault/v1.19.x/data/docs-nav-data.json
@@ -326,6 +326,11 @@
 
   {
     "title": "License Vault",
+    "badge": {
+      "text": "ENT",
+      "type": "filled",
+      "color": "neutral"
+    },
     "routes": [
       {
         "title": "Overview",

--- a/content/vault/v1.20.x/data/docs-nav-data.json
+++ b/content/vault/v1.20.x/data/docs-nav-data.json
@@ -353,6 +353,11 @@
 
   {
     "title": "License Vault",
+    "badge": {
+      "text": "ENT",
+      "type": "filled",
+      "color": "neutral"
+    },
     "routes": [
       {
         "title": "Overview",

--- a/content/vault/v1.21.x/data/docs-nav-data.json
+++ b/content/vault/v1.21.x/data/docs-nav-data.json
@@ -353,6 +353,11 @@
 
   {
     "title": "License Vault",
+    "badge": {
+      "text": "ENT",
+      "type": "filled",
+      "color": "neutral"
+    },
     "routes": [
       {
         "title": "Overview",


### PR DESCRIPTION
## Description

🔍 [Deploy preview](https://unified-docs-frontend-preview-hak1p14af-hashicorp.vercel.app/vault/docs)

This PR adds the `ENT` badge to the enterprise license doc side-nav.

<img width="1092" height="568" alt="image" src="https://github.com/user-attachments/assets/3b020466-40ca-4abe-a2c7-b5df6844fcf8" />

The license doc used to be under  the "[Vault Enterprise](https://developer.hashicorp.com/vault/docs/enterprise)" section of the side-nav. Now that it has moved up to the top, we should have the `ENT` badget to make it more eye-catchy. 

### Requested review scope:

- [x] Content touched by the PR _only_ (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

### Review urgency:

- [ ] ASAP (bug fixes, broken content, imminent releases)
- [x] 3 days (small changes, easy reviews)
- [ ] 1 week (default)
- [ ] Best effort (very non-urgent)

<!-- Fill out only the appropriate checklist for your type of feature (or both if necessary) and delete the other one! -->

## All updates:

<!-- This section is mandatory for all PRs: -->

I have:

- [x] Verified that all status checks have passed
- [x] Verified that preview environment has successfully deployed
- [x] Verified appropriate `label` applied (`hcp` + `product name`)
- [x] Added all required reviewers (code owners and external)

