### PR TITLE
Fix typo in Stacks API documentation

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/stacks/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/stacks/index.mdx
@@ -47,7 +47,7 @@ The scope of the API includes the following endpoints:
 | Method   | Path                                              | Action                                                                                                     |
 |----------|-------------------------------------------------- |------------------------------------------------------------------------------------------------------------|
 | `POST`   | `/stacks`                                         | Call this endpoint to [create a Stack](#create-a-stack).                                                   |
-| `GET`    | `/organizations/:organization_name/ss`        | Call this endpoint to [list Stacks](#list-stacks).                                                         |
+| `GET`    | `/organizations/:organization_name/stacks`        | Call this endpoint to [list Stacks](#list-stacks).                                                         |
 | `GET`    | `/stacks/:stack_id`                               | Call this endpoint to [show a Stack](#show-a-stack).                                                       |
 | `GET`    | `/stacks/:stack_id/stack-configuration-summaries` | Call this endpoint to [list Stack configuration summaries](#list-stack-configuration-summaries).           |
 | `PATCH`  | `/stacks/:stack_id`                               | Call this endpoint to [update a Stack](#update-a-stack).                                                   |


### PR DESCRIPTION
## Description

:ticket: [TF-30954](https://hashicorp.atlassian.net/browse/TF-30954)

This PR fixes a typo in the Stacks API documentation.

### Requested review scope:

- [x] Content touched by the PR _only_ (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

### Review urgency:

- [ ] ASAP (bug fixes, broken content, imminent releases)
- [x] 3 days (small changes, easy reviews)
- [ ] 1 week (default)
- [ ] Best effort (very non-urgent)

## All updates:

I have:

- [x] Verified that all status checks have passed
- [x] Verified that preview environment has successfully deployed
- [x] Verified appropriate `label` applied (`hcp` + `product name`)
- [x] Added all required reviewers (code owners and external)


[TF-30954]: https://hashicorp.atlassian.net/browse/TF-30954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ