### PR TITLE
Document new environment variable in SAML auth plugin

### DIFF
--- a/content/vault/v1.20.x/content/docs/auth/saml/index.mdx
+++ b/content/vault/v1.20.x/content/docs/auth/saml/index.mdx
@@ -65,8 +65,11 @@ Auth methods must be configured in advance before users or machines can
 authenticate. These steps are usually completed by an operator or configuration
 management tool.
 
-1. To prevent users from configuring the `idp_metadata_url`, `idp_sso_url`, or `acs_urls` fields with URLs that resolve to an internal IP address (such as `localhost`), 
-Vault cluster administrators should set the `VAULT_SAML_DENY_INTERNAL_URLS` environment variable on the plugin process to `true` when registering the plugin.
+1. When you register the `saml` plugin, we recommend setting the
+   `VAULT_SAML_DENY_INTERNAL_URLS` environment variable on the plugin process to
+   `true`. Otherwise, users can configure the `idp_metadata_url`, `idp_sso_url`,
+   and `acs_urls` fields with URLs that resolve to internal IP addresses such as
+   `localhost`.
 
    ```shell-session
    $ vault plugin register                     \


### PR DESCRIPTION
This change documents a new environment variable being added to the SAML auth plugin, which will be included in the next monthly Vault release.

The [PR](https://github.com/hashicorp/vault-plugin-auth-saml/pull/60) that added the variable contains more background information. Since running the plugin with this environment variable set is a security recommendation, I put it as the first step.