### PR TITLE
Fix TFE_REDIS_USE_MTLS header level in configuration reference in 1.0.x

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/reference/configuration.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/reference/configuration.mdx
@@ -314,7 +314,7 @@ Must be `true` or `false`. `true` indicates Redis server is configured to use `T
 
 Must be `true` or `false`. `true` indicates to use TLS to access Redis. Defaults to `false`.
 
-## `TFE_REDIS_USE_MTLS`
+### `TFE_REDIS_USE_MTLS`
 
 Must be `true` or `false`. `true` indicates to use mutual TLS (mTLS) authentication for clients to access Redis with Redis standalone or Sentinel. Defaults to `false`. 
 


### PR DESCRIPTION
Fix heading size mismatch for 1.0.x, I think the content was copied before #605 was merged.