### PR TITLE
Update sentinel override docs

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
@@ -60,11 +60,15 @@ You can set an enforcement level for each policy that determines what happens wh
 
 ### Sentinel
 
-Sentinel provides three policy enforcement levels:
+You can enable one of the following options to set the enforcement level when creating a Sentinel policy:
 
-- **advisory:** Failed policies never interrupt the run. They provide information about policy check failures in the UI.
-- **soft mandatory:** Failed policies stop the run, but any user with [Manage Policy Overrides permission](/terraform/cloud-docs/users-teams-organizations/permissions/organization#manage-policy-overrides) can override these failures and allow the run to complete.
-- **hard mandatory:** Failed policies stop the run. Terraform does not apply runs with failed **hard mandatory** policies until a user fixes the issue that caused the failure.
+- **Advisory:** Failed policies never interrupt the run. They provide information about policy check failures in the UI.
+- **Soft mandatory:** Failed policies stop the run, but any user with [Manage Policy Overrides permission](/terraform/cloud-docs/users-teams-organizations/permissions/organization#manage-policy-overrides) can override these failures and allow the run to complete.
+- **Hard mandatory:** Failed policies stop the run. Unless the set containing the policy is configured to [allow overrides](#allow-policy-level-overrides), Terraform does not apply runs until a user fixes the issue that caused the failure. 
+
+#### Allow policy level overrides
+
+When adding policies to a policy set, you can enable the **This policy set can be overridden in the event of mandatory failures** option. Enabling this option lets users with the appropriate permissions, such as admins or team owners, override any failed policy checks in that set, even policies set to **Hard mandatory**. This override setting takes precedence over the individual policy’s enforcement level.
 
 ### OPA
 

--- a/content/terraform-enterprise/1.0.x/docs/enterprise/policy-enforcement/manage-policy-sets/index.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/policy-enforcement/manage-policy-sets/index.mdx
@@ -55,17 +55,19 @@ Policy evaluations **cannot** access cost estimation data, so use policy checks 
 
 ## Policy enforcement levels
 
-You can set an enforcement level for each policy that determines what happens when a Terraform plan does not pass the policy rule. Sentinel and OPA policies have different enforcement levels available.
+You can set an enforcement level for each policy. Enforcement levels determine what happens when a Terraform plan does not pass the policy rule. Sentinel and OPA policies have different enforcement levels available.
 
 ### Sentinel
 
-Sentinel provides three policy enforcement levels:
+You can enable one of the following options to set the enforcement level when creating a Sentinel policy:
 
--   **advisory:** Failed policies never interrupt the run. They provide information about policy check failures in the UI.
--   **soft mandatory:** Failed policies stop the run, but any user with [Manage Policy Overrides permission](/terraform/enterprise/users-teams-organizations/permissions#manage-policy-overrides) can override these failures and allow the run to complete.
--   **hard mandatory:** Failed policies stop the run. Terraform does not apply runs with failed **hard mandatory** policies until a user fixes the issue that caused the failure.
+- **Advisory:** Failed policies never interrupt the run. They provide information about policy check failures in the UI.
+- **Soft mandatory:** Failed policies stop the run, but any user with [Manage Policy Overrides permission](/terraform/enterprise/users-teams-organizations/permissions#manage-policy-overrides) can override these failures and allow the run to complete.
+- **Hard mandatory:** Failed policies stop the run. Unless the set containing the policy is configured to [allow overrides](#allow-policy-level-overrides), Terraform does not apply runs until a user fixes the issue that caused the failure. 
 
-~> **Tip:** If the policy set option “This policy set can be overridden in the event of mandatory failures” is enabled, users with the appropriate permissions (such as admins or team owners) can override any failed policy checks in that set, including those marked as `hard-mandatory`. This override setting takes precedence over the individual policy’s enforcement level.
+#### Allow policy level overrides
+
+When adding policies to a policy set, you can enable the **This policy set can be overridden in the event of mandatory failures** option. Enabling this option lets users with the appropriate permissions, such as admins or team owners, override any failed policy checks in that set, even policies set to **Hard mandatory**. This override setting takes precedence over the individual policy’s enforcement level.
 
 ### OPA
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/policy-enforcement/manage-policy-sets/index.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/policy-enforcement/manage-policy-sets/index.mdx
@@ -59,11 +59,15 @@ You can set an enforcement level for each policy that determines what happens wh
 
 ### Sentinel
 
-Sentinel provides three policy enforcement levels:
+You can enable one of the following options to set the enforcement level when creating a Sentinel policy:
 
--   **advisory:** Failed policies never interrupt the run. They provide information about policy check failures in the UI.
--   **soft mandatory:** Failed policies stop the run, but any user with [Manage Policy Overrides permission](/terraform/enterprise/users-teams-organizations/permissions#manage-policy-overrides) can override these failures and allow the run to complete.
--   **hard mandatory:** Failed policies stop the run. Terraform does not apply runs with failed **hard mandatory** policies until a user fixes the issue that caused the failure.
+- **Advisory:** Failed policies never interrupt the run. They provide information about policy check failures in the UI.
+- **Soft mandatory:** Failed policies stop the run, but any user with [Manage Policy Overrides permission](/terraform/enterprise/users-teams-organizations/permissions#manage-policy-overrides) can override these failures and allow the run to complete.
+- **Hard mandatory:** Failed policies stop the run. Unless the set containing the policy is configured to [allow overrides](#allow-policy-level-overrides), Terraform does not apply runs until a user fixes the issue that caused the failure. 
+
+#### Allow policy level overrides
+
+When adding policies to a policy set, you can enable the **This policy set can be overridden in the event of mandatory failures** option. Enabling this option lets users with the appropriate permissions, such as admins or team owners, override any failed policy checks in that set, even policies set to **Hard mandatory**. This override setting takes precedence over the individual policy’s enforcement level.
 
 ### OPA
 


### PR DESCRIPTION
### PR Description

This small doc update adds a note to clarify why some mandatory Sentinel policies can still be overridden in Terraform Enterprise.

We had a few customer tickets where users were confused about why “hard mandatory” policies could still be overridden. The behaviour is expected, when the policy set has “This policy set can be overridden in the event of mandatory failures” enabled, users with the right permissions (like admins or team owners) can override both soft- and hard-mandatory policy failures.

This doc change makes that clearer to help prevent future confusion.

**What’s Changed**

- Added a short clarification about when and why overrides can still occur.

**Why**

- To address customer feedback and help users better understand how enforcement levels actually behave in practice.
