### PR TITLE
Add hcp img dirs to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,12 +37,12 @@
 /content/well-architected-framework/ @hashicorp/well-architected-education-approvers
 
 # HCP-docs documentation ownership
-/content/hcp-docs/* @hashicorp/education
-/content/hcp-docs/img/docs/hcp-core/* @hashicorp/vault-education-approvers
+/content/hcp-docs/ @hashicorp/education
+/content/hcp-docs/img/docs/hcp-core/ @hashicorp/vault-education-approvers
 
 # HCP Consul Docs
-/content/hcp-docs/content/docs/consul/* @hashicorp/consul-docs
-/content/hcp-docs/img/docs/consul/* @hashicorp/consul-docs
+/content/hcp-docs/content/docs/consul/ @hashicorp/consul-docs
+/content/hcp-docs/img/docs/consul/ @hashicorp/consul-docs
 
 # HCP Vault & HCP Vault Radar docs
 /content/hcp-docs/content/docs/vault* @hashicorp/vault-education-approvers
@@ -50,13 +50,13 @@
 /content/hcp-docs/img/docs/vault* @hashicorp/vault-education-approvers
 
 # HCP Boundary docs
-/content/hcp-docs/content/docs/boundary/* @hashicorp/boundary-education-approvers
-/content/hcp-docs/img/docs/boundary/* @hashicorp/boundary-education-approvers
+/content/hcp-docs/content/docs/boundary/ @hashicorp/boundary-education-approvers
+/content/hcp-docs/img/docs/boundary/ @hashicorp/boundary-education-approvers
 
 #HCP IAM
-/content/hcp-docs/content/partials/hcp-administration/* @hashicorp/cloud-access-control @hashicorp/cloud-identity
-/content/hcp-docs/content/docs/hcp/iam/* @hashicorp/cloud-access-control @hashicorp/cloud-identity
-/content/hcp-docs/content/img/docs/hcp-core/* @hashicorp/cloud-access-control @hashicorp/cloud-identity
+/content/hcp-docs/content/partials/hcp-administration/ @hashicorp/cloud-access-control @hashicorp/cloud-identity
+/content/hcp-docs/content/docs/hcp/iam/ @hashicorp/cloud-access-control @hashicorp/cloud-identity
+/content/hcp-docs/content/img/docs/hcp-core/ @hashicorp/cloud-access-control @hashicorp/cloud-identity
 
 # Boundary
-/content/boundary/* @hashicorp/boundary-education-approvers @hashicorp/boundary
+/content/boundary/ @hashicorp/boundary-education-approvers @hashicorp/boundary


### PR DESCRIPTION
Adds the img directory and associated codewoner for each HCP service.

Because of the shared directory structure for HCP docs, and corresponding code owners for each, images were causing web-devdot to be added as a code owner.