### PR TITLE
docs: Clarify Client Agent support

### DIFF
--- a/content/boundary/v0.20.x/content/docs/client-agent/index.mdx
+++ b/content/boundary/v0.20.x/content/docs/client-agent/index.mdx
@@ -21,6 +21,14 @@ You must enable both IPv4 and IPv6 protocols for your environment to ensure the 
 
 </Note>
 
+Currently HashiCorp tests the Client Agent on the following operating systems:
+
+- macOS 14
+- macOS 15
+- Windows 11
+
+Refer to the [Transparent sessions interoperability matrix](/boundary/docs/interoperability-matrix) for a list of third-party products that have been tested and confirmed to work with the Client Agent to provide transparent sessions.
+
 ## Security
 
 When you successfully authorize a session on a Boundary controller, the response includes a list of any brokered credentials, which include the decoded secrets.

--- a/content/boundary/v0.20.x/content/docs/deploy/self-managed/install-clients.mdx
+++ b/content/boundary/v0.20.x/content/docs/deploy/self-managed/install-clients.mdx
@@ -27,7 +27,11 @@ The Boundary installer bundles together the following components:
 - Boundary Desktop Client app
 - Boundary Client Agent <sup>HCP/ENT</sup>
 
-Download the appropriate Boundary installer for your Windows, MacOS, or Linux environment from the [Install Boundary](/boundary/install#installer) downloads page or the [releases](https://releases.hashicorp.com/boundary-installer) page. You can also download the components individually, but compatibility is not guaranteed. Refer to the [Supported versions policy](/boundary/docs/enterprise/supported-versions#control-plane-and-client-cli-compatibility) to learn more.
+Download the appropriate Boundary installer for your Windows, MacOS, or Linux environment from the [Install Boundary](/boundary/install#installer) downloads page or the [releases](https://releases.hashicorp.com/boundary-installer) page.
+
+You can also download the components individually, but compatibility is not guaranteed. Refer to the [Supported versions policy](/boundary/docs/enterprise/supported-versions#control-plane-and-client-cli-compatibility) to learn more.
+
+Refer to the [Transparent sessions interoperability matrix](/boundary/docs/interoperability-matrix) for a list of third-party products that have been tested and confirmed to work with the Boundary Client Agent to provide transparent sessions.
 
 <Warning>
 
@@ -47,11 +51,9 @@ We recommend the following components for end users:
 
 Download these components for your Windows, MacOS, or Linux environment from the [Install Boundary](/boundary/install) downloads page or the [HashiCorp releases](https://releases.hashicorp.com/) page.
 
-<Warning>
-
 Client compatibility is not guaranteed. You should always ensure that your client is compatible with the version of the Boundary control plane you connect to. Refer to the [Supported versions policy](/boundary/docs/enterprise/supported-versions#control-plane-and-client-cli-compatibility) to learn more.
 
-</Warning>
+Refer to the [Transparent sessions interoperability matrix](/boundary/docs/interoperability-matrix) for a list of third-party products that have been tested and confirmed to work with the Boundary Client Agent to provide transparent sessions.
 
 To learn more about installing the Boundary CLI and Boundary Desktop Client app, refer to the [Get started with self-managed Boundary](/boundary/tutorials/get-started-community) tutorials.
 

--- a/content/boundary/v0.20.x/content/docs/interoperability-matrix/index.mdx
+++ b/content/boundary/v0.20.x/content/docs/interoperability-matrix/index.mdx
@@ -13,6 +13,12 @@ Transparent sessions require you to use the Boundary installer to install the Bo
 To support a variety of use cases, HashiCorp verifies implementation and integrations with partner products and applications.
 
 HashiCorp engineering has tested and confirmed that you can use the following third-party products with the specific versions of the Boundary installer, Boundary Client Agent, and any operating systems listed in the table.
+Currently HashiCorp tests the Client Agent on the following operating systems:
+
+- macOS 14
+- macOS 15
+- Windows 11
+
 Transparent sessions may operate with other versions of the products listed below or with other products, but they have not been tested.
 We will update the list of products as we test them.
 
@@ -54,7 +60,7 @@ Any patches or updates will be reflected in the minor number.
     <td style={{verticalAlign: 'middle'}}>
     <b>MacOS</b>: 14.6, 15.3
     <br />
-    <b>Windows</b>: 10 Pro, 11 Pro
+    <b>Windows</b>: 11 Pro
     </td>
     <td style={{verticalAlign: 'middle'}}>
     Refer to <a href="/boundary/docs/client-agent/conflicting-software#cloudflare-warp-client">Conflicting software</a>
@@ -78,7 +84,7 @@ Any patches or updates will be reflected in the minor number.
     <td style={{verticalAlign: 'middle'}}>
     <b>MacOS</b>: 14.6, 15.3
     <br />
-    <b>Windows</b>: 10 Pro, 11 Pro
+    <b>Windows</b>: 11 Pro
     </td>
     <td style={{verticalAlign: 'middle'}}>
     Refer to <a href="/boundary/docs/client-agent/conflicting-software#huntress-edr-client-windows">Conflicting software</a>
@@ -98,7 +104,7 @@ Any patches or updates will be reflected in the minor number.
     <td style={{verticalAlign: 'middle'}}>
     <b>MacOS</b>: 14, 15
     <br />
-    <b>Windows</b>: 10, 11 Pro
+    <b>Windows</b>: 11 Pro
     </td>
     <td style={{verticalAlign: 'middle'}}>
     &nbsp;
@@ -118,7 +124,7 @@ Any patches or updates will be reflected in the minor number.
     <td style={{verticalAlign: 'middle'}}>
     <b>MacOS</b>: 14, 15
     <br />
-    <b>Windows</b>: 10, 11
+    <b>Windows</b>: 11
     </td>
     <td style={{verticalAlign: 'middle'}}>
     &nbsp;
@@ -138,7 +144,7 @@ Any patches or updates will be reflected in the minor number.
     <td style={{verticalAlign: 'middle'}}>
     <b>MacOS</b>: 14, 15.2
     <br />
-    <b>Windows</b>: 10, 11
+    <b>Windows</b>: 11
     </td>
     <td style={{verticalAlign: 'middle'}}>
     &nbsp;


### PR DESCRIPTION
Per [ICU-17986](https://hashicorp.atlassian.net/browse/ICU-17986), we need to remove mentions of Windows 10 from the interoperability matrix. Also, we do not state which operating systems we test the Client Agent on, so this PR adds that to the Client Agent page and adds a link out from the Install Clients page.

View the updates in the preview deployment:

- [Transparent sessions interoperability matrix](https://unified-docs-frontend-preview-g7pk8f450-hashicorp.vercel.app/boundary/docs/interoperability-matrix)
- [Boundary Client Agent](https://unified-docs-frontend-preview-g7pk8f450-hashicorp.vercel.app/boundary/docs/client-agent)
- [Install Boundary clients](https://unified-docs-frontend-preview-g7pk8f450-hashicorp.vercel.app/boundary/docs/deploy/self-managed/install-clients)


[ICU-17986]: https://hashicorp.atlassian.net/browse/ICU-17986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ