### PR TITLE
docs: remove extra column for tfcomponent variable arguments

### DIFF
--- a/content/terraform/v1.13.x/docs/language/block/stack/tfcomponent/variable.mdx
+++ b/content/terraform/v1.13.x/docs/language/block/stack/tfcomponent/variable.mdx
@@ -59,7 +59,7 @@ The `variable` block supports the following arguments:
 | `description` | A description of the variable's purpose and the value it expects. | String | Optional |
 | `sensitive` | Specifies if Terraform hides this value in UI and logs. | Boolean | Optional |
 | `nullable` | Specifies if the value of a variable can be `null`. | Boolean | Optional |
-| `ephemeral` | Specifies whether Terraform excludes this value from plans and state. | Boolean | Boolean | Optional |
+| `ephemeral` | Specifies whether Terraform excludes this value from plans and state. | Boolean | Optional |
 
 ### `type`
 


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
