### PR TITLE
adds redirs for older data and removed block paths

### DIFF
--- a/content/terraform-docs-common/redirects.jsonc
+++ b/content/terraform-docs-common/redirects.jsonc
@@ -649,6 +649,18 @@
     "destination": "/terraform/language/v:version/block/moved",
     "permanent": true
   },
+    // redir for /data block older than 1.11
+  {    
+    "source": "/terraform/language/v:version(1\\.(?:[1-9]|1[01])\\.x)/block/data",
+    "destination": "/terraform/language/v:version/data-sources",
+    "permanent": true
+  },
+    // redir for /removed block older than 1.11
+  {    
+    "source": "/terraform/language/v:version(1\\.(?:[1-9]|1[01])\\.x)/block/removed",
+    "destination": "/terraform/language/v:version/resources/syntax#removing-resources",
+    "permanent": true
+  },
   // Terraform migrate docs moved to their own docs set
   {
     "source": "/terraform/cloud-docs/migrate/tf-migrate",


### PR DESCRIPTION
This PR adds a redirect for the data block page in Terrafrom when you use the switcher to view an older version of the page. The page did not exist until 1.12, so we are redirecting to the /data-sources page. This is PR recreates https://github.com/hashicorp/web-unified-docs/pull/1205, which became bloated with unrelated commits