### PR TITLE
add redir for import block older than 1.11

### DIFF
--- a/content/terraform-docs-common/redirects.jsonc
+++ b/content/terraform-docs-common/redirects.jsonc
@@ -661,6 +661,12 @@
     "destination": "/terraform/language/v:version/resources/syntax#removing-resources",
     "permanent": true
   },
+    // redir for /import block older than 1.11
+  {    
+    "source": "/terraform/language/v:version(1\\.(?:[1-9]|1[01])\\.x)/block/import",
+    "destination": "/terraform/language/v:version/import  ",
+    "permanent": true
+  },
   // Terraform migrate docs moved to their own docs set
   {
     "source": "/terraform/cloud-docs/migrate/tf-migrate",


### PR DESCRIPTION
This PR adds a redirect for  pre-import block URLs. To verify, go to /terrform/language/block/import, then choose 1.11 or older from the version switcher. 
