### PR TITLE
RADAR-6950: Fix scopes for Bitbucket Cloud API token

### DIFF
--- a/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/bitbucket.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/bitbucket.mdx
@@ -26,7 +26,7 @@ Server](#add-bitbucket-server).
 - Token creator email address
 - [API token with the right set of scopes](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
     - read:account
-    - read:name
+    - read:me
     - read:project:bitbucket
     - read:pullrequest:bitbucket
     - read:repository:bitbucket


### PR DESCRIPTION
## Description

https://hashicorp.atlassian.net/browse/RADAR-6950

This is a follow up of #1192 to fix the API token scopes for Bitbucket Cloud - update `read:name` scope to `read:me`

### Requested review scope:

- [x] Content touched by the PR _only_ (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

### Review urgency:

- [x] ASAP (bug fixes, broken content, imminent releases)
- [ ] 3 days (small changes, easy reviews)
- [ ] 1 week (default)
- [ ] Best effort (very non-urgent)

## All updates:

I have:

- [x] Verified that all status checks have passed
- [ ] Verified that preview environment has successfully deployed
- [x] Verified appropriate `label` applied (`hcp` + `product name`)
- [x] Added all required reviewers (code owners and external)

## Content checklist (optional)

Please do these things before requesting a review. I have:

- [ ] Made any associated code repositories public
- [ ] Added the `hashicorp-education/teamName` to any additional code or example repos as repo admin
- [ ] Added redirects for any moved or removed pages
- [ ] Spell checked the tutorial(s)
- [ ] Followed the [unified style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] Linted code snippets (Details per language [here](https://github.com/hashicorp/engineering-docs/blob/master/writing/markdown.md#code-blocks))
- [ ] Checked the steps for completeness (no steps are implied or hidden)
- [ ] Looked at the local or vercel build and checked each new or changed page for:
  - display on the product curriculum page
  - callout box formatting
  - code block highlighting
  - right-hand navigation
  - next and back buttons
  - URL path
