### PR TITLE
[Boundary] Fix the hyperlink in Release Notes

### DIFF
--- a/content/boundary/v0.20.x/content/docs/release-notes/v0_20_0.mdx
+++ b/content/boundary/v0.20.x/content/docs/release-notes/v0_20_0.mdx
@@ -132,7 +132,7 @@ description: >-
     Boundary now supports IBM Key Protect for key management.
     <br /><br />You can configure IBM Key Protect as the KMS to manage encryption keys for various functions.
     <br /><br />
-    Learn more:&nbsp;<a href="/boundary/docs/secure/encryption/data-encryption">Data encryption in Boundary</a> and <a href="/boundary/docs/configuration/kms/ibmkp">ibmkms KMS</a>.
+    Learn more:&nbsp;<a href="/boundary/docs/secure/encryption/data-encryption">Data encryption in Boundary</a> and <a href="/boundary/docs/configuration/kms/ibmkp">ibmkp KMS</a>.
     </td>
   </tr>
 


### PR DESCRIPTION
This PR fixes the broken link in the release notes. 

<img width="978" height="210" alt="image" src="https://github.com/user-attachments/assets/7933ac56-2c4d-48fb-a79f-167fba767f8d" />

The URL has extra 's' in it.