### PR TITLE
Adjust signup language

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/users.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/users.mdx
@@ -33,7 +33,7 @@ Use the [Account API](/terraform/cloud-docs/api-docs/account) to get account det
 
 We recommend using a [HashiCorp Cloud Platform (HCP)](https://portal.cloud.hashicorp.com/sign-up) account to log in to HCP Terraform. Your HCP Account grants access to every HashiCorp product and the Terraform Registry. If you use an HCP Account, you manage account settings like multi-factor authentication and password resets from within HCP instead of the HCP Terraform UI.
 
-To log in with your HCP account, navigate to [HCP Terraform](https://app.terraform.io/) and click **Continue with HCP account**. HCP Terraform may ask if you want to link your account.
+To log in with your HCP account, navigate to [HCP Terraform](https://app.terraform.io/) and login with your HCP credentials.
 
 ### Linking HCP and HCP Terraform accounts
 


### PR DESCRIPTION
https://hashicorp.atlassian.net/jira/software/c/projects/TF/boards/8847?selectedIssue=TF-24643 

And additional context form Andre: "we removed the **Continue with HCP account**, but if your email address is associated with a HCP account, or is not associated to any account at all, we automatically redirect you to HCP login. And the **Create HCP account** is still available in the sign-up UI."