### PR TITLE
Stacks: Remove self-referential links

### DIFF
--- a/content/terraform/v1.13.x/docs/language/stacks/deploy/pass-data.mdx
+++ b/content/terraform/v1.13.x/docs/language/stacks/deploy/pass-data.mdx
@@ -20,8 +20,8 @@ To consume the data exported by the upstream Stack, declare an `upstream_input` 
 Downstream Stacks must reside in the same project as their upstream Stacks.
 
 The following limitations apply to passing data between Stacks:
-- Stacks can link to up to 20 other upstream Stacks. [Learn more about passing data between Stacks](/terraform/language/stacks/deploy/pass-data).
-- Stacks can expose values to up to 25 downstream Stacks. [Learn more about passing data between Stacks](/terraform/language/stacks/deploy/pass-data).
+- Stacks can link to up to 20 other upstream Stacks.
+- Stacks can expose values to up to 25 downstream Stacks.
 
 ## Expose outputs to another Stack
 


### PR DESCRIPTION
These links are unnecessary now because they refer to the same page they're on.

Please go to the `Preview` tab and select the appropriate template:

* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
