### PR TITLE
Add example for manual force revoke lease by lease_id

### DIFF
--- a/content/vault/v1.21.x/content/docs/commands/lease/revoke.mdx
+++ b/content/vault/v1.21.x/content/docs/commands/lease/revoke.mdx
@@ -27,6 +27,15 @@ $ vault lease revoke -prefix database/creds
 Success! Revoked any leases with prefix: database/creds
 ```
 
+Force revoke an irrevocable lease which starts with a prefix plus lease ID:
+
+```shell-session
+$ vault lease revoke -force -prefix database/creds/test-role/9Y5YA7vmRs2uESbSOInm0BpC
+Warning! Force-removing leases can cause Vault to become out of sync with
+secret engines!
+Success! Force revoked any leases with prefix: database/creds/test-role/9Y5YA7vmRs2uESbSOInm0BpC```
+```
+
 ## Usage
 
 The following flags are available in addition to the [standard set of


### PR DESCRIPTION
I found it is supported to force revoke an irrevocable Vault lease by providing lease id.

