### PR TITLE
added missing on_failure arg to resource > provisioners docs

### DIFF
--- a/content/terraform/v1.12.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.12.x/docs/language/block/resource.mdx
@@ -739,6 +739,29 @@ You cannot add a `scripts` argument in the same provisioner with `inline` or `sc
 - Data type: List.
 - Default: None.
 
+### `on_failure`
+
+Specifies an action for Terraform to take when a provisioner fails. 
+
+```hcl
+resource {
+  # ...
+  provisioner "<TYPE>" {
+    on_failure =  fail
+  }
+}
+```
+
+You can specify one of the following values in `on_failure` argument:
+
+- `continue`: Terraform ignores the error and continues the creation or destruction operation.
+- `fail`: Raise an error and stops applying the configuration. Terraform taints the resource when this value is set for a creation provisioner. This is the default.
+
+#### Summary
+
+- Data type: Directive
+- Default: `fail`
+
 ## Examples
 
 The following examples show how to write configuration for common use cases.

--- a/content/terraform/v1.13.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.13.x/docs/language/block/resource.mdx
@@ -745,6 +745,29 @@ You cannot add a `scripts` argument in the same provisioner with `inline` or `sc
 - Data type: List.
 - Default: None.
 
+### `on_failure`
+
+Specifies an action for Terraform to take when a provisioner fails. 
+
+```hcl
+resource {
+  # ...
+  provisioner "<TYPE>" {
+    on_failure =  fail
+  }
+}
+```
+
+You can specify one of the following values in `on_failure` argument:
+
+- `continue`: Terraform ignores the error and continues the creation or destruction operation.
+- `fail`: Raise an error and stops applying the configuration. Terraform taints the resource when this value is set for a creation provisioner. This is the default.
+
+#### Summary
+
+- Data type: Directive
+- Default: `fail`
+
 ## Examples
 
 The following examples show how to write configuration for common use cases.

--- a/content/terraform/v1.14.x (rc)/docs/language/block/resource.mdx
+++ b/content/terraform/v1.14.x (rc)/docs/language/block/resource.mdx
@@ -777,6 +777,29 @@ You cannot add a `scripts` argument in the same provisioner with `inline` or `sc
 - Data type: List.
 - Default: None.
 
+### `on_failure`
+
+Specifies an action for Terraform to take when a provisioner fails. 
+
+```hcl
+resource {
+  # ...
+  provisioner "<TYPE>" {
+    on_failure =  fail
+  }
+}
+```
+
+You can specify one of the following values in `on_failure` argument:
+
+- `continue`: Terraform ignores the error and continues the creation or destruction operation.
+- `fail`: Raise an error and stops applying the configuration. Terraform taints the resource when this value is set for a creation provisioner. This is the default.
+
+#### Summary
+
+- Data type: Directive
+- Default: `fail`
+
 ## Examples
 
 The following examples show how to write configuration for common use cases.


### PR DESCRIPTION
This PR re-adds the `on_failure` argument that we accidentally excluded during the reference restructure. It addresses issue [1231](https://github.com/hashicorp/web-unified-docs/issues/1231).