### PR TITLE
docs: Update PostgreSQL support policy

### DIFF
--- a/content/boundary/v0.20.x/content/docs/enterprise/supported-versions.mdx
+++ b/content/boundary/v0.20.x/content/docs/enterprise/supported-versions.mdx
@@ -58,5 +58,5 @@ To view the Desktop version along with the corresponding CLI and control plane v
 
 ## PostgreSQL support policy
 
-Boundary Enterprise supports PostgreSQL versions 14 and above.
+Boundary Enterprise supports PostgreSQL versions 15 and above.
 On an ongoing basis, Boundary will end support for a PostgreSQL version one (1) year prior to its EOL as documented on PostgreSQL’s versioning policy website.


### PR DESCRIPTION
Per [SPE-1347](https://hashicorp.atlassian.net/browse/SPE-1347) and a [Slack conversation](https://ibm-hashicorp.slack.com/archives/C09L3DN152Q/p1759938049242559). The minimum supported version of PostgreSQL will increment to 15 on November 12. This PR updates the Boundary Enterprise supported versions policy.

[View the preview deployment](https://unified-docs-frontend-preview-l25007cv4-hashicorp.vercel.app/boundary/docs/enterprise/supported-versions#postgresql-support-policy)

**Do not merge until November 12**


[SPE-1347]: https://hashicorp.atlassian.net/browse/SPE-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ