### PR TITLE
Add Docker network and extra hosts configuration

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/docker/index.mdx
@@ -181,6 +181,8 @@ services:
       TFE_TLS_KEY_FILE: "/etc/ssl/private/terraform-enterprise/key.pem"
       TFE_TLS_CA_BUNDLE_FILE: "/etc/ssl/private/terraform-enterprise/bundle.pem"
       TFE_IACT_SUBNETS: "<IACT subnet, eg. 10.0.0.0/8,192.168.0.0/24>"
+      TFE_RUN_PIPELINE_DOCKER_NETWORK: "terraform-enterprise_default"
+      TFE_RUN_PIPELINE_DOCKER_EXTRA_HOSTS: "<TFE hostname (DNS) e.g. terraform.example.com>:host-gateway"
     cap_add:
       - IPC_LOCK
     read_only: true
@@ -230,6 +232,8 @@ services:
       TFE_TLS_KEY_FILE: "/etc/ssl/private/terraform-enterprise/key.pem"
       TFE_TLS_CA_BUNDLE_FILE: "/etc/ssl/private/terraform-enterprise/bundle.pem"
       TFE_IACT_SUBNETS: "<IACT subnet, eg. 10.0.0.0/8,192.168.0.0/24>"
+      TFE_RUN_PIPELINE_DOCKER_NETWORK: "terraform-enterprise_default"
+      TFE_RUN_PIPELINE_DOCKER_EXTRA_HOSTS: "<TFE hostname (DNS) e.g. terraform.example.com>:host-gateway"
 
       # Database settings. See the configuration reference for more settings.
       TFE_DATABASE_USER: "<Database user e.g. postgres>"
@@ -290,6 +294,8 @@ services:
       TFE_TLS_KEY_FILE: "/etc/ssl/private/terraform-enterprise/key.pem"
       TFE_TLS_CA_BUNDLE_FILE: "/etc/ssl/private/terraform-enterprise/bundle.pem"
       TFE_IACT_SUBNETS: "<IACT subnet, eg. 10.0.0.0/8,192.168.0.0/24>"
+      TFE_RUN_PIPELINE_DOCKER_NETWORK: "terraform-enterprise_default"
+      TFE_RUN_PIPELINE_DOCKER_EXTRA_HOSTS: "<TFE hostname (DNS) e.g. terraform.example.com>:host-gateway"
 
       # Database settings. See the configuration reference for more settings.
       TFE_DATABASE_USER: "<Database user e.g. postgres>"


### PR DESCRIPTION
These configurations worked for standing up TFE, however when a Run was created and an agent container spawned, it was not created in the same Docker Network as Terraform Enterprise.

These changes were confirmed to work for Disk and External mode (I did not test for Active-Active).

Please go to the `Preview` tab and select the appropriate template:

* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
