### PR TITLE
framework: Fix link in 1.16.x documentation for core language list documentation 

### DIFF
--- a/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/list-resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/list-resources/index.mdx
@@ -14,7 +14,7 @@ List support is in technical preview and offered without compatibility promises 
 
 </Highlight>
 
-[List resources](/terraform/language/v1.14.x/resources/list) are an abstraction that allows Terraform to search for a specific resource type within a given scope, for example listing all EC2 instances within an AWS account or all virtual networks within a resource group. Taking a list configuration as input, remote objects are retrieved and returned to Terraform as list result data which is displayed to the user.
+[List resources](/terraform/language/v1.14.x/block/tfquery/list) are an abstraction that allows Terraform to search for a specific resource type within a given scope, for example listing all EC2 instances within an AWS account or all virtual networks within a resource group. Taking a list configuration as input, remote objects are retrieved and returned to Terraform as list result data which is displayed to the user.
 
 Searching is invoked directly with the Terraform CLI via the `terraform query` command with list blocks authored in a `.tfquery.hcl` file.
 


### PR DESCRIPTION
> There wasn't an appropriate template for `terraform-plugin-framework` 😆 , so I just went with HCP services.

## Description

No JIRA ticket for this. This just fixes a link in existing docs that was probably refactored prior to our upcoming 1.14.0 GA release of Terraform

### Requested review scope:

- [x] Content touched by the PR _only_ (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

### Review urgency:

- [ ] ASAP (bug fixes, broken content, imminent releases)
- [x] 3 days (small changes, easy reviews)
- [ ] 1 week (default)
- [ ] Best effort (very non-urgent)

<!-- Fill out only the appropriate checklist for your type of feature (or both if necessary) and delete the other one! -->

## All updates:

<!-- This section is mandatory for all PRs: -->

I have:

- [x] Verified that all status checks have passed
- [x] Verified that preview environment has successfully deployed
- [x] Verified appropriate `label` applied (`hcp` + `product name`)
- [x] Added all required reviewers (code owners and external)

## Content checklist (optional)

Please do these things before requesting a review. I have:

- [ ] Made any associated code repositories public
- [ ] Added the `hashicorp-education/teamName` to any additional code or example repos as repo admin
- [ ] Added redirects for any moved or removed pages
- [ ] Spell checked the tutorial(s)
- [ ] Followed the [unified style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] Linted code snippets (Details per language [here](https://github.com/hashicorp/engineering-docs/blob/master/writing/markdown.md#code-blocks))
- [ ] Checked the steps for completeness (no steps are implied or hidden)
- [ ] Looked at the local or vercel build and checked each new or changed page for:
  - display on the product curriculum page
  - callout box formatting
  - code block highlighting
  - right-hand navigation
  - next and back buttons
  - URL path
