### PR TITLE
Revert release highlights for database support and IAM

### DIFF
--- a/content/terraform-enterprise/1.1.x/docs/enterprise/releases/1.1.x/index.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/releases/1.1.x/index.mdx
@@ -72,7 +72,8 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 ## Highlights
 1. PostgreSQL 17, Google Cloud AlloyDB 16, and EnterpriseDB Postgres Advanced Server 16 and 17 databases are now officially supported.
 1. You can now use AWS Identity and Access Management (IAM) to authenticate to Amazon RDS for PostgreSQL.
-1. PostgreSQL 17, Google Cloud AlloyDB 16, and EnterpriseDB Postgres Advanced Server 16 and 17 databases are now officially supported.
+1. You can now use Google Default Credentials to authenticate to Cloud SQL.
+1. You can now use AWS Identity and Access Management (IAM) to authenticate to Redis instance.
 1. You can now use the Terraform Enterprise [Admin Console](/terraform/enterprise/deploy/configuration/admin-console) and API to manage support bundles, product usage bundles, and retrieve node information.
 
 ## Features


### PR DESCRIPTION
This PR reverts the release notes highlights which were removed [inadvertently](https://github.com/hashicorp/web-unified-docs/pull/1291/commits/1084c0e0b510670d2523daf0c244f7f39ad7d0ee).
There is also a duplicate entry which is removed.

My guess is that it happened due to GitHub [comment](https://github.com/hashicorp/web-unified-docs/pull/1291#discussion_r2522766879) commit feature 🤔 

