### PR TITLE
copyright headers fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 name: Documentation Issue
 description: |-
   HashiCorp Product Documentation Issue

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 # Apply a product label based on the product selected in the issue template's
 # product list.
 #


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

Adding missing copyright headers

https://github.com/hashicorp/web-unified-docs/actions/runs/19451150940/job/55655988414

* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad&title=Nomad+Docs&template=nomad_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
