### PR TITLE
Terraform 1.15: Update provisioner section following PowerShell update

### DIFF
--- a/content/terraform/v1.15.x (alpha)/docs/language/block/resource.mdx
+++ b/content/terraform/v1.15.x (alpha)/docs/language/block/resource.mdx
@@ -392,7 +392,7 @@ We recommend using configuration management tools or other means to perform acti
 
 <Warning>
 
-Terraform makes no attempts to sanitize the code being executed (in either `local-exec` or `remote-exec` provisioners) or any interpolated inputs within the code. You are responsible for ensuring the code is safe to execute on the given machine and for preventing e.g. command injection triggered by untrusted input.
+Terraform makes no attempts to sanitize the code being executed (in either `local-exec` or `remote-exec` provisioners) or any interpolated inputs within the code. You are responsible for ensuring the code is safe to execute on the given machine and for preventing vulnerabilities, for e.g. command injection triggered by untrusted input.
 
 </Warning>
 


### PR DESCRIPTION
This is a follow-up documentation update related to https://github.com/hashicorp/terraform/pull/37794 where we (re)introduced PowerShell support to SSH based provisioners (file & remote-exec).
