### PR TITLE
Clarify binding options and remove mention of deny_null_bind

### DIFF
--- a/content/vault/v1.16.x/content/docs/auth/ldap.mdx
+++ b/content/vault/v1.16.x/content/docs/auth/ldap.mdx
@@ -111,7 +111,7 @@ management tool.
 ### Binding parameters
 
 The LDAP auth method supports the following methods for resolving the user object used to authenticate the end user:
-- **Search** - Searches the LDAP server directory for the user object based on the provided username. This search can performed in one of two ways:
+- **Search** - Searches the LDAP server directory for the user object based on the provided username. Vault can search in two ways:
     - Authenticated search - The bind user must be set using `binddn` and `bindpass`
     - Anonymous search - `discoverdn` must be set to `true`
 - **User Principal Name (UPN)** - UPN is a method of specifying users supported

--- a/content/vault/v1.19.x/content/docs/auth/ldap.mdx
+++ b/content/vault/v1.19.x/content/docs/auth/ldap.mdx
@@ -111,7 +111,7 @@ management tool.
 ### Binding parameters
 
 The LDAP auth method supports the following methods for resolving the user object used to authenticate the end user:
-- **Search** - Searches the LDAP server directory for the user object based on the provided username. This search can performed in one of two ways:
+- **Search** - Searches the LDAP server directory for the user object based on the provided username. Vault can search in two ways:
     - Authenticated search - The bind user must be set using `binddn` and `bindpass`
     - Anonymous search - `discoverdn` must be set to `true`
 - **User Principal Name (UPN)** - UPN is a method of specifying users supported

--- a/content/vault/v1.20.x/content/docs/auth/ldap.mdx
+++ b/content/vault/v1.20.x/content/docs/auth/ldap.mdx
@@ -113,7 +113,7 @@ management tool.
 ### Binding parameters
 
 The LDAP auth method supports the following methods for resolving the user object used to authenticate the end user:
-- **Search** - Searches the LDAP server directory for the user object based on the provided username. This search can performed in one of two ways:
+- **Search** - Searches the LDAP server directory for the user object based on the provided username. Vault can search in two ways:
     - Authenticated search - The bind user must be set using `binddn` and `bindpass`
     - Anonymous search - `discoverdn` must be set to `true`
 - **User Principal Name (UPN)** - UPN is a method of specifying users supported

--- a/content/vault/v1.21.x/content/docs/auth/ldap.mdx
+++ b/content/vault/v1.21.x/content/docs/auth/ldap.mdx
@@ -113,7 +113,7 @@ management tool.
 ### Binding parameters
 
 The LDAP auth method supports the following methods for resolving the user object used to authenticate the end user:
-- **Search** - Searches the LDAP server directory for the user object based on the provided username. This search can performed in one of two ways:
+- **Search** - Searches the LDAP server directory for the user object based on the provided username. Vault can search in two ways:
     - Authenticated search - The bind user must be set using `binddn` and `bindpass`
     - Anonymous search - `discoverdn` must be set to `true`
 - **User Principal Name (UPN)** - UPN is a method of specifying users supported


### PR DESCRIPTION
The LDAP auth method docs were erroneously stating anonymous search required the `deny_null_bind` parameter to be set to false. This PR removes mention of this parameter and clarifies the options for resolving the DN of the login user.

* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad&title=Nomad+Docs&template=nomad_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
