### PR TITLE
feat: add packer codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -69,3 +69,6 @@
 
 # Nomad
 /content/nomad/ @hashicorp/nomad-docs @hashicorp/nomad-eng 
+
+# Packer
+/content/packer @hashicorp/team-docs-packer-and-terraform @hashicorp/packer


### PR DESCRIPTION
### Description

Adds teams for packer docs code owners


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211675868365936