### PR TITLE
Nomad Docs: NMD-955 port from nomad/release-1.11.x to nomad/1.11.1

### DIFF
--- a/content/nomad/v1.11.x/content/docs/other-specifications/acl-policy.mdx
+++ b/content/nomad/v1.11.x/content/docs/other-specifications/acl-policy.mdx
@@ -117,6 +117,7 @@ The `policy` field for namespace rules can have one of the following values:
 - `write`: allow the resource to be read and modified
 - `deny`: do not allow the resource to be read or modified. Deny takes
   precedence when multiple policies are associated with a token.
+- `scale`: allow the resource to be scaled by the nomad-autoscaler
 
 In addition to the coarse-grained `policy`, you can provide a fine-grained list
 of `capabilities`. This includes:
@@ -171,7 +172,7 @@ The coarse-grained policy permissions are shorthand for these fine-grained names
 | `deny`  | deny                                                                                                                                                                                                                                                                                                      |
 | `read`  | list-jobs<br />parse-job<br />read-job<br />csi-list-volume<br />csi-read-volume<br />host-volume-read<br />list-scaling-policies<br />read-scaling-policy<br />read-job-scaling                                                                                                                                                |
 | `write` | list-jobs<br />parse-job<br />read-job<br />submit-job<br />dispatch-job<br />read-logs<br />read-fs<br />alloc-exec<br />alloc-lifecycle<br />csi-write-volume<br />csi-mount-volume<br />host-volume-write<br />list-scaling-policies<br />read-scaling-policy<br />read-job-scaling<br />scale-job<br />submit-recommendation |
-| `scale` | list-scaling-policies<br />read-scaling-policy<br />read-job-scaling<br />scale-job                                                                                                                                                                                                                       |
+| `scale` | list-scaling-policies<br />read-scaling-policy<br />read-job-scaling<br />scale-job<br />read-job<br />submit-recommendation                                                                                                                                                                                                                 |
 
 
 

--- a/content/nomad/v1.11.x/content/tools/autoscaling/agent.mdx
+++ b/content/nomad/v1.11.x/content/tools/autoscaling/agent.mdx
@@ -26,7 +26,8 @@ The Nomad Autoscaler can be configured to interact with an ACL-enabled Nomad
 cluster. Nomad includes the `scale` ACL policy disposition specifically for
 supporting the operations of the Nomad Autoscaler. Therefore, the
 following policy is sufficient for creating an ACL token that can be used by
-the autoscaler for fetching scaling policies and scaling jobs:
+the autoscaler for fetching scaling policies, scaling jobs, and submitting
+recommendations when applicable:
 
 ```hcl
 namespace "default" {


### PR DESCRIPTION
## Description

This moves the docs content from Allison Larson's merged PR https://github.com/hashicorp/nomad/pull/27061

NMD-955 port from nomad/release-1.11.x to nomad/1.11.1


## Links

Jira: [NMD-955]

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [x] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[NMD-955]: https://hashicorp.atlassian.net/browse/NMD-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ