### PR TITLE
feat(TF-32172): update dynamic cred docs

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/dynamic-provider-credentials/index.mdx
@@ -46,7 +46,7 @@ You can also use Vault to generate credentials for AWS, GCP, or Azure by setting
 
 To use dynamic credentials for queries, complete the steps for [configuring dynamic credentials for workspaces](#configure-dynamic-credentials-for-workspaces). 
 
--> **Note:** Dynamic credentials for queries do not support run phase specific environment variables (plan and apply). Must use the required Run-specific environment variables for the corresponding cloud platform.
+When using dynamic credentials to run queries, you must configure the run-specific environment variables for the corresponding cloud platform. HCP Terraform doesn't support using phase-specific variables, such as variables for plan and apply operations, when providing dynamic credentials to run a query. 
 
 The following variables are examples of run-specific environment variables you can use to configure dynamic provider credentials for queries:
 - [Amazon Web Services](/terraform/cloud-docs/dynamic-provider-credentials/aws-configuration#required-environment-variables): `TFC_AWS_RUN_ROLE_ARN`


### PR DESCRIPTION
Updates documentation index for dynamic credentials by adding a dedicated section for Terraform Queries. The intent is to communicate that some of the optional variables that specify _PLAN_ or _APPLY_ don't apply to queries and therefore cannot be used. Only required _RUN_ variables can be used.
