### PR TITLE
IPL-8862: Add known issue for agent TLS certificate failure in TFE v1.1.0

### DIFF
--- a/content/terraform-enterprise/1.1.x/docs/enterprise/releases/1.1.x/index.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/releases/1.1.x/index.mdx
@@ -62,7 +62,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 
 ## Known Issues
 1. You may experience failures when using an S3-compatible storage solution. An updated AWS library may trigger authentication issues with some third-party storage solutions. As a result, you may experience errors when running plans and applies or when accessing Terraform state files. Refer to issue 2960 on the AWS SDK GitHub issues page for more information. Please ensure your S3-compatible storage solution is fully updated.
-1. Agents launched by Terraform Enterprise using a custom CA bundle, when Terraform Enterprise is using Docker as its run pipeline, may error when registering with TFE, resulting in Terraform runs failing to complete. Runs remain in pending status and eventually fail with `x509: certificate signed by unknown authority` errors. Version 1.1.1 resolves this issue.
+1. Agents launched by Terraform Enterprise using a custom CA bundle, when Terraform Enterprise is using Docker as its run pipeline, may error when registering with Terraform Enterprise, resulting in Terraform runs failing to complete. Runs remain in pending status and eventually fail with `x509: certificate signed by unknown authority` errors. Version 1.1.1 resolves this issue.
 
 ## Deprecations
 1. PostgreSQL 13 is [reaching end-of-life](https://www.postgresql.org/support/versioning/) in November. We are deprecating support for PostgreSQL 13 in this release, and we will remove support in the 1.2.0 release.


### PR DESCRIPTION
Adds a known issue entry to the Terraform Enterprise v1.1.0 release notes documenting agent registration failures when using Docker with custom TLS certificates.

**Changes:**
- Documents that agents fail to register due to incorrect certificate file permissions in Docker deployments
- Indicates that version 1.1.1 resolves the issue

**Related:** [IPL-8862](https://hashicorp.atlassian.net/browse/IPL-8862)

[IPL-8862]: https://hashicorp.atlassian.net/browse/IPL-8862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ