### PR TITLE
Nomad Docs: Fix broken link on plugin driver landing page

### DIFF
--- a/content/nomad/v1.11.x/content/plugins/drivers/index.mdx
+++ b/content/nomad/v1.11.x/content/plugins/drivers/index.mdx
@@ -19,4 +19,4 @@ specification usage.
 
 Nomad's task driver architecture is pluggable, which gives you the flexibility
 to create your own drivers without having to recompile Nomad. Refer to the
-[plugin authoring guide][/nomad/plugins/author/task-driver] for details.
+[plugin authoring guide](nomad/plugins/author/task-driver) for details.


### PR DESCRIPTION
## Description

/nomad/plugins/drivers has a malformed link




## Contributor checklists

Review urgency:

- [x] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [ ] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
