### PR TITLE
Update TFE 1.1.1 and 1.0.3 release notes to include Discuss bulletin link

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/releases/1.0.x/index.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/releases/1.0.x/index.mdx
@@ -83,7 +83,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 1. When `TFE_REDIS_SIDEKIQ_PASSWORDLESS_AZURE_CLIENT_ID` is unspecified, Terraform Enterprise now defaults to `TFE_REDIS_PASSWORDLESS_AZURE_CLIENT_ID` for Azure passwordless authentication in Redis.
 
 ## Security
-1. State versions could be created or removed with a combination of permissions that should not have allowed write access. This bug has been resolved, and only write permissions to the workspace or state versions should grant access to modify state versions.
+1. Fixed an issue that let users without sufficient permissions create new state versions. To learn more about the previous issue, refer to [CVE-2025-13432](https://discuss.hashicorp.com/t/hcsec-2025-34-terraform-enterprise-state-versions-can-be-created-by-users-without-sufficient-write-access/76821).
 1. Security vulnerabilities have been addressed and resolved in this update to enhance overall system protection.
 
 ## 1.0.2

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/releases/1.0.x/index.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/releases/1.0.x/index.mdx
@@ -83,7 +83,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 1. When `TFE_REDIS_SIDEKIQ_PASSWORDLESS_AZURE_CLIENT_ID` is unspecified, Terraform Enterprise now defaults to `TFE_REDIS_PASSWORDLESS_AZURE_CLIENT_ID` for Azure passwordless authentication in Redis.
 
 ## Security
-1. State versions could be created or removed with a combination of permissions that should not have allowed write access. This bug has been resolved, and only write permissions to the workspace or state versions should grant access to modify state versions.
+1. Fixed an issue that let users without sufficient permissions create new state versions. To learn more about the previous issue, refer to [CVE-2025-13432](https://discuss.hashicorp.com/t/hcsec-2025-34-terraform-enterprise-state-versions-can-be-created-by-users-without-sufficient-write-access/76821).
 1. Security vulnerabilities have been addressed and resolved in this update to enhance overall system protection.
 
 ## 1.0.2

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/releases/1.1.x/index.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/releases/1.1.x/index.mdx
@@ -68,7 +68,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 - Fixed an issue where agents launched by Terraform Enterprise using a custom CA bundle, when Terraform Enterprise is using Docker as its run pipeline, would error when registering with Terraform Enterprise, resulting in Terraform runs failing to complete. Runs would remain in pending status and eventually fail with `x509: certificate signed by unknown authority` errors.
 
 ## Security
-- Fixed an issue where new state versions could be created with a combination of permissions that should not have allowed write access (CVE-2025-13432).
+- Fixed an issue that let users without sufficient permissions create new state versions. To learn more about the previous issue, refer to [CVE-2025-13432](https://discuss.hashicorp.com/t/hcsec-2025-34-terraform-enterprise-state-versions-can-be-created-by-users-without-sufficient-write-access/76821).
 
 
 ## 1.1.0

--- a/content/terraform-enterprise/releases/1.0.3.md
+++ b/content/terraform-enterprise/releases/1.0.3.md
@@ -36,7 +36,7 @@ The redis-server version has been upgraded to `7.4.6`.
 
 ## Security
 
-1. State versions could be created or removed with a combination of permissions that should not have allowed write access. This bug has been resolved, and only write permissions to the workspace or state versions should grant access to modify state versions.
+1. Fixed an issue that let users without sufficient permissions create new state versions. To learn more about the previous issue, refer to [CVE-2025-13432](https://discuss.hashicorp.com/t/hcsec-2025-34-terraform-enterprise-state-versions-can-be-created-by-users-without-sufficient-write-access/76821).
 
 <!-- CUSTOMER_FACING_STOP_DELIMITER: Everything below this line will not be viewable by customers. -->
 

--- a/content/terraform-enterprise/releases/1.1.1.md
+++ b/content/terraform-enterprise/releases/1.1.1.md
@@ -23,7 +23,7 @@ customer should care about the change. More information on
 - Fixed an issue where agents launched by Terraform Enterprise using a custom CA bundle, when Terraform Enterprise is using Docker as its run pipeline, would error when registering with Terraform Enterprise, resulting in Terraform runs failing to complete. Runs would remain in pending status and eventually fail with `x509: certificate signed by unknown authority` errors.
 
 ## Security
-- Fixed an issue where new state versions could be created by a user with a combination of permissions that should not have allowed write access (CVE-2025-13432).
+- Fixed an issue that let users without sufficient permissions create new state versions. To learn more about the previous issue, refer to [CVE-2025-13432](https://discuss.hashicorp.com/t/hcsec-2025-34-terraform-enterprise-state-versions-can-be-created-by-users-without-sufficient-write-access/76821).
 
 <!-- CUSTOMER_FACING_STOP_DELIMITER: Everything below this line will not be viewable by customers. -->
 


### PR DESCRIPTION
This adds a link to the Discuss bulletin for the relevant patch in Terraform Enterprise 1.1.1 and 1.0.3, and updates the changelog entry for 1.0.3 to match 1.1.1.