### PR TITLE
Vault Radar: Fix default environment variables for AWS Secrets Manager docs

### DIFF
--- a/content/hcp-docs/content/docs/vault-radar/agent/correlate-aws-secrets-manager.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/agent/correlate-aws-secrets-manager.mdx
@@ -80,7 +80,7 @@ The IAM user, role, or assumed role must have the following permissions:
 ## Agent configuration with AWS Secrets Manager
 
 Set up and manage AWS Secrets Manager from the Vault Radar module in the [HCP
-Portal](https://portal.cloud.hashicorp.com/). 
+Portal](https://portal.cloud.hashicorp.com/).
 
 1. Click **Settings**.
 
@@ -96,26 +96,26 @@ Portal](https://portal.cloud.hashicorp.com/).
 
    <Tabs>
    <Tab heading="IAM Role">
-   
+
    - Select **IAM Role** if you want to use instance profile or role-based authentication.
-   
+
    ![IAM Role](/img/docs/vault-radar/indexing/aws-secrets-manager/iam-role.png)
-   
+
    - (Optional) Enter an assume role ARN in the **Assume Role ARN** text field if you need to assume a different role for access.
-   
+
    </Tab>
    <Tab heading="Environment Variables">
-   
+
    - Select **AWS Credentials from environment variables** if you want to use access keys.
-   
+
    ![Environment Variables](/img/docs/vault-radar/indexing/aws-secrets-manager/environment-variables.png)
-   
-   - Enter your AWS Access Key ID location in the **AWS Access Key ID Env variable** text field (default: `env://AWS_ACCESS_ID_LOCATION`).
-   
-   - Enter your AWS Secret Access Key location in the **AWS Secret Access Key Env variable** text field (default: `env://AWS_SECRET_KEY_LOCATION`).
-   
+
+   - Enter your AWS Access Key ID location in the **AWS Access Key ID Env variable** text field (default: `env://AWS_ACCESS_KEY_ID`).
+
+   - Enter your AWS Secret Access Key location in the **AWS Secret Access Key Env variable** text field (default: `env://AWS_SECRET_ACCESS_KEY`).
+
    - (Optional) Enter an assume role ARN in the **Assume Role ARN** text field if you need to assume a different role for access.
-   
+
    </Tab>
    </Tabs>
 


### PR DESCRIPTION
## Description

:ticket: https://hashicorp.atlassian.net/browse/RADAR-6812

Update the default environment variables in AWS Secrets Manager correlation docs as they were inaccurate

### Requested review scope:

- [x] Content touched by the PR _only_ (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

### Review urgency:

- [x] ASAP (bug fixes, broken content, imminent releases)
- [ ] 3 days (small changes, easy reviews)
- [ ] 1 week (default)
- [ ] Best effort (very non-urgent)

<!-- Fill out only the appropriate checklist for your type of feature (or both if necessary) and delete the other one! -->

## All updates:

<!-- This section is mandatory for all PRs: -->

I have:

- [x] Verified that all status checks have passed
- [x] Verified that preview environment has successfully deployed
- [x] Verified appropriate `label` applied (`hcp` + `product name`)
- [x] Added all required reviewers (code owners and external)

## Content checklist (optional)

Please do these things before requesting a review. I have:

- [ ] Made any associated code repositories public
- [ ] Added the `hashicorp-education/teamName` to any additional code or example repos as repo admin
- [ ] Added redirects for any moved or removed pages
- [ ] Spell checked the tutorial(s)
- [ ] Followed the [unified style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] Linted code snippets (Details per language [here](https://github.com/hashicorp/engineering-docs/blob/master/writing/markdown.md#code-blocks))
- [ ] Checked the steps for completeness (no steps are implied or hidden)
- [ ] Looked at the local or vercel build and checked each new or changed page for:
  - display on the product curriculum page
  - callout box formatting
  - code block highlighting
  - right-hand navigation
  - next and back buttons
  - URL path
