### PR TITLE
docs: fix typo in invoke-actions documentation

### DIFF
--- a/content/terraform/v1.14.x/docs/language/invoke-actions.mdx
+++ b/content/terraform/v1.14.x/docs/language/invoke-actions.mdx
@@ -13,7 +13,7 @@ Declare an `action` block in your Terraform configuration and apply your configu
 
 ## Requirements
 
-Provider develoeprs must implement actions for them to be available. Refer to the provider documentation for information about actions that may be available in your provider. 
+Provider developers must implement actions for them to be available. Refer to the provider documentation for information about actions that may be available in your provider. 
 
 ### HCP Terraform 
 


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad&title=Nomad+Docs&template=nomad_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
