### PR TITLE
Terraform 1.10+: Clarify `providers mirror -lock-file` defaults and value meanings

### DIFF
--- a/content/terraform/v1.10.x/docs/cli/commands/providers/mirror.mdx
+++ b/content/terraform/v1.10.x/docs/cli/commands/providers/mirror.mdx
@@ -55,9 +55,9 @@ This command supports the following additional option:
   architecture. For example, `linux_amd64` selects the Linux operating system
   running on an AMD64 or x86_64 CPU.
 
-* `-lock-file=false` - Ignore the provider lock file when fetching providers.
-By default the mirror command will use the version info in the lock file if the
-configuration directory has been previously initialized.
+* `-lock-file=true` - Set to `false` to ignore the provider lock file when fetching
+providers. By default (`true`) the mirror command will use the version info in the
+lock file if the configuration directory has been previously initialized.
 
 You can run `terraform providers mirror` again on an existing mirror directory
 to update it with new packages. For example, you can add packages for a new

--- a/content/terraform/v1.11.x/docs/cli/commands/providers/mirror.mdx
+++ b/content/terraform/v1.11.x/docs/cli/commands/providers/mirror.mdx
@@ -55,9 +55,9 @@ This command supports the following additional option:
   architecture. For example, `linux_amd64` selects the Linux operating system
   running on an AMD64 or x86_64 CPU.
 
-* `-lock-file=false` - Ignore the provider lock file when fetching providers.
-By default the mirror command will use the version info in the lock file if the
-configuration directory has been previously initialized.
+* `-lock-file=true` - Set to `false` to ignore the provider lock file when fetching
+providers. By default (`true`) the mirror command will use the version info in the
+lock file if the configuration directory has been previously initialized.
 
 You can run `terraform providers mirror` again on an existing mirror directory
 to update it with new packages. For example, you can add packages for a new

--- a/content/terraform/v1.12.x/docs/cli/commands/providers/mirror.mdx
+++ b/content/terraform/v1.12.x/docs/cli/commands/providers/mirror.mdx
@@ -55,9 +55,9 @@ This command supports the following additional option:
   architecture. For example, `linux_amd64` selects the Linux operating system
   running on an AMD64 or x86_64 CPU.
 
-* `-lock-file=false` - Ignore the provider lock file when fetching providers.
-By default the mirror command will use the version info in the lock file if the
-configuration directory has been previously initialized.
+* `-lock-file=true` - Set to `false` to ignore the provider lock file when fetching
+providers. By default (`true`) the mirror command will use the version info in the
+lock file if the configuration directory has been previously initialized.
 
 You can run `terraform providers mirror` again on an existing mirror directory
 to update it with new packages. For example, you can add packages for a new

--- a/content/terraform/v1.13.x/docs/cli/commands/providers/mirror.mdx
+++ b/content/terraform/v1.13.x/docs/cli/commands/providers/mirror.mdx
@@ -55,9 +55,9 @@ This command supports the following additional option:
   architecture. For example, `linux_amd64` selects the Linux operating system
   running on an AMD64 or x86_64 CPU.
 
-* `-lock-file=false` - Ignore the provider lock file when fetching providers.
-By default the mirror command will use the version info in the lock file if the
-configuration directory has been previously initialized.
+* `-lock-file=true` - Set to `false` to ignore the provider lock file when fetching
+providers. By default (`true`) the mirror command will use the version info in the
+lock file if the configuration directory has been previously initialized.
 
 You can run `terraform providers mirror` again on an existing mirror directory
 to update it with new packages. For example, you can add packages for a new

--- a/content/terraform/v1.14.x/docs/cli/commands/providers/mirror.mdx
+++ b/content/terraform/v1.14.x/docs/cli/commands/providers/mirror.mdx
@@ -55,9 +55,9 @@ This command supports the following additional option:
   architecture. For example, `linux_amd64` selects the Linux operating system
   running on an AMD64 or x86_64 CPU.
 
-* `-lock-file=false` - Ignore the provider lock file when fetching providers.
-By default the mirror command will use the version info in the lock file if the
-configuration directory has been previously initialized.
+* `-lock-file=true` - Set to `false` to ignore the provider lock file when fetching
+providers. By default (`true`) the mirror command will use the version info in the
+lock file if the configuration directory has been previously initialized.
 
 You can run `terraform providers mirror` again on an existing mirror directory
 to update it with new packages. For example, you can add packages for a new

--- a/content/terraform/v1.15.x (alpha)/docs/cli/commands/providers/mirror.mdx
+++ b/content/terraform/v1.15.x (alpha)/docs/cli/commands/providers/mirror.mdx
@@ -55,9 +55,9 @@ This command supports the following additional option:
   architecture. For example, `linux_amd64` selects the Linux operating system
   running on an AMD64 or x86_64 CPU.
 
-* `-lock-file=false` - Ignore the provider lock file when fetching providers.
-By default the mirror command will use the version info in the lock file if the
-configuration directory has been previously initialized.
+* `-lock-file=true` - Set to `false` to ignore the provider lock file when fetching
+providers. By default (`true`) the mirror command will use the version info in the
+lock file if the configuration directory has been previously initialized.
 
 You can run `terraform providers mirror` again on an existing mirror directory
 to update it with new packages. For example, you can add packages for a new


### PR DESCRIPTION
While the existing wording isn't strictly wrong, it could be confusing on first read. This PR proposes an update that should make it clearer what the default is and what the values (true or false) mean when set.