### PR TITLE
Nomad Docs: Add note that client node intro feature does not replace mTLS

### DIFF
--- a/content/nomad/v1.11.x/content/docs/architecture/cluster/node-identity.mdx
+++ b/content/nomad/v1.11.x/content/docs/architecture/cluster/node-identity.mdx
@@ -8,7 +8,8 @@ description: Nomad's node identity feature uniquely identities each Nomad client
 
 This page provides conceptual information about Nomad's node identity feature,
 which uniquely identities each Nomad client node and provides an authentication
-mechanism for nodes to make RPC calls to the Nomad servers.
+mechanism for nodes to make RPC calls to the Nomad servers. This feature does
+not replace mTLS.
 
 The Nomad cluster gives every node a default identity once the cluster is able
 to fully support the feature with a defined lifetime. This node identity is a

--- a/content/nomad/v1.11.x/content/docs/release-notes/nomad/v1-11-x.mdx
+++ b/content/nomad/v1.11.x/content/docs/release-notes/nomad/v1-11-x.mdx
@@ -15,7 +15,7 @@ We are pleased to announce the following Nomad updates.
 
 Nomad's client node identity feature uniquely identities each Nomad client node
 and provides an authentication mechanism for nodes to make RPC calls to the
-Nomad servers.
+Nomad servers. This feature does not replace mTLS.
 
 Introduce Nomad clients to the cluster with JWT tokens. Configure Nomad servers
 with introduction enforcement levels that dictate how clients join the cluster.


### PR DESCRIPTION
## Description

Add note that client node intro feature does not replace mTLS. 

## Links

Jira: [CE-1084]

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CE-1084]: https://hashicorp.atlassian.net/browse/CE-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ