### PR TITLE
[Vault] Style fixes for PR 1375

### DIFF
--- a/content/vault/v1.21.x/content/docs/enterprise/managed-keys/ssh-secret-engine.mdx
+++ b/content/vault/v1.21.x/content/docs/enterprise/managed-keys/ssh-secret-engine.mdx
@@ -1,30 +1,30 @@
 ---
 layout: docs
-page_title: Configure SSH secret engine to use HSM managed keys
+page_title: Configure SSH secrets engine to use HSM managed keys
 description: >-
-  Understand how to configure vault to use keys present in pkcs#11 based HSM as CA to sign user's public key.
+  Understand how to configure Vault to use keys present in PKCS #11 based HSM as CA to sign user's public key.
 ---
 
-# Configure SSH Secret Engine to use pkcs11 HSM using Managed keys
+# Configure SSH secrets engine to use PKCS 11 HSM using managed keys
 
 @include 'alerts/enterprise-only.mdx'
 
-SSH Secret Engine can be pluged into vault's centralised abstraction layer called [*Managed Keys*](/vault/docs/enterprise/managed-keys) to delegate 
+SSH secrets engine can be pluged into Vault's centralised abstraction layer called [managed keys](/vault/docs/enterprise/managed-keys) to delegate 
 crypto-operations operations to a trusted external KMS or HSM.
-This allows customers to leverage key management systems external to vault for handling, storing and interacting 
+This allows customers to leverage key management systems external to Vault for handling, storing, and interacting 
 with private key material. 
-We can leverage HSM for storing private key pair of CA created in [SSH using signed certificates method](/vault/docs/secrets/ssh/signed-ssh-certificates). Also vault delegates signing operation to HSM. 
+You can leverage HSM for storing private key pair of CA created in [SSH using signed certificates method](/vault/docs/secrets/ssh/signed-ssh-certificates). Also Vault delegates signing operation to HSM. 
 
 ## Requirements
 
-To setup Transit Secret engine backed by pkcs11 based HSM, the following are required : 
+To setup SSH secrets engine backed by PKCS 11 based HSM, you need: 
 
-- A vault enterprise server running. 
-- A pkcs11 based HSM.
+- A Vault Enterprise server running. 
+- A PKCS 11 based HSM.
 
-## Vault Setup
+## Vault setup
 
-1.   Configure Managed Key
+1. Configure a managed key.
     
     A PKCS#11 HSM requires a shared library to configure Vault to communicate with the HSM. 
     To declare this library, edit the Vault server configuration to add a [`kms_library` stanza](/vault/docs/configuration/kms-library)
@@ -33,49 +33,54 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
 
     ```hcl
     kms_library "pkcs11" {
-    name = "myhsm"
-    library = "/usr/vault/lib/libCryptoki2_64.so"
+        name = "myhsm"
+        library = "/usr/vault/lib/libCryptoki2_64.so"
     }
     ```
 
     </CodeBlockConfig>
 
-    
-    ### Use pkcs11 with IBM EP11 tokens
+1. Use pkcs11 with IBM EP11 tokens.
 
-    ~> **Note**: User needs to have Crypto Express adapters enabled in the LinuxOne and Linux on IBM Z instances as well as configure to use EP11 token. 
-    User also needs to install opencryptoki which can then talk to EP11 token. For more details refer [IBM EP11 Token](https://www.ibm.com/docs/en/linux-on-systems?topic=support-exploiting-enterprise-pkcs-11-using-opencryptoki)
+    <Note>
+
+    User needs to have Crypto Express adapters enabled in the LinuxOne and Linux on IBM Z instances as well as configure to use EP11 token. 
+    User also needs to install opencryptoki which can then talk to EP11 token. For more details, refe to the [IBM EP11 Token](https://www.ibm.com/docs/en/linux-on-systems?topic=support-exploiting-enterprise-pkcs-11-using-opencryptoki) page.
+
+    </Note>
 
     ```hcl
     kms_library "pkcs11" {
-    name = "myhsm"
-    library = "/usr/local/lib/opencryptoki/libopencryptoki.so"
+        name = "myhsm"
+        library = "/usr/local/lib/opencryptoki/libopencryptoki.so"
     }
     ```
 
-1.   Restart or reload Vault's configuration with `SIGHUP`   
+1. Restart or reload Vault's configuration with `SIGHUP`   
+
     ```shell-session
     $ kill -HUP $(pidof vault)
     ```  
-1.   Each managed key requires type-specific configuration. You must identify the location of a key and PIN to access the HSM. This is very similar to Vault's PKCS#11 auto-unseal mechanism. Configure the managed key.
+
+1. Each managed key requires type-specific configuration. You must identify the location of a key and PIN to access the HSM. This is similar to Vault's PKCS#11 auto-unseal mechanism. Configure the managed key.
    
     ```shell-session
     $ vault write sys/managed-keys/pkcs11/ssh-CA-key \
-    library=myhsm \
-    slot=4 \
-    pin=12345678 \
-    key_label="hsm-CA-key" \
-    allow_generate_key=true \
-    mechanism=0x0001 \
-    allow_store_key=true \
-    key_bits=4096 \
-    any_mount=false
+        library=myhsm \
+        slot=4 \
+        pin=12345678 \
+        key_label="hsm-CA-key" \
+        allow_generate_key=true \
+        mechanism=0x0001 \
+        allow_store_key=true \
+        key_bits=4096 \
+        any_mount=false
     ```
 
     The PKCS#11 specific parameters are `library`, referring to the previously
     configured `kms_library` stanza, `slot`, `pin`, `key_label`, and `mechanism`,
     which identifies the object in the HSM which will hold the key. Its
-    mechanism is CKM_RSA_PKCS (RSA with PKCS#1 v1.5 signatures), and that will
+    mechanism is `CKM_RSA_PKCS` (RSA with PKCS#11 v1.5 signatures), and that will
     require a 4096 bit key. The `allow_generate_key` flag indicates that Vault is
     allowed to request that the HSM generate a key. The `allow_store_key` parameter
     indicates that a new key may be stored in the backend. Without this flag, you
@@ -84,7 +89,7 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
     key. For this example, it is set to false so that you can demonstrate how to
     lock managed key access down to a specific mount.
 
-    ** Vault output:**
+    **Example output:**
 
     <CodeBlockConfig hideClipboard>
 
@@ -94,7 +99,7 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
 
     </CodeBlockConfig>
 
-1.   Read the key back. Verify if named managed key was created successfully. 
+1. Read the key back to verify if named managed key was created successfully. 
 
     ```shell-session
     $ vault read sys/managed-keys/pkcs11/ssh-CA-key
@@ -117,19 +122,19 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
     usages                [3 4]
     ```
 
-##  Configure SSH Secrets Engine
+## Configure SSH secrets engine
 
-1.  Enable the `ssh` secrets engine at the `ssh-client-signer` path.
+1. Enable the `ssh` secrets engine at the `ssh-client-signer` path.
 
     ```shell-session
     $ vault secrets enable -path=ssh-client-signer ssh
     Success! Enabled the ssh secrets engine at: ssh-client-signer/
     ```
 
-1.  Tune the secrets engine to use managed keys.
+1. Tune the secrets engine to use managed keys.
 
     ```shell-session
-    $vault secrets tune --allowed-managed-keys=ssh-CA-key ssh-client-signer
+    $ vault secrets tune --allowed-managed-keys=ssh-CA-key ssh-client-signer
     Success! Tuned the secrets engine at: ssh-client-signer/
     ```
 
@@ -137,21 +142,24 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
     This command grants access to the `ssh-CA-key` to the SSH secrets
     engine's mount.
 
-1.  Configure SSH CA to use managed keys
+1. Configure SSH CA to use managed keys.
 
     ```shell-session
-    vault write ssh-client-signer/config/ca managed_key_name="ssh-CA-key"
+    $ vault write ssh-client-signer/config/ca managed_key_name="ssh-CA-key"
     Success! Data written to: ssh-client-signer/config/ca
     ```
 
     RSA 4096 public private key pair gets created at this step while configuring SSH CA to use managed-key. And its key label is `hsm-CA-key`
 
-1.  Read the private key of CA created inside HSM. 
+1. Read the private key of CA created inside HSM. 
+
     ```shell-session
-    vault read ssh-client-signer/config/ca
+    $ vault read ssh-client-signer/config/ca
     ```
 
-    **Vault output:**
+    **Example output:**
+
+    <CodeBlockConfig hideClipboard>
 
     ```shell-session
     Key           Value
@@ -159,15 +167,17 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
     public_key    ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQChGcB66LAVB9FEPS0tJSiV6r/jBS8rUls7CWelMnMfGn9tPJrl0rzBtAhrcjfiPhMd/bh7dYvAQhVvggo1M83owVsAljGoKbeHbL6qg73vO7mDJAWz1MpDetJwkC1QJKsXaE6WT6vjIFnRy2tnQ9mxP6mjRYCYSa0AMuyjMuh9L6ZRJ5Msrf8LJqkrklkr2QBuxyrMZhZqQHpar+rkTccXU2s3as8IQIWBEaYIGN7o3Og1zAH4r7OeyKAft58WhkCwU3y9gmBD4UTrz8Ohs3liAw3DuLTJ5JdWK0I4QPsx2+cB2sTz+2/Dsy+ip0CpjhzY8PpbIYXuLlTb5kxwsNrWXvtX86TVFqpnX5FadOeNnF3XWGJmECElFeaFQv4pH/0P+wg67Sx3cqq3vGKjxW4gKcn9B7cPp8rgCS9UKl/S8Vg3KTLCr/KFsyIrv/m4C0Yu2Yp88GiLz9Q4QuUOowsi/PoMpSH1W57sn8rM/zxMzjIWu2scqSNy29seAhJl0YOtuUhbep4+3/lChvVdqTPpfi5UzWsaawTF5S3AB0DD2ehEw6P7ZU78vGo5I+Pod+As6qEDdmcIXDR0IHcnXII2MqoTEjoHU6NiHR2RpHkRmRlGHy7HAQ/vqdEPuF1X0WjfH/l8fMRyq0v75GFiYcfbNWCGRlZFjyt3Tk3nEH7cZw==
     ```
 
+    </CodeBlockConfig>
+
 1.  Add the public key to all target host's SSH configuration. This process can
     be manual or automated using a configuration management tool. The public key is
     accessible via the API and does not require authentication.
 
-    ```text
+    ```shell-session
     $ curl -o /etc/ssh/trusted-user-ca-keys.pem http://127.0.0.1:8200/v1/ssh-client-signer/public_key
     ```
 
-    ```text
+    ```shell-session
     $ vault read -field=public_key ssh-client-signer/config/ca > /etc/ssh/trusted-user-ca-keys.pem
     ```
 
@@ -185,17 +195,17 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
 1.  Create a named Vault role for signing client keys.
 
     ```shell-session
-    vault write ssh-client-signer/roles/sshrole -<<EOH
+    $ vault write ssh-client-signer/roles/sshrole -<<EOH
     {
-    "algorithm_signer": "rsa-sha2-256",
-    "allow_user_certificates": true,
-    "allowed_users": "*",
-    "allowed_extensions": "permit-pty,permit-port-forwarding",
-    "default_extensions": {
-    "permit-pty": ""
-    },
-    "key_type": "ca",
-    "ttl": "30m0s"
+        "algorithm_signer": "rsa-sha2-256",
+        "allow_user_certificates": true,
+        "allowed_users": "*",
+        "allowed_extensions": "permit-pty,permit-port-forwarding",
+        "default_extensions": {
+        "permit-pty": ""
+        },
+        "key_type": "ca",
+        "ttl": "30m0s"
     }
     EOH
     ```
@@ -208,33 +218,41 @@ the client's local workstation.
 1.  Locate or generate the SSH public key. Usually this is `~/.ssh/id_rsa.pub`.
     If you do not have an SSH keypair, generate one:
 
-    ```text
+    ```shell-session
     $ ssh-keygen -t rsa -C "user@example.com"
     ```
 
 1.  Ask Vault to sign your **public key**. This file usually ends in `.pub` and
     the contents begin with `ssh-rsa ...`.
 
-    ```text
+    ```shell-session
     $ vault write ssh-client-signer/sign/sshrole -<<EOH
     {
-    public_key=@$HOME/.ssh/id_rsa.pub,
-    "valid_principals": "root"
+        public_key=@$HOME/.ssh/id_rsa.pub,
+        "valid_principals": "root"
     }
-    EOH        
+    EOH
+    ```
 
+    **Example output:**
+    
+    <CodeBlockConfig hideClipboard>        
+
+    ```plaintext
     Key             Value
     ---             -----
     serial_number   c73f26d2340276aa
     signed_key      ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1...
     ```
 
+    </CodeBlockConfig>
+
     The result will include the serial and the signed key. This signed key is
     another public key.
 
 1.  Save the resulting signed, public key to disk. Limit permissions as needed.
 
-    ```text
+    ```shell-session
     $ vault write -field=signed_key ssh-client-signer/sign/my-role \
         public_key=@$HOME/.ssh/id_rsa.pub > signed-cert.pub
     ```
@@ -247,15 +265,15 @@ the client's local workstation.
     signed public key from Vault **and** the corresponding private key as
     authentication to the SSH call.
 
-    ```text
+    ```shell-session
     $ ssh -i signed-cert.pub -i ~/.ssh/id_rsa username@10.0.23.5
     ```
 
 ## Reference
 
--   [Signed SSH Certificates Method](/vault/docs/secrets/ssh/signed-ssh-certificates)
+- [Signed SSH certificates](/vault/docs/secrets/ssh/signed-ssh-certificates)
 
 ## API
 
--   [SSH Secret Engine API](/vault/api-docs/secret/ssh)
--   [Managed Keys API](/vault/api-docs/system/managed-keys)
+- [SSH secrets engine (API)](/vault/api-docs/secret/ssh)
+- [`/sys/managed-keys`](/vault/api-docs/system/managed-keys) endpoint

--- a/content/vault/v1.21.x/content/docs/enterprise/managed-keys/transit-secret-engine.mdx
+++ b/content/vault/v1.21.x/content/docs/enterprise/managed-keys/transit-secret-engine.mdx
@@ -2,28 +2,28 @@
 layout: docs
 page_title: Configure transit secret engine to use HSM managed keys
 description: >-
-  Understand how to configure vault to use keys present in pkcs#11 based HSM for crypto-operations.
+  Understand how to configure vault to use keys present in PKCS #11 based HSM for crypto-operations.
 ---
 
-# Configure Transit Secret Engine to use pkcs11 HSM using Managed keys
+# Configure transit secrets engine to use PKCS 11 HSM using managed keys
 
 @include 'alerts/enterprise-only.mdx'
 
-Transit Secret Engine can be pluged into vault's centralised abstraction layer called [*Managed Keys*](/vault/docs/enterprise/managed-keys) to delegate 
+Transit secrets engine can be pluged into Vault's centralised abstraction layer called [managed keys](/vault/docs/enterprise/managed-keys) to delegate 
 crypto-operations operations to a trusted external KMS or HSM.
-This allows customers to leverage key management systems external to vault for handling, storing and interacting 
+This allows users to leverage key management systems external to Vault for handling, storing, and interacting 
 with private key material. 
 
 ## Requirements
 
-To setup Transit Secret engine backed by pkcs11 based HSM, the following are required : 
+To setup transit secrets engine backed by PKCS 11 based HSM, you need: 
 
-- A vault enterprise server running. 
-- A pkcs11 based HSM.
+- A Vault Enterprise server running. 
+- A PKCS 11 based HSM.
 
-## Vault Setup
+## Vault setup
 
-1.  Configure Managed Key
+1. Configure managed key.
     
     A PKCS#11 HSM requires a shared library to configure Vault to communication with the HSM. 
     To declare this library, edit the Vault server configuration to add a [`kms_library` stanza](/vault/docs/configuration/kms-library)
@@ -32,26 +32,31 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
 
     ```hcl
     kms_library "pkcs11" {
-    name = "myhsm"
-    library = "/usr/vault/lib/libCryptoki2_64.so"
+        name = "myhsm"
+        library = "/usr/vault/lib/libCryptoki2_64.so"
     }
     ```
 
     </CodeBlockConfig>
 
-    ### Use pkcs11 with IBM EP11 tokens
+1. Use PKCS 11 with IBM EP11 tokens.
 
-    ~> **Note**: User needs to have Crypto Express adapters enabled in the LinuxOne and Linux on IBM Z instances as well as configure to use EP11 token. 
-    User also needs to install opencryptoki which can then talk to EP11 token. For more details refer [IBM EP11 Token](https://www.ibm.com/docs/en/linux-on-systems?topic=support-exploiting-enterprise-pkcs-11-using-opencryptoki)
+    <Note> 
+
+    User needs to have Crypto Express adapters enabled in the LinuxOne and Linux on IBM Z instances as well as configure to use EP11 token. 
+    User also needs to install opencryptoki which can then talk to EP11 token. For more details, refer to the [IBM EP11 Token](https://www.ibm.com/docs/en/linux-on-systems?topic=support-exploiting-enterprise-pkcs-11-using-opencryptoki) page.
+
+    </Note>
 
     ```hcl
     kms_library "pkcs11" {
-    name = "myhsm"
-    library = "/usr/local/lib/opencryptoki/libopencryptoki.so"
+        name = "myhsm"
+        library = "/usr/local/lib/opencryptoki/libopencryptoki.so"
     }
     ```
 
-1.  Restart or reload Vault's configuration with `SIGHUP`   
+1.  Restart or reload Vault's configuration with `SIGHUP`.
+
     ```shell-session
     $ kill -HUP $(pidof vault)
     ```  
@@ -59,21 +64,21 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
    
     ```shell-session
     $ vault write sys/managed-keys/pkcs11/transit-rsa-key \
-    library=myhsm \
-    slot=4 \
-    pin=12345678 \
-    key_label="vault-rsa-key" \
-    allow_generate_key=true \
-    mechanism=0x0001 \
-    allow_store_key=true \
-    key_bits=2048 \
-    any_mount=false
+        library=myhsm \
+        slot=4 \
+        pin=12345678 \
+        key_label="vault-rsa-key" \
+        allow_generate_key=true \
+        mechanism=0x0001 \
+        allow_store_key=true \
+        key_bits=2048 \
+        any_mount=false
     ```
 
     The PKCS#11 specific parameters are `library`, referring to the previously
     configured `kms_library` stanza, `slot`, `pin`, `key_label`, and `mechanism`,
     which identifies the object in the HSM which will hold the key. Its
-    mechanism is CKM_RSA_PKCS (RSA with PKCS#1 v1.5 signatures), and that will
+    mechanism is `CKM_RSA_PKCS` (RSA with PKCS#11 v1.5 signatures), and that will
     require a 2048 bit key. The `allow_generate_key` flag indicates that Vault is
     allowed to request that the HSM generate a key. The `allow_store_key` parameter
     indicates that a new key may be stored in the backend. Without this flag, you
@@ -82,7 +87,7 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
     key. For this example, it is set to false so that you can demonstrate how to
     lock managed key access down to a specific mount.
 
-    ** Vault output:**
+    **Example output:**
 
     <CodeBlockConfig hideClipboard>
 
@@ -92,7 +97,7 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
 
     </CodeBlockConfig>
 
-1.  Read the key back. Verify if named managed key was created successfully. 
+1.  Read the key back to verify if named managed key was created successfully. 
 
     ```shell-session
     $ vault read sys/managed-keys/pkcs11/transit-rsa-key
@@ -115,7 +120,7 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
     usages                [3 4]
     ```
 
-##  Configure Transit Secrets Engine
+##  Configure transit secrets engine
 
 1.  Enable the `transit` secrets engine at the `transit` path.
 
@@ -135,16 +140,20 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
     This command grants access to the `transit-rsa-key` to the Transit secrets
     engine's mount.
 
-1.  Create Transit Key
+1.  Create a transit key.
 
     ```shell-session
-    vault write transit/keys/hsm-transit-key \
-    type=managed_key \
-    managed_key_name=transit-rsa-key \
-    allow_plaintext_backup=false \
-    exportable=false
+    $ vault write transit/keys/hsm-transit-key \
+        type=managed_key \
+        managed_key_name=transit-rsa-key \
+        allow_plaintext_backup=false \
+        exportable=false
     ```
-    **Vault output:**
+   
+    **Example output:**
+
+    <CodeBlockConfig hideClipboard>
+   
     ```text
     Key                       Value
     ---                       -----
@@ -166,19 +175,23 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
     type                      managed_key
     ```
 
-    At this step while creating transit key, RSA 2048 public private key pair also gets created in the HSM. And its key label is `vault-rsa-key`
+    </CodeBlockConfig>
+
+    At this step while creating transit key, RSA 2048 public private key pair also gets created in the HSM. The key label is `vault-rsa-key`.
 
 ##  Perform crypto-operation
 
-1.  Perform Sign
+1.  Perform the sign data operation.
 
     ```shell-session
-    vault write transit/sign/hsm-transit-key \
-    input=$(echo -n "data to sign" | base64) \
-    hash_algorithm=sha2-256
+    $ vault write transit/sign/hsm-transit-key \
+        input=$(echo -n "data to sign" | base64) \
+        hash_algorithm=sha2-256
     ```
 
-    **Vault output:**
+    **Example output:**
+
+    <CodeBlockConfig hideClipboard>
 
     ```text
     Key            Value
@@ -187,18 +200,22 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
     signature      vault:v1:bqLeknlTuvrPt99ubS0CZyDs5iG8q9n+7kLG+2qHmg1xcHxUdKYCvtIUO5ZpCjJ6SUA/cTJgeFqdhK5rOcSfTzhU5B+HABEYeVb+H7yQ4+sLWrJQ5fNAQZCly+AiXM4q2lAvMW651oq0D4R86f0tOUHVjsaQyqhrrtaA1GQoIcNikx4llTXiGRmc3A1dZmpFCpG7ejQuUF8mGj1tFmY/dyrV0V9o58rmqGe/ddfg+bAfpewNcqWPoWtB+o9QuFhw3L8eqxVCbF8lGfZlqJmudep13So4bC03bWdlZBET8nYpX51Bi5yz0C9wth666IiqE61JnPBlmcJFEyd3FCJ4yQ==
     ```
 
-2.  Perform Verify
+    </CodeBlockConfig>
+
+2.  Verify signed data.
 
     ```shell-session
-    vault write transit/verify/hsm-transit-key \
-    input=$(echo -n "data to sign" | base64) \
-    hash_algorithm=sha2-256 \
-    signature="vault:v1:..."
+    $ vault write transit/verify/hsm-transit-key \
+        input=$(echo -n "data to sign" | base64) \
+        hash_algorithm=sha2-256 \
+        signature="vault:v1:..."
     ```
 
-    Here signature is the output of sign commnand
+    The signature is the output of the sign command.
 
-    **Vault output:**
+    **Example output:**
+
+    <CodeBlockConfig hideClipboard>
 
     ```shell-session
     Key      Value
@@ -206,12 +223,15 @@ To setup Transit Secret engine backed by pkcs11 based HSM, the following are req
     valid    true
     ```
 
+    </CodeBlockConfig>
+
 
 ## Reference
 
-1. [Transit Secret Engine Tutorial](/vault/tutorials/encryption-as-a-service/eaas-transit)
-1. [Transit Secret Engine Documentation](/vault/docs/secrets/transit)
+- [Encrypt data in transit with Vault](/vault/tutorials/encryption-as-a-service/eaas-transit)
+- [Transit secrets engine](/vault/docs/secrets/transit)
 
 ## API 
-1. [Transit Secret Engine API](/vault/api-docs/secret/transit)
-1. [Managed Keys API](/vault/api-docs/system/managed-keys)
+
+- [Transit secrets engine (API)](/vault/api-docs/secret/transit)
+- [`/sys/managed-keys`](/vault/api-docs/system/managed-keys) endpoint


### PR DESCRIPTION
This is an editorial PR for https://github.com/hashicorp/web-unified-docs/pull/1375

- [Use sentence case for titles](https://github.com/hashicorp/web-unified-docs/blob/main/docs/style-guide/general/titles-and-headings.md)
- Use `shell-session` for code blocks
- "Secret Engine" should be "secret**s** engine"