### PR TITLE
Add workflow dispatch to algolia sync action

### DIFF
--- a/.github/workflows/algolia-prod.yml
+++ b/.github/workflows/algolia-prod.yml
@@ -1,6 +1,7 @@
 name: Algolia Sync - Production
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'main'


### PR DESCRIPTION
Allow algolia sync to be triggered by workflow dispatch. That way, we don't have to wait for content updates if we want to trigger a manual re-index of the site
