### PR TITLE
nomad remove docker email auth parameter

### DIFF
--- a/content/nomad/v1.10.x/content/docs/job-declare/task-driver/docker.mdx
+++ b/content/nomad/v1.10.x/content/docs/job-declare/task-driver/docker.mdx
@@ -608,8 +608,6 @@ The `auth` object supports the following keys:
 
 - `password` - (Optional) The account password.
 
-- `email` - (Optional) The account email.
-
 - `server_address` - (Optional) The server domain/IP without the protocol.
   Docker Hub is used by default.
 

--- a/content/nomad/v1.11.x/content/docs/job-declare/task-driver/docker.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-declare/task-driver/docker.mdx
@@ -608,8 +608,6 @@ The `auth` object supports the following keys:
 
 - `password` - (Optional) The account password.
 
-- `email` - (Optional) The account email.
-
 - `server_address` - (Optional) The server domain/IP without the protocol.
   Docker Hub is used by default.
 

--- a/content/nomad/v1.8.x/content/docs/drivers/docker.mdx
+++ b/content/nomad/v1.8.x/content/docs/drivers/docker.mdx
@@ -584,8 +584,6 @@ The `auth` object supports the following keys:
 
 - `password` - (Optional) The account password.
 
-- `email` - (Optional) The account email.
-
 - `server_address` - (Optional) The server domain/IP without the protocol.
   Docker Hub is used by default.
 


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad&title=Nomad+Docs&template=nomad_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
