### PR TITLE
Vault: fix logshipper_buffer_length value

### DIFF
--- a/content/vault/v1.18.x/content/docs/concepts/tune-server-performance.mdx
+++ b/content/vault/v1.18.x/content/docs/concepts/tune-server-performance.mdx
@@ -514,7 +514,7 @@ Detailed information about each configuration option follows.
 
 - `resolver_discover_servers` controls whether the log shipper's resolver should discover other Vault servers; the option accepts a boolean value, and the default value is true;
 
-- `logshipper_buffer_length` sets the maximum number of entries that the log shipper buffer holds as an integer value; the default value is zero (0). In the example configuration, the value is 1000 entries.
+- `logshipper_buffer_length` sets the maximum number of entries that the log shipper buffer holds as an integer value; the default value is `16384`. In the example configuration, the value is 1000 entries.
 
 - `logshipper_buffer_size` sets the maximum size that the log shipper buffer can grow to, expressed as an integer indicating the number of bytes or as a capacity string. Valid capacity strings are `kb, kib, mb, mib, gb, gib, tb, tib`; there is no default value. In the example configuration, the value is 5 gigabytes.
 

--- a/content/vault/v1.19.x/content/docs/concepts/tune-server-performance.mdx
+++ b/content/vault/v1.19.x/content/docs/concepts/tune-server-performance.mdx
@@ -514,7 +514,7 @@ Detailed information about each configuration option follows.
 
 - `resolver_discover_servers` controls whether the log shipper's resolver should discover other Vault servers; the option accepts a boolean value, and the default value is true;
 
-- `logshipper_buffer_length` sets the maximum number of entries that the log shipper buffer holds as an integer value; the default value is zero (0). In the example configuration, the value is 1000 entries.
+- `logshipper_buffer_length` sets the maximum number of entries that the log shipper buffer holds as an integer value; the default value is `16384`. In the example configuration, the value is 1000 entries.
 
 - `logshipper_buffer_size` sets the maximum size that the log shipper buffer can grow to, expressed as an integer indicating the number of bytes or as a capacity string. Valid capacity strings are `kb, kib, mb, mib, gb, gib, tb, tib`; there is no default value. In the example configuration, the value is 5 gigabytes.
 

--- a/content/vault/v1.20.x/content/docs/concepts/tune-server-performance.mdx
+++ b/content/vault/v1.20.x/content/docs/concepts/tune-server-performance.mdx
@@ -514,7 +514,7 @@ Detailed information about each configuration option follows.
 
 - `resolver_discover_servers` controls whether the log shipper's resolver should discover other Vault servers; the option accepts a boolean value, and the default value is true;
 
-- `logshipper_buffer_length` sets the maximum number of entries that the log shipper buffer holds as an integer value; the default value is zero (0). In the example configuration, the value is 1000 entries.
+- `logshipper_buffer_length` sets the maximum number of entries that the log shipper buffer holds as an integer value; the default value is `16384`. In the example configuration, the value is 1000 entries.
 
 - `logshipper_buffer_size` sets the maximum size that the log shipper buffer can grow to, expressed as an integer indicating the number of bytes or as a capacity string. Valid capacity strings are `kb, kib, mb, mib, gb, gib, tb, tib`; there is no default value. In the example configuration, the value is 5 gigabytes.
 

--- a/content/vault/v1.21.x/content/docs/concepts/tune-server-performance.mdx
+++ b/content/vault/v1.21.x/content/docs/concepts/tune-server-performance.mdx
@@ -514,7 +514,7 @@ Detailed information about each configuration option follows.
 
 - `resolver_discover_servers` controls whether the log shipper's resolver should discover other Vault servers; the option accepts a boolean value, and the default value is true;
 
-- `logshipper_buffer_length` sets the maximum number of entries that the log shipper buffer holds as an integer value; the default value is zero (0). In the example configuration, the value is 1000 entries.
+- `logshipper_buffer_length` sets the maximum number of entries that the log shipper buffer holds as an integer value; the default value is `16384`. In the example configuration, the value is 1000 entries.
 
 - `logshipper_buffer_size` sets the maximum size that the log shipper buffer can grow to, expressed as an integer indicating the number of bytes or as a capacity string. Valid capacity strings are `kb, kib, mb, mib, gb, gib, tb, tib`; there is no default value. In the example configuration, the value is 5 gigabytes.
 


### PR DESCRIPTION
## Description

This PR fixes the default value for `logshipper_buffer_length` on the [Tune server performance page](https://developer.hashicorp.com/vault/docs/concepts/tune-server-performance#logshipper_buffer_length), which should be `16384`, not zero.

## Links

Jira: [SPE-1375]
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.

Jira: [<jira-ticket-number>]  // for example, Jira: [CE-1001] GH-Jira integration generates the link and updates the Jira ticket.
GitHub Issue: <issue-link>
Deploy previews:

The bot does publish a root-level link to the deploy preview, 
but it's nice to include a direct link to your content so the reviewers don't have to navigate to your pages.
-->

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [x] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[SPE-1375]: https://hashicorp.atlassian.net/browse/SPE-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CE-1001]: https://hashicorp.atlassian.net/browse/CE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ