### PR TITLE
fix[docs]: update lifecycle.mdx `prevent_destory` typo

### DIFF
--- a/content/terraform/v1.14.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.14.x/docs/language/meta-arguments/lifecycle.mdx
@@ -67,7 +67,7 @@ You can use `create_before_destroy` in [`resource`](/terraform/language/block/re
 
 When `prevent_destroy` is set to `true`, Terraform rejects plans that would destroy the infrastructure object associated with the resource and returns an error. The argument must be present in the configuration. This rule doesn't prevent Terraform from destroying a resource if you remove its configuration. Refer to [Remove a resource from state](/terraform/language/state/remove) for instructions on how to remove a resource from state without destroying the actual resource.
 
-Use this rule as protection against accidentally replacing objects that may be costly to reproduce, such as database instances. Enabling `prevent_destory`, however, makes certain configuration changes impossible to apply
+Use this rule as protection against accidentally replacing objects that may be costly to reproduce, such as database instances. Enabling `prevent_destroy`, however, makes certain configuration changes impossible to apply
 and prevents the `terraform destroy` command from operating once such objects are created. Use `prevent_destroy` sparingly.
 
 You can use `prevent_destroy` in in [`resource`](/terraform/language/block/resource) blocks. 


### PR DESCRIPTION
Address a small typo in the docs, s/destory/destroy/
