### PR TITLE
Nomad Docs: Fix default vault engine version in nomad secrets block

### DIFF
--- a/content/nomad/v1.11.x/content/docs/job-specification/secret.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-specification/secret.mdx
@@ -79,8 +79,8 @@ as an example, you would reference the value in the secret key "foo"  as
 
   Config parameters:
 
-    - `engine` `(string: "kv_v2")` - Specifies what Vault storage engine to
-  query. Options are `kv_v1` and `kv_v2`.
+    - `engine` `(string: "kv")` - Specifies what Vault storage engine to
+  query. Options are `kv` and `kv_v2`.
 
 
 ## Custom providers


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad&title=Nomad+Docs&template=nomad_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
