### PR TITLE
vault: updating vault-k8s default for the v1.7.1 injector release

### DIFF
--- a/content/vault/v1.21.x/content/docs/deploy/kubernetes/injector/annotations.mdx
+++ b/content/vault/v1.21.x/content/docs/deploy/kubernetes/injector/annotations.mdx
@@ -28,7 +28,7 @@ them, optional commands to run, etc.
 
 - `vault.hashicorp.com/agent-image` - name of the Vault docker image to use. This
   value overrides the default image configured in the injector and is usually
-  not needed. Defaults to `hashicorp/vault:1.19.5`.
+  not needed. Defaults to `hashicorp/vault:1.21.1`.
 
 - `vault.hashicorp.com/agent-init-first` - configures the pod to run the Vault Agent
   init container first if `true` (last if `false`). This is useful when other init


### PR DESCRIPTION
Updating the Vault Agent default for the injector from the [v1.7.1](https://github.com/hashicorp/vault-k8s/releases/tag/v1.7.1) release.