### PR TITLE
CI: fix labeler syntax

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -245,8 +245,8 @@ Runtime:
 - any:
   - changed-files:
     - any-glob-to-any-file: [
-        'content/consul/**'
-        'content/nomad/**'
-        'content/hcp-docs/content/docs/cli/**'
+        'content/consul/**',
+        'content/nomad/**',
+        'content/hcp-docs/content/docs/cli/**',
         'content/hcp-docs/content/docs/hcp/**'
       ]


### PR DESCRIPTION
Labeler job syntax seems to be broken, this might fix it?

Example: https://github.com/hashicorp/web-unified-docs/actions/runs/19843088062/job/56855420138?pr=1419

Before this patch:

```
web-unified-docs on  main 
❯ cat .github/labeler.yml| yq .
Error: bad file '-': yaml: line 236: did not find expected ',' or ']'
```

With this patch:

```
web-unified-docs on  tvoran/VAULT-40510/fix-labeler 
❯ cat .github/labeler.yml| yq .
...
Runtime:
  - any:
      - changed-files:
          - any-glob-to-any-file: ['content/consul/**', 'content/nomad/**', 'content/hcp-docs/content/docs/cli/**', 'content/hcp-docs/content/docs/hcp/**']
```