### PR TITLE
Actions: Fix broken PR labeler 

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -14,11 +14,11 @@ policy:
           - name: 'Boundary'
             keys: ['Boundary']
           - name: 'Consul'
-            keys: ['Consul', 'Runtime']
+            keys: ['Consul']
           - name: 'HCP'
             keys: ['HashiCorp Cloud Platform']
           - name: 'Nomad'
-            keys: ['Nomad', 'Runtime']
+            keys: ['Nomad']
           - name: 'Packer'
             keys: ['Packer']
           - name: 'Sentinel'
@@ -35,4 +35,6 @@ policy:
             keys: ['Waypoint']
           - name: 'Triage'
             keys: ['No product', 'Other product']
+          - name: 'Runtime'
+            keys: ['Nomad', 'Consul']
  

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -245,8 +245,8 @@ Runtime:
 - any:
   - changed-files:
     - any-glob-to-any-file: [
-        'content/consul/**'
-        'content/nomad/**'
-        'content/hcp-docs/content/docs/cli/**'
+        'content/consul/**',
+        'content/nomad/**',
+        'content/hcp-docs/content/docs/cli/**',
         'content/hcp-docs/content/docs/hcp/**'
       ]


### PR DESCRIPTION
This PR fixes the syntax mistakes in the A[dd Runtime label to support Slack automation PR](https://github.com/hashicorp/web-unified-docs/pull/1409).

1. Advanced issue labeler: add additional Runtime label for Nomad and Consul issues
2. PR labeler: Add commas to entries in Runtime section. The current version throws an error when run due to missing commas in the collection.