### PR TITLE
Nomad: clarify per_alloc vs sticky for dynamic host volumes

### DIFF
--- a/content/nomad/v1.10.x/content/docs/job-specification/volume.mdx
+++ b/content/nomad/v1.10.x/content/docs/job-specification/volume.mdx
@@ -81,7 +81,7 @@ the [volume_mount][volume_mount] block in the `task` configuration.
   group always receives the volume with the same ID, if available. Use sticky
   volumes for [stateful deployments]. You may only use the `sticky` field for
   dynamic host volumes. For CSI volumes, the `per_alloc` field provides similar
-  functionality
+  functionality.
 
 - `per_alloc` `(bool: false)` - Specifies that the `source` of the volume
   should have the suffix `[n]`, where `n` is the allocation index. This allows
@@ -92,8 +92,11 @@ the [volume_mount][volume_mount] block in the `task` configuration.
 
   The `per_alloc` field cannot be true for system jobs, sysbatch jobs, or jobs
   that use canaries. `per_alloc` is mutually exclusive with the `sticky`
-  property. Use `per_alloc` only with CSI volumes and `sticky` only
-  with dynamic host volumes.
+  property. If you use `per_alloc` with dynamic host volumes, you are
+  responsible for ensuring that the volumes have unique volume names. Unless you
+  need multiple allocations for the same job to use dynamic host volumes on the
+  same host, we recommend using `sticky` for dynamic host volumes and
+  `per_alloc` for CSI volumes.
 
 The following fields are only valid for volumes with `type = "csi"` or dynamic
 host volumes with `type = "host"`:

--- a/content/nomad/v1.11.x/content/docs/job-specification/volume.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-specification/volume.mdx
@@ -81,7 +81,7 @@ the [volume_mount][volume_mount] block in the `task` configuration.
   group always receives the volume with the same ID, if available. Use sticky
   volumes for [stateful deployments]. You may only use the `sticky` field for
   dynamic host volumes. For CSI volumes, the `per_alloc` field provides similar
-  functionality
+  functionality.
 
 - `per_alloc` `(bool: false)` - Specifies that the `source` of the volume
   should have the suffix `[n]`, where `n` is the allocation index. This allows
@@ -92,8 +92,11 @@ the [volume_mount][volume_mount] block in the `task` configuration.
 
   The `per_alloc` field cannot be true for system jobs, sysbatch jobs, or jobs
   that use canaries. `per_alloc` is mutually exclusive with the `sticky`
-  property. Use `per_alloc` only with CSI volumes and `sticky` only
-  with dynamic host volumes.
+  property. If you use `per_alloc` with dynamic host volumes, you are
+  responsible for ensuring that the volumes have unique volume names. Unless you
+  need multiple allocations for the same job to use dynamic host volumes on the
+  same host, we recommend using `sticky` for dynamic host volumes and
+  `per_alloc` for CSI volumes.
 
 The following fields are only valid for volumes with `type = "csi"` or dynamic
 host volumes with `type = "host"`:


### PR DESCRIPTION
Although it's possible to use `per_alloc` with Nomad dynamic host volumes, this imposes requirements on the user. Expand on the details of these requirements, make an explicit recommendation for using `sticky` over `per_alloc`, and explain when you might want to ignore that recommendation.

Ref: https://github.com/hashicorp/nomad/issues/27140

## Links

GitHub Issue: https://github.com/hashicorp/nomad/issues/27140
Deploy previews:
* https://unified-docs-frontend-preview-hv5d29il5-hashicorp.vercel.app/nomad/docs/job-specification/volume#per_alloc
* https://unified-docs-frontend-preview-hv5d29il5-hashicorp.vercel.app/nomad/docs/v1.10.x/job-specification/volume#per_alloc

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [x] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
