### PR TITLE
Added force_delete parameter to delete destination for vault secrets-sync feature

### DIFF
--- a/content/vault/v1.21.x (rc)/content/api-docs/system/secrets-sync.mdx
+++ b/content/vault/v1.21.x (rc)/content/api-docs/system/secrets-sync.mdx
@@ -223,6 +223,10 @@ associations cannot be deleted unless they are also purged.
 - `purge` `(bool: false)` - If true, asynchronously unsync all secrets and delete all associations managed by this destination
 before it is deleted.
 
+- `force_delete` `(bool: false)` - If true, deletes a destination even if its associations cannot be unsynced. 
+This should be used only as a last-resort deletion mechanism, as any secrets already synced to the external provider will remain orphaned and 
+will require manual cleanup.
+
 ### Sample request
 
 ```shell-session


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
