### PR TITLE
docs: Update transparent sessions interoperability matrix

### DIFF
--- a/content/boundary/v0.20.x/content/docs/interoperability-matrix/index.mdx
+++ b/content/boundary/v0.20.x/content/docs/interoperability-matrix/index.mdx
@@ -52,10 +52,10 @@ Any patches or updates will be reflected in the minor number.
     <b>Windows version</b>: 2025.2.600.0
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.1.4, 0.19.5, 0.19.6
+    0.19.6, 0.20.1
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.1.4, 0.19.5, 0.19.6
+    0.19.6, 0.20.1
     </td>
     <td style={{verticalAlign: 'middle'}}>
     <b>MacOS</b>: 14.6, 15.3
@@ -76,10 +76,10 @@ Any patches or updates will be reflected in the minor number.
     <b>Windows version</b>: 0.14.14
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.1.4
+    0.20.1
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.1.4
+    0.20.1
     </td>
     <td style={{verticalAlign: 'middle'}}>
     <b>MacOS</b>: 14.6, 15.3
@@ -96,10 +96,10 @@ Any patches or updates will be reflected in the minor number.
     Microsoft Defender for Endpoint
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.1.4, 0.19.5, 0.19.6
+    0.19.6
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.1.4, 0.19.5, 0.19.6
+    0.19.6
     </td>
     <td style={{verticalAlign: 'middle'}}>
     <b>MacOS</b>: 14, 15
@@ -116,10 +116,10 @@ Any patches or updates will be reflected in the minor number.
     Palo Alto GlobalProtect
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.19.5, 0.19.6
+    0.19.6
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.19.5, 0.19.6
+    0.19.6
     </td>
     <td style={{verticalAlign: 'middle'}}>
     <b>MacOS</b>: 14, 15
@@ -136,10 +136,10 @@ Any patches or updates will be reflected in the minor number.
     SentinelOne Singularity
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.1.4, 0.19.5, 0.19.6
+    0.19.6, 0.20.1
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.1.4, 0.19.5, 0.19.6
+    0.19.6, 0.20.1
     </td>
     <td style={{verticalAlign: 'middle'}}>
     <b>MacOS</b>: 14, 15.2
@@ -156,10 +156,10 @@ Any patches or updates will be reflected in the minor number.
     Zscaler ZPA
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.1.4, 0.19.5, 0.19.6
+    0.19.6, 0.20.1
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.1.4, 0.19.5, 0.19.6
+    0.19.6, 0.20.1
     </td>
     <td style={{verticalAlign: 'middle'}}>
     <b>MacOS</b>: 15


### PR DESCRIPTION
Per [ICU-18237](https://hashicorp.atlassian.net/browse/ICU-18237), the transparent sessions interoperability matrix should be updated with the 3rd party test results for version 0.20.1.

This PR adds updated 0.20.1 test results for CloudFlare WARP, Huntess, SentinelOne Singularity, and Zscaler ZPA. It also removes test results for the older 0.1.4 and 0.19.5 versions,

[View the update in the preview deployment](https://unified-docs-frontend-preview-kzrgoqvtj-hashicorp.vercel.app/boundary/docs/interoperability-matrix)


[ICU-18237]: https://hashicorp.atlassian.net/browse/ICU-18237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ