### PR TITLE
Nomad docs: add sidecar_task.identity feature

### DIFF
--- a/content/nomad/v1.11.x/content/docs/job-specification/identity.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-specification/identity.mdx
@@ -12,6 +12,7 @@ description: |-
     ['job', 'group', 'service', 'identity'],
     ['job', 'group', 'task', 'identity'],
     ['job', 'group', 'task', 'service', 'identity'],
+    ['job', 'group', 'service', 'connect', 'sidecar_task', 'identity'],
   ]}
 />
 

--- a/content/nomad/v1.11.x/content/docs/job-specification/sidecar_task.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-specification/sidecar_task.mdx
@@ -156,6 +156,11 @@ meta.connect.sidecar_image = custom/envoy-${NOMAD_envoy_version}:latest
 - `volume_mount` <code>([VolumeMount][]: nil)</code> - Specifies where a group
   volume should be mounted.
 
+- `identity` <code>([Identity][]: nil)</code> - Expose an extra [Workload Identity][]
+  to the task. Nomad automatically configures Consul Service Mesh sidecars with
+  the required identities to communicate with Consul. Specifying this block lets
+  you add extra identities that can be consumed by third-party services.
+
 ## Examples
 
 The following example configures resources for the sidecar task and other configuration.
@@ -181,6 +186,8 @@ The following example configures resources for the sidecar task and other config
 [group]: /nomad/docs/job-specification/group 'Nomad group Job Specification'
 [interpolation]: /nomad/docs/reference/runtime-variable-interpolation 'Nomad interpolation'
 [job]: /nomad/docs/job-specification/job 'Nomad job Job Specification'
+[Identity]: /nomad/docs/job-specification/identity 'Nomad identity Job Specification'
+[Workload Identity]: /nomad/docs/concepts/workload-identity
 [logs]: /nomad/docs/job-specification/logs 'Nomad logs Job Specification'
 [resources]: /nomad/docs/job-specification/resources 'Nomad resources Job Specification'
 [sidecar_service]: /nomad/docs/job-specification/sidecar_service 'Nomad sidecar service Specification'


### PR DESCRIPTION
## Description

Add docs for the `sidecar_task.identity` block added in https://github.com/hashicorp/nomad/pull/25877

## Links

Jira: https://hashicorp.atlassian.net/browse/NMD-439
GitHub Issue: https://github.com/hashicorp/nomad/pull/25877
Deploy previews:
* https://unified-docs-frontend-preview-ianou7eol-hashicorp.vercel.app/nomad/docs/job-specification/sidecar_task#identity
* https://unified-docs-frontend-preview-ianou7eol-hashicorp.vercel.app/nomad/docs/job-specification/identity (header only)

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CE-1001]: https://hashicorp.atlassian.net/browse/CE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ