### PR TITLE
docs: Remove remaining IPv6 requirement

### DIFF
--- a/content/boundary/v0.20.x/content/docs/targets/configuration/configure-transparent-sessions.mdx
+++ b/content/boundary/v0.20.x/content/docs/targets/configuration/configure-transparent-sessions.mdx
@@ -28,7 +28,6 @@ Before you configure transparent sessions, you must:
 - Install the Boundary Client Agent, CLI, and Desktop client.
    - Refer to [Install the Boundary clients](/boundary/docs/deploy/self-managed/install-clients) for instructions.
    - Refer to the [transparent sessions interoperability matrix](/boundary/docs/interoperability-matrix) for a list of third-party products that have been tested for use with the Boundary installer and Client Agent.
-- Ensure that both IPv4 and IPv6 protocols are enabled for your environment. The [Client Agent](/boundary/docs/client-agent) requires both protocols to start and perform DNS lookups.
 
 You should also make sure you have the appropriate grants configured so that you can resolve aliases and establish transparent sessions.
 For more information, refer to the [Grants](/boundary/docs/client-agent#grants) section in the Client Agent documentation.


### PR DESCRIPTION
For [ICU-18250](https://hashicorp.atlassian.net/browse/ICU-18250), we removed documentation that said IPv6 was required for the Client Agent, as this requirement was relaxed in version 0.20.0. We merged the changes in #1444 , but I missed a requirement listed in the [Configuring transparent sessions](https://developer.hashicorp.com/boundary/docs/targets/configuration/configure-transparent-sessions#requirements:~:text=Ensure%20that%20both%20IPv4%20and%20IPv6%20protocols%20are%20enabled%20for%20your%20environment.%20The%20Client%20Agent%20requires%20both%20protocols%20to%20start%20and%20perform%20DNS%20lookups.) topic. This PR removes that reference.

[View the preview deployment](https://unified-docs-frontend-preview-abhsle72z-hashicorp.vercel.app/boundary/docs/targets/configuration/configure-transparent-sessions)

[ICU-18250]: https://hashicorp.atlassian.net/browse/ICU-18250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ