### PR TITLE
Nomad Docs: Podman driver - add pasta parm to network_mode

### DIFF
--- a/content/nomad/v1.11.x/content/plugins/drivers/podman.mdx
+++ b/content/nomad/v1.11.x/content/plugins/drivers/podman.mdx
@@ -387,10 +387,11 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   ```
 
 - `network_mode` - (Optional) Set the [network mode][network-mode] for the
-  container. By default the task uses the network stack defined in the task
+  container. By default, the task uses the network stack defined in the task
   group [`network`][nomad_group_network] block. If the groups network behavior
-  is also undefined, it will fallback to `bridge` in rootful mode or
-  `slirp4netns` for rootless containers.
+  is also undefined, it falls back to `bridge` in rootful mode, `slirp4netns`
+  for rootless containers on Podman version less than 5.0.0, or `pasta` for
+  rootless containers on Podman v5.0.0 or greater.
 
   - `bridge` - (Default for rootful) Create a network stack on the default
   Podman bridge.
@@ -399,9 +400,13 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   container full access to local system services such as D-bus and is therefore
   considered insecure.
   - `none` - No networking.
-  - `slirp4netns` - (Default for rootless) Use `slirp4netns` to create a user
-  network stack. Podman currently does not support this option for rootful
-  containers ([issue][slirp-issue]).
+  - `pasta`: Use `pasta` to create a user network stack. This is the
+    default for rootless containers on Podman v5.0.0 or greater.
+  - `slirp4netns`: Use `slirp4netns` to create a user network stack. This is the
+  default for rootless containers on Podman versions less than 5.0.0. Podman
+  does not support `slirp4netns` for root containers. Refer to this [Podman
+  GitHub issue](https://github.com/containers/libpod/issues/6097) for an
+  explanation.
   - `task:name-of-other-task`: Join the network of another task in the same
   allocation.
 


### PR DESCRIPTION
## Description

Add `pasta` parameter to `network_mode`. I ported the README content updates from the code PR.

**do not merge** until Nomad Eng releases the Podman driver, which James has scheduled for 10 December.

## Links

Jira: [CE-1092]
Podman PR: https://github.com/hashicorp/nomad-driver-podman/pull/476

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CE-1092]: https://hashicorp.atlassian.net/browse/CE-1092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ