### PR TITLE
Nomad Docs - Secrets plugin typo fix and add plugin environment variables

### DIFF
--- a/content/nomad/v1.11.x/content/docs/job-specification/secret.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-specification/secret.mdx
@@ -89,9 +89,9 @@ Nomad extends the provider list via the use of custom providers plugins. Custom
 providers must implement both the `fingerprint` and `fetch` functionality. You
 must place custom providers in the `common_plugin_dir/secrets/` subdirectory. On
 startup, the Nomad client fingerprints executables in the secrets directory by
-executing it with the first argument of `fingerblock`. When using a custom
-plugin "foo", Nomad looks for an executable "foo" and runs it with the first
-argument being "fetch", and the second argument being the secret's path
+executing it with the first argument being `fingerprint`. When a task using a custom
+plugin "foo" to fetch a secret, Nomad looks for an executable "foo" and runs it with
+the first argument being "fetch", and the second argument being the secret's path
 parameter. Refer to the [plugin authoring][secret-provider] guide on secret providers
 for an example custom provider.
 

--- a/content/nomad/v1.11.x/content/plugins/author/secret-provider.mdx
+++ b/content/nomad/v1.11.x/content/plugins/author/secret-provider.mdx
@@ -196,7 +196,8 @@ CPI_OPERATION=fingerprint
 Nomad calls `fetch` when a Nomad job includes a secret block with a provider
 registered as a plugin. When calling fetch, Nomad includes the secret path as
 the second CLI argument. If the `env{}` block was specified, any key/values are
-supplied as environment variables to the plugin process.
+supplied as environment variables to the plugin process. Nomad automatically
+provides the `NOMAD_JOB_ID` and `NOMAD_NAMESPACE` environment variables to plugins.
 
 **CLI Arguments:** `$1=fetch $2=path`
 


### PR DESCRIPTION
<!--
**Merge branch**

Make sure you create your PR against the correct **base** branch. For instructions, refer to
GitHub's **Change the branch range and destination repository guide** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

If your content is an update to:

- Currently published content

  Choose **base: main** when you are updating published documentation, and you
  want your changes published when the PR is merged. We publish Nomad content
  from the `main` branch.
- Upcoming Nomad release

  Choose the branch for the Nomad release that your content is for. Nomad
  release branches use the `nomad/<exact-release-number>` format. If you are not
  able to find the upcoming Nomad release branch that you are looking for,
  contact the tech writer that works with the Nomad team.

**Backports**

This repo stores previous version docs in folders instead of branches. There are
no backport labels.  If you backported your code PR to previous branches, update
the docs content in the corresponding folders. For example, if the current
release is 1.10.x and you backported your code to 1.9.x and 1.8.x, update the docs content
in the v1.10.x, v1.9.x, and v1.8.x folders.
-->

## Description

<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of. 

Include the target release as well as prior versions if applicable.
-->

## Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.

Jira: [<jira-ticket-number>]  // for example, Jira: [CE-1001] GH-Jira integration generates the link and updates the Jira ticket.
GitHub Issue: <issue-link>
Deploy previews:

The bot does publish a root-level link to the deploy preview, 
but it's nice to include a direct link to your content so the reviewers don't have to navigate to your pages.
-->

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [x] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CE-1001]: https://hashicorp.atlassian.net/browse/CE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ