### PR TITLE
Minor improvements to Framework and SDKv2 List Docs

### DIFF
--- a/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/list-resources/non-framework-resource.mdx
+++ b/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/list-resources/non-framework-resource.mdx
@@ -37,3 +37,5 @@ func (r *ThingListResource) RawV5Schemas(ctx context.Context, req list.RawV5Sche
 	}
 }
 ```
+
+For a more complete example of implementing a list resource with an SDKv2 resource, refer to the [SDKv2 List documentation](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/list).

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/list.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/list.mdx
@@ -52,6 +52,14 @@ In this example, the list method on the resource `examplecloud_thing` is defined
 
 ```go
 // Some list.ListResource interface methods are omitted for brevity.
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
 type ThingListResource struct{}
 
 func (r *ThingListResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -59,6 +67,7 @@ func (r *ThingListResource) Metadata(ctx context.Context, req resource.MetadataR
 }
 
 func (r *ThingListResource) RawV5Schemas(ctx context.Context, req list.RawV5SchemaRequest, resp *list.RawV5SchemaResponse) {
+	// Where `resourceThing` returns an SDKv2 `schema.Resource` instance
 	thingResource := resourceThing()
 
 	resp.ProtoV5Schema = thingResource.ProtoSchema(ctx)()
@@ -69,8 +78,9 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 	var data ThingListResourceModel
 
 	// Read list config data into the model
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}
 


### PR DESCRIPTION
### What

- Framework's list documentation on non-framework resources links to a more complete example in the SDKv2 documentation
- SDKv2's list documentation received some minor fixes in the example as well as further comments and explicit imports to reduce confusion

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
