### PR TITLE
Nomad Docs: Fix typo in v1.10.x go template syntax

### DIFF
--- a/content/nomad/v1.10.x/content/docs/reference/go-template-syntax.mdx
+++ b/content/nomad/v1.10.x/content/docs/reference/go-template-syntax.mdx
@@ -139,7 +139,7 @@ trim markers on one or both ends to remove whitespace. Comments with trim marker
 must have a space between the `-` and the start or end of the comment.
 
 ```plaintext
-{{- /* example comment with trim markers /* -}}
+{{- /* example comment with trim markers */ -}}
 ```
 
 <Tip>


### PR DESCRIPTION
## Description

Fix type in v1.10.x go template syntax

Relates to #1507 

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [ ] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [x] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
