### PR TITLE
add endpoint to list all workspace variables

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/workspace-variables.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/workspace-variables.mdx
@@ -190,6 +190,108 @@ $ curl \
 }
 ```
 
+## List all accessible variables
+
+This endpoint returns all variables that are accessible to a workspace. This includes variables defined directly on the workspace and variables inherited from variable sets (both global and scoped variable sets). The endpoint excludes variables that have been overwritten by higher-precedence variables.
+
+`GET /workspaces/:workspace_id/all-vars`
+
+| Parameter       | Description      |
+| --------------- | ---------------- |
+| `:workspace_id` | The workspace ID |
+
+### Variable precedence
+
+When multiple variables share the same key and category, HCP Terraform applies the following precedence order (highest to lowest):
+
+1. Variables defined directly on the workspace
+2. Variables from variable sets scoped to the workspace
+3. Variables from variable sets scoped to the workspace's project
+4. Variables from global variable sets
+
+The response includes only the highest-precedence variable for each unique key and category combination.
+
+### Sample request
+
+```shell-session
+$ curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://app.terraform.io/api/v2/workspaces/ws-SihZTyXKfNXUWuUa/all-vars
+```
+
+### Sample response
+
+```json
+{
+  "data": [
+    {
+      "id": "var-AD4pibb9nxo1468E",
+      "type": "vars",
+      "attributes": {
+        "key": "region",
+        "value": "us-east-1",
+        "sensitive": false,
+        "category": "terraform",
+        "hcl": false,
+        "created-at": "2021-06-15T19:33:40.931Z",
+        "description": "AWS region for resources"
+      },
+      "relationships": {
+        "configurable": {
+          "data": {
+            "id": "ws-SihZTyXKfNXUWuUa",
+            "type": "workspaces"
+          },
+          "links": {
+            "related": "/api/v2/organizations/my-organization/workspaces/my-workspace"
+          }
+        }
+      },
+      "links": {
+        "self": "/api/v2/workspaces/ws-SihZTyXKfNXUWuUa/vars/var-AD4pibb9nxo1468E"
+      }
+    },
+    {
+      "id": "var-yRmifb4PJj7cLkMG",
+      "type": "vars",
+      "attributes": {
+        "key": "ami_id",
+        "value": "ami-0c55b159cbfafe1f0",
+        "sensitive": false,
+        "category": "terraform",
+        "hcl": false,
+        "created-at": "2021-06-15T19:35:21.487Z",
+        "description": null
+      },
+      "relationships": {
+        "configurable": {
+          "data": {
+            "id": "varset-47qC3LmA47piVan7",
+            "type": "varsets"
+          },
+          "links": {
+            "related": "/api/v2/varsets/varset-47qC3LmA47piVan7"
+          }
+        },
+        "varset": {
+          "data": {
+            "id": "varset-47qC3LmA47piVan7",
+            "type": "varsets"
+          },
+          "links": {
+            "related": "/api/v2/varsets/varset-47qC3LmA47piVan7"
+          }
+        }
+      },
+      "links": {
+        "self": "/api/v2/varsets/varset-47qC3LmA47piVan7/relationships/vars/var-yRmifb4PJj7cLkMG"
+      }
+    }
+  ]
+}
+```
+
 ## Update Variables
 
 `PATCH /workspaces/:workspace_id/vars/:variable_id`


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Added documentation for the `/workspaces/:workspace_id/all-vars` API endpoint in the Workspace Variables API reference page.

**Changed pages:**
- `content/terraform-docs-common/docs/cloud-docs/api-docs/workspace-variables.mdx`

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
The `/all-vars` endpoint was previously undocumented. This endpoint returns all variables accessible to a workspace, including variables defined directly on the workspace and variables inherited from variable sets (global and scoped). This is useful for users who need to see the complete variable configuration with precedence rules applied, as the endpoint automatically filters out overwritten variables and shows only the effective variables.


### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->



----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.