### PR TITLE
Guide users to the releases page and explicitly state that "latest" i…

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/kubernetes/index.mdx
@@ -62,7 +62,7 @@ By default, Terraform Enterprise runs as the `terraform-enterprise` user. If you
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
     ```shell-session
     $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/openshift.mdx
@@ -101,7 +101,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated-migration.mdx
@@ -139,7 +139,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/kubernetes/index.mdx
@@ -62,7 +62,7 @@ By default, Terraform Enterprise runs as the `terraform-enterprise` user. If you
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
     ```shell-session
     $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/openshift.mdx
@@ -101,7 +101,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated-migration.mdx
@@ -139,7 +139,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -54,7 +54,7 @@ Before you begin, ensure you meet the [shared requirements](/terraform/enterpris
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -25,7 +25,7 @@ Before installing, ensure you meet the [requirements for Kubernetes deployments]
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -103,7 +103,7 @@ for more information on all of the available configuration settings for Flexible
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -54,7 +54,7 @@ Before you begin, ensure you meet the [shared requirements](/terraform/enterpris
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -25,7 +25,7 @@ Kubernetes deployments have different operational and observability consideratio
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -104,7 +104,7 @@ for more information on all of the available configuration settings for Flexible
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -54,7 +54,7 @@ Before you begin, ensure you meet the [shared requirements](/terraform/enterpris
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -25,7 +25,7 @@ Kubernetes deployments have different operational and observability consideratio
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -104,7 +104,7 @@ for more information on all of the available configuration settings for Flexible
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -54,7 +54,7 @@ Before you begin, ensure you meet the [shared requirements](/terraform/enterpris
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -25,7 +25,7 @@ Kubernetes deployments have different operational and observability consideratio
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -62,7 +62,7 @@ for installing Terraform Enterprise on Podman.
   $ echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -104,7 +104,7 @@ for more information on all of the available configuration settings for Flexible
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -54,7 +54,7 @@ Before you begin, ensure you meet the [shared requirements](/terraform/enterpris
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -25,7 +25,7 @@ Kubernetes deployments have different operational and observability consideratio
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -62,7 +62,7 @@ for installing Terraform Enterprise on Podman.
   $ echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -104,7 +104,7 @@ for more information on all of the available configuration settings for Flexible
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -54,7 +54,7 @@ Before you begin, ensure you meet the [shared requirements](/terraform/enterpris
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -25,7 +25,7 @@ Kubernetes deployments have different operational and observability consideratio
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -62,7 +62,7 @@ for installing Terraform Enterprise on Podman.
   $ echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/replicated-migration.mdx
@@ -105,7 +105,7 @@ for more information on all of the available configuration settings for Flexible
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -54,7 +54,7 @@ Before you begin, ensure you meet the [shared requirements](/terraform/enterpris
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -25,7 +25,7 @@ Kubernetes deployments have different operational and observability consideratio
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -62,7 +62,7 @@ for installing Terraform Enterprise on Podman.
   $ echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -104,7 +104,7 @@ for more information on all of the available configuration settings for Flexible
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -54,7 +54,7 @@ Before you begin, ensure you meet the [shared requirements](/terraform/enterpris
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -25,7 +25,7 @@ Kubernetes deployments have different operational and observability consideratio
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -62,7 +62,7 @@ for installing Terraform Enterprise on Podman.
   $ echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/replicated-migration.mdx
@@ -105,7 +105,7 @@ for more information on all of the available configuration settings for Flexible
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -54,7 +54,7 @@ Before you begin, ensure you meet the [shared requirements](/terraform/enterpris
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -25,7 +25,7 @@ Kubernetes deployments have different operational and observability consideratio
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -73,7 +73,7 @@ for installing Terraform Enterprise on Podman.
   $ echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -123,7 +123,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -54,7 +54,7 @@ Before you begin, ensure you meet the [shared requirements](/terraform/enterpris
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -25,7 +25,7 @@ Kubernetes deployments have different operational and observability consideratio
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -73,7 +73,7 @@ for installing Terraform Enterprise on Podman.
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/replicated-migration.mdx
@@ -132,7 +132,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -54,7 +54,7 @@ Before you begin, ensure you meet the [shared requirements](/terraform/enterpris
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -25,7 +25,7 @@ Kubernetes deployments have different operational and observability consideratio
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -73,7 +73,7 @@ for installing Terraform Enterprise on Podman.
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -132,7 +132,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -55,7 +55,7 @@ and Docker [requirements](/terraform/enterprise/flexible-deployments/install/doc
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -37,7 +37,7 @@ Kubernetes and OpenShift deployments have different operational and observabilit
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -72,7 +72,7 @@ for installing Terraform Enterprise on Podman.
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -136,7 +136,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -55,7 +55,7 @@ and Docker [requirements](/terraform/enterprise/flexible-deployments/install/doc
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -29,7 +29,7 @@ Kubernetes and OpenShift deployments have different operational and observabilit
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -72,7 +72,7 @@ for installing Terraform Enterprise on Podman.
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -136,7 +136,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/kubernetes/index.mdx
@@ -49,7 +49,7 @@ Create a custom YAML configuration file, for example `/tmp/overrides.yaml`, to o
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/openshift.mdx
@@ -98,7 +98,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/kubernetes/index.mdx
@@ -49,7 +49,7 @@ Create a custom YAML configuration file, for example `/tmp/overrides.yaml`, to o
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/openshift.mdx
@@ -98,7 +98,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -129,7 +129,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/kubernetes/index.mdx
@@ -49,7 +49,7 @@ Create a custom YAML configuration file, for example `/tmp/overrides.yaml`, to o
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/openshift.mdx
@@ -98,7 +98,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated-migration.mdx
@@ -129,7 +129,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/kubernetes/index.mdx
@@ -49,7 +49,7 @@ Create a custom YAML configuration file, for example `/tmp/overrides.yaml`, to o
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/openshift.mdx
@@ -98,7 +98,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/kubernetes/index.mdx
@@ -49,7 +49,7 @@ Create a custom YAML configuration file, for example `/tmp/overrides.yaml`, to o
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/openshift.mdx
@@ -98,7 +98,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/kubernetes/index.mdx
@@ -62,7 +62,7 @@ By default, Terraform Enterprise runs as the `terraform-enterprise` user. If you
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/openshift.mdx
@@ -100,7 +100,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/kubernetes/index.mdx
@@ -62,7 +62,7 @@ By default, Terraform Enterprise runs as the `terraform-enterprise` user. If you
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/openshift.mdx
@@ -100,7 +100,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/kubernetes/index.mdx
@@ -62,7 +62,7 @@ By default, Terraform Enterprise runs as the `terraform-enterprise` user. If you
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
     ```shell-session
     $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/openshift.mdx
@@ -100,7 +100,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/kubernetes/index.mdx
@@ -62,7 +62,7 @@ By default, Terraform Enterprise runs as the `terraform-enterprise` user. If you
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
     ```shell-session
     $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/openshift.mdx
@@ -100,7 +100,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/kubernetes/index.mdx
@@ -62,7 +62,7 @@ By default, Terraform Enterprise runs as the `terraform-enterprise` user. If you
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
     ```shell-session
     $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/openshift.mdx
@@ -100,7 +100,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/kubernetes/index.mdx
@@ -62,7 +62,7 @@ By default, Terraform Enterprise runs as the `terraform-enterprise` user. If you
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
     ```shell-session
     $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/openshift.mdx
@@ -100,7 +100,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/kubernetes/index.mdx
@@ -62,7 +62,7 @@ By default, Terraform Enterprise runs as the `terraform-enterprise` user. If you
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
     ```shell-session
     $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/openshift.mdx
@@ -100,7 +100,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/kubernetes/index.mdx
@@ -62,7 +62,7 @@ By default, Terraform Enterprise runs as the `terraform-enterprise` user. If you
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
     ```shell-session
     $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/openshift.mdx
@@ -100,7 +100,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/kubernetes/index.mdx
@@ -62,7 +62,7 @@ By default, Terraform Enterprise runs as the `terraform-enterprise` user. If you
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
     ```shell-session
     $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/openshift.mdx
@@ -100,7 +100,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/docker/index.mdx
@@ -54,7 +54,7 @@ Create a deployment configuration file and specify settings for the operational 
     $ echo "<HASHICORP_LICENSE>" |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/kubernetes/index.mdx
@@ -62,7 +62,7 @@ By default, Terraform Enterprise runs as the `terraform-enterprise` user. If you
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
     ```shell-session
     $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/openshift.mdx
@@ -100,7 +100,7 @@ securityContext:
     $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
     ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/podman.mdx
@@ -51,7 +51,7 @@ Create a deployment configuration file and specify settings for the operational 
   # echo "<HASHICORP_LICENSE>" |  podman login --username terraform images.releases.hashicorp.com --password-stdin
   ```
 
-  1. Pull the Terraform Enterprise image from the registry.
+  1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
   ```shell-session
   # podman pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -138,7 +138,7 @@ To make migration smoother and faster, we recommend using the same host as your 
    $ cat <PATH_TO_HASHICORP_LICENSE_FILE> |  docker login --username terraform images.releases.hashicorp.com --password-stdin
    ```
 
-1. Pull the Terraform Enterprise image from the registry.
+1. Pull the Terraform Enterprise image from the registry.  Refer to [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) for a list of versions and replace `<vYYYYMM-#>` with the version you wish to install; `latest` is not a valid tag.  
 
    ```shell-session
    $ docker pull images.releases.hashicorp.com/hashicorp/terraform-enterprise:<vYYYYMM-#>


### PR DESCRIPTION
I'd like to add some language clarifying where to find TFE versions numbers and explicitly state that 'latest' is not a tag we publish.
