### PR TITLE
change cert.key to key.pem and cert.crt to cert.pem to align with fil…

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/prepare-host.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/prepare-host.mdx
@@ -120,12 +120,11 @@ The following example uses the `openssl` command to generate an RSA key and cert
 
 ```shell-session
 openssl req -nodes -x509 -sha256 -newkey rsa:4096 \
- -keyout cert.key \
- -out cert.crt \
+ -keyout key.pem \
+ -out cert.pem \
  -days 356 \
  -subj "/C=US/ST=CA/L=San Francisco/O=MyOrganization/OU=Global/CN=example.com" \
- -addext "subjectAltName=DNS:example.com"
-```
+ -addext "subjectAltName=DNS:example.com"```
 
 When generating the key, replace `<terraform.example.com>` with the Terraform Enterprise hostname:
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/prepare-host.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/prepare-host.mdx
@@ -117,12 +117,11 @@ The following example uses the `openssl` command to generate an RSA key and cert
 
 ```shell-session
 openssl req -nodes -x509 -sha256 -newkey rsa:4096 \
- -keyout cert.key \
- -out cert.crt \
+ -keyout key.pem \
+ -out cert.pem \
  -days 356 \
  -subj "/C=US/ST=CA/L=San Francisco/O=MyOrganization/OU=Global/CN=example.com" \
- -addext "subjectAltName=DNS:example.com"
-```
+ -addext "subjectAltName=DNS:example.com"```
 
 When generating the key, replace `<terraform.example.com>` with the Terraform Enterprise hostname:
 

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/prepare-host.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/prepare-host.mdx
@@ -120,12 +120,11 @@ The following example uses the `openssl` command to generate an RSA key and cert
 
 ```shell-session
 openssl req -nodes -x509 -sha256 -newkey rsa:4096 \
- -keyout cert.key \
- -out cert.crt \
+ -keyout key.pem \
+ -out cert.pem \
  -days 356 \
  -subj "/C=US/ST=CA/L=San Francisco/O=MyOrganization/OU=Global/CN=example.com" \
- -addext "subjectAltName=DNS:example.com"
-```
+ -addext "subjectAltName=DNS:example.com"```
 
 When generating the key, replace `<terraform.example.com>` with the Terraform Enterprise hostname:
 

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/prepare-host.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/prepare-host.mdx
@@ -120,12 +120,11 @@ The following example uses the `openssl` command to generate an RSA key and cert
 
 ```shell-session
 openssl req -nodes -x509 -sha256 -newkey rsa:4096 \
- -keyout cert.key \
- -out cert.crt \
+ -keyout key.pem \
+ -out cert.pem \
  -days 356 \
  -subj "/C=US/ST=CA/L=San Francisco/O=MyOrganization/OU=Global/CN=example.com" \
- -addext "subjectAltName=DNS:example.com"
-```
+ -addext "subjectAltName=DNS:example.com"```
 
 When generating the key, replace `<terraform.example.com>` with the Terraform Enterprise hostname:
 

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/prepare-host.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/prepare-host.mdx
@@ -120,12 +120,11 @@ The following example uses the `openssl` command to generate an RSA key and cert
 
 ```shell-session
 openssl req -nodes -x509 -sha256 -newkey rsa:4096 \
- -keyout cert.key \
- -out cert.crt \
+ -keyout key.pem \
+ -out cert.pem \
  -days 356 \
  -subj "/C=US/ST=CA/L=San Francisco/O=MyOrganization/OU=Global/CN=example.com" \
- -addext "subjectAltName=DNS:example.com"
-```
+ -addext "subjectAltName=DNS:example.com"```
 
 When generating the key, replace `<terraform.example.com>` with the Terraform Enterprise hostname:
 

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/prepare-host.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/prepare-host.mdx
@@ -120,12 +120,11 @@ The following example uses the `openssl` command to generate an RSA key and cert
 
 ```shell-session
 openssl req -nodes -x509 -sha256 -newkey rsa:4096 \
- -keyout cert.key \
- -out cert.crt \
+ -keyout key.pem \
+ -out cert.pem \
  -days 356 \
  -subj "/C=US/ST=CA/L=San Francisco/O=MyOrganization/OU=Global/CN=example.com" \
- -addext "subjectAltName=DNS:example.com"
-```
+ -addext "subjectAltName=DNS:example.com"```
 
 When generating the key, replace `<terraform.example.com>` with the Terraform Enterprise hostname:
 

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/prepare-host.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/prepare-host.mdx
@@ -120,12 +120,11 @@ The following example uses the `openssl` command to generate an RSA key and cert
 
 ```shell-session
 openssl req -nodes -x509 -sha256 -newkey rsa:4096 \
- -keyout cert.key \
- -out cert.crt \
+ -keyout key.pem \
+ -out cert.pem \
  -days 356 \
  -subj "/C=US/ST=CA/L=San Francisco/O=MyOrganization/OU=Global/CN=example.com" \
- -addext "subjectAltName=DNS:example.com"
-```
+ -addext "subjectAltName=DNS:example.com"```
 
 When generating the key, replace `<terraform.example.com>` with the Terraform Enterprise hostname:
 


### PR DESCRIPTION
Elsewhere we refer to these as key.pem and cert.pem.  I'd like to change the command to output files with those names to align with the other examples and docs.
