### PR TITLE
Update to next.js 14.2.35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 				"@mdx-js/util": "^1.6.22",
 				"algoliasearch": "^5.21.0",
 				"gray-matter": "^4.0.3",
-				"next": "^14.2.17",
+				"next": "^14.2.35",
 				"path-to-regexp": "^6.2.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -1849,15 +1849,15 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "14.2.21",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.21.tgz",
-			"integrity": "sha512-lXcwcJd5oR01tggjWJ6SrNNYFGuOOMB9c251wUNkjCpkoXOPkDeF/15c3mnVlBqrW4JJXb2kVxDFhC4GduJt2A==",
+			"version": "14.2.35",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+			"integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
 			"license": "MIT"
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "14.2.21",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.21.tgz",
-			"integrity": "sha512-HwEjcKsXtvszXz5q5Z7wCtrHeTTDSTgAbocz45PHMUjU3fBYInfvhR+ZhavDRUYLonm53aHZbB09QtJVJj8T7g==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+			"integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1871,9 +1871,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "14.2.21",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.21.tgz",
-			"integrity": "sha512-TSAA2ROgNzm4FhKbTbyJOBrsREOMVdDIltZ6aZiKvCi/v0UwFmwigBGeqXDA97TFMpR3LNNpw52CbVelkoQBxA==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+			"integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
 			"cpu": [
 				"x64"
 			],
@@ -1887,9 +1887,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "14.2.21",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.21.tgz",
-			"integrity": "sha512-0Dqjn0pEUz3JG+AImpnMMW/m8hRtl1GQCNbO66V1yp6RswSTiKmnHf3pTX6xMdJYSemf3O4Q9ykiL0jymu0TuA==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+			"integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1903,9 +1903,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "14.2.21",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.21.tgz",
-			"integrity": "sha512-Ggfw5qnMXldscVntwnjfaQs5GbBbjioV4B4loP+bjqNEb42fzZlAaK+ldL0jm2CTJga9LynBMhekNfV8W4+HBw==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+			"integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1919,9 +1919,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "14.2.21",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.21.tgz",
-			"integrity": "sha512-uokj0lubN1WoSa5KKdThVPRffGyiWlm/vCc/cMkWOQHw69Qt0X1o3b2PyLLx8ANqlefILZh1EdfLRz9gVpG6tg==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+			"integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
 			"cpu": [
 				"x64"
 			],
@@ -1935,9 +1935,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "14.2.21",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.21.tgz",
-			"integrity": "sha512-iAEBPzWNbciah4+0yI4s7Pce6BIoxTQ0AGCkxn/UBuzJFkYyJt71MadYQkjPqCQCJAFQ26sYh7MOKdU+VQFgPg==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+			"integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
 			"cpu": [
 				"x64"
 			],
@@ -1951,9 +1951,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "14.2.21",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.21.tgz",
-			"integrity": "sha512-plykgB3vL2hB4Z32W3ktsfqyuyGAPxqwiyrAi2Mr8LlEUhNn9VgkiAl5hODSBpzIfWweX3er1f5uNpGDygfQVQ==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+			"integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1967,9 +1967,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "14.2.21",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.21.tgz",
-			"integrity": "sha512-w5bacz4Vxqrh06BjWgua3Yf7EMDb8iMcVhNrNx8KnJXt8t+Uu0Zg4JHLDL/T7DkTCEEfKXO/Er1fcfWxn2xfPA==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+			"integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -1983,9 +1983,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "14.2.21",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.21.tgz",
-			"integrity": "sha512-sT6+llIkzpsexGYZq8cjjthRyRGe5cJVhqh12FmlbxHqna6zsDDK8UNaV7g41T6atFHCJUPeLb3uyAwrBwy0NA==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+			"integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
 			"cpu": [
 				"x64"
 			],
@@ -6730,12 +6730,12 @@
 			"license": "MIT"
 		},
 		"node_modules/next": {
-			"version": "14.2.21",
-			"resolved": "https://registry.npmjs.org/next/-/next-14.2.21.tgz",
-			"integrity": "sha512-rZmLwucLHr3/zfDMYbJXbw0ZeoBpirxkXuvsJbk7UPorvPYZhP7vq7aHbKnU7dQNCYIimRrbB2pp3xmf+wsYUg==",
+			"version": "14.2.35",
+			"resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+			"integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "14.2.21",
+				"@next/env": "14.2.35",
 				"@swc/helpers": "0.5.5",
 				"busboy": "1.6.0",
 				"caniuse-lite": "^1.0.30001579",
@@ -6750,15 +6750,15 @@
 				"node": ">=18.17.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "14.2.21",
-				"@next/swc-darwin-x64": "14.2.21",
-				"@next/swc-linux-arm64-gnu": "14.2.21",
-				"@next/swc-linux-arm64-musl": "14.2.21",
-				"@next/swc-linux-x64-gnu": "14.2.21",
-				"@next/swc-linux-x64-musl": "14.2.21",
-				"@next/swc-win32-arm64-msvc": "14.2.21",
-				"@next/swc-win32-ia32-msvc": "14.2.21",
-				"@next/swc-win32-x64-msvc": "14.2.21"
+				"@next/swc-darwin-arm64": "14.2.33",
+				"@next/swc-darwin-x64": "14.2.33",
+				"@next/swc-linux-arm64-gnu": "14.2.33",
+				"@next/swc-linux-arm64-musl": "14.2.33",
+				"@next/swc-linux-x64-gnu": "14.2.33",
+				"@next/swc-linux-x64-musl": "14.2.33",
+				"@next/swc-win32-arm64-msvc": "14.2.33",
+				"@next/swc-win32-ia32-msvc": "14.2.33",
+				"@next/swc-win32-x64-msvc": "14.2.33"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"@mdx-js/util": "^1.6.22",
 		"algoliasearch": "^5.21.0",
 		"gray-matter": "^4.0.3",
-		"next": "^14.2.17",
+		"next": "^14.2.35",
 		"path-to-regexp": "^6.2.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",


### PR DESCRIPTION
## 🔗 Relevant links

- [Vercel CVE-2025-55184 vulnerability](https://app.asana.com/1/90955849329269/project/1211614190522916/task/1212483265200248?focus=true) 🎟️

## Description

Updates next.js to 14.2.35, which is a minor update for us, to protect us from [CVE-2025-55184](https://nvd.nist.gov/vuln/detail/CVE-2025-55184).

## Testing

This would only effect the file [app/page.tsx](https://github.com/hashicorp/web-unified-docs/blob/main/app/page.tsx). Which is a redirect so IMO no real testing is needed for this PR.