### PR TITLE
Change disable_mlock setting to false

### DIFF
--- a/content/vault/v1.21.x/content/docs/get-vault/install-binary.mdx
+++ b/content/vault/v1.21.x/content/docs/get-vault/install-binary.mdx
@@ -228,7 +228,7 @@ Create a basic Vault configuration file for testing and development.
    ui            = true
    cluster_addr  = "http://127.0.0.1:8201"
    api_addr      = "https://127.0.0.1:8200"
-   disable_mlock = true
+   disable_mlock = false 
 
    storage "raft" {
      path    = "${VAULT_DATA}"


### PR DESCRIPTION
The current guide is setting mlock capability for no root user in step #1  there is no reason to use disable_mlock at this step.

