### PR TITLE
redirs for links in exam materials

### DIFF
--- a/content/terraform-docs-common/redirects.jsonc
+++ b/content/terraform-docs-common/redirects.jsonc
@@ -1326,5 +1326,21 @@
     "source": "/terraform/language/v:version(1\\.11\\.x)/block/terraform",
     "destination": "/terraform/language/v:version/terraform#cloud",
     "permanent": true
+  },
+  // the TF 004 exam materials pinned 1.12 and 1.13 docs when we temporarily updated paths to var docs
+  {
+    "source": "/terraform/language/v:version(1\\.12\\.x|1\\.13.x)/parameterize",
+    "destination": "/terraform/language/v:version/values",
+    "permanent": true
+  },
+  {
+    "source": "/terraform/language/v:version(1\\.12\\.x|1\\.13.x)/parameterize#define-module-input-arguments-with-variables",
+    "destination": "/terraform/language/v:version/values/variables",
+    "permanent": true
+  },
+  {
+    "source": "/terraform/language/v:version(1\\.12\\.x|1\\.13.x)/parameterize#define-outputs-to-expose-module-data",
+    "destination": "/terraform/language/v:version/values/outputs",
+    "permanent": true
   }
 ]


### PR DESCRIPTION
During the exam materials update, we changed paths in the docs. The changes seemed to negatively affect traffic, so we changed them back but did not update the exam materials before publishing. This PR adds redirects for the language docs so that links placed in the TF exam study materials don't break. 