### PR TITLE
Rectify azure peering VPC terminology

### DIFF
--- a/content/hcp-docs/content/docs/hcp/network/hvn-azure/hvn-peering.mdx
+++ b/content/hcp-docs/content/docs/hcp/network/hvn-azure/hvn-peering.mdx
@@ -7,7 +7,7 @@ description: |-
 # Peering connections
 
 You can create a peering connection between HashiCorp Cloud Platform (HCP) and
-your virtual private cloud (VPC) in Azure to allow traffic between services.
+your virtual network (VNet) in Azure to allow traffic between services.
 
 ## Overview
 


### PR DESCRIPTION
This PR modifies VPC term used in Azure peering to VNet.
Please go to the `Preview` tab and select the appropriate template:

* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
