### PR TITLE
TF-32720: Documents Sidekiq Metrics since TFE 1.0.0

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/reference/metrics.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/reference/metrics.mdx
@@ -28,6 +28,15 @@ The following table describes metrics report runtime information about Terraform
 | `tfe.container.disk.io_bytes_write_total` | `counter`    | Running count of the number of disk bytes written by the container                                               |
 | `tfe.container.process_count`             | `gauge`      | The number of processes active within the container                                                              |
 | `tfe.container.process_limit`             | `gauge`      | The maximum number of processes that can be executed inside the container                                        |
+| `sidekiq.sidekiq.queue.latency`           | `gauge`      | The difference in seconds since the oldest job in the queue was enqueued                                         |
+| `sidekiq.sidekiq.queue.size`              | `gauge`      | The current size of the queue                                                                                    |
+| `sidekiq.sidekiq.failed`                  | `gauge`      | The number of failed jobs                                                                                        |
+| `sidekiq.sidekiq.processed`               | `gauge`      | The number of processed jobs                                                                                     |
+| `sidekiq.sidekiq.enqueued`                | `gauge`      | The number of enqueued jobs                                                                                      |
+| `sidekiq.sidekiq.retries`                 | `gauge`      | The number of jobs scheduled for retry                                                                           |
+| `sidekiq.sidekiq.dead`                    | `gauge`      | The number of jobs that have exhausted retries                                                                   |
+| `sidekiq.sidekiq.scheduled`               | `gauge`      | The number of jobs scheduled for future execution                                                                |
+| `sidekiq.sidekiq.busy`                    | `gauge`      | The number of workers currently processing jobs                                                                  |
 
 The following metadata labels will be added to each container metric emitted:
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/reference/metrics.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/reference/metrics.mdx
@@ -28,6 +28,15 @@ The following table describes metrics report runtime information about Terraform
 | `tfe.container.disk.io_bytes_write_total` | `counter`    | Running count of the number of disk bytes written by the container                                               |
 | `tfe.container.process_count`             | `gauge`      | The number of processes active within the container                                                              |
 | `tfe.container.process_limit`             | `gauge`      | The maximum number of processes that can be executed inside the container                                        |
+| `sidekiq.sidekiq.queue.latency`           | `gauge`      | The difference in seconds since the oldest job in the queue was enqueued                                         |
+| `sidekiq.sidekiq.queue.size`              | `gauge`      | The current size of the queue                                                                                    |
+| `sidekiq.sidekiq.failed`                  | `gauge`      | The number of failed jobs                                                                                        |
+| `sidekiq.sidekiq.processed`               | `gauge`      | The number of processed jobs                                                                                     |
+| `sidekiq.sidekiq.enqueued`                | `gauge`      | The number of enqueued jobs                                                                                      |
+| `sidekiq.sidekiq.retries`                 | `gauge`      | The number of jobs scheduled for retry                                                                           |
+| `sidekiq.sidekiq.dead`                    | `gauge`      | The number of jobs that have exhausted retries                                                                   |
+| `sidekiq.sidekiq.scheduled`               | `gauge`      | The number of jobs scheduled for future execution                                                                |
+| `sidekiq.sidekiq.busy`                    | `gauge`      | The number of workers currently processing jobs                                                                  |
 
 The following metadata labels will be added to each container metric emitted:
 


### PR DESCRIPTION
[JIRA](https://hashicorp.atlassian.net/browse/TF-32720)

These sidekiq metrics were introduced with TFE 1.0.0, and so I've documented these for both the 1.0.x and 1.1.x TFE release series.

Please go to the `Preview` tab and select the appropriate template:

* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
