### PR TITLE
Clarify lookup function usage

### DIFF
--- a/content/packer/v1.14.x/content/guides/hcl/variables.mdx
+++ b/content/packer/v1.14.x/content/guides/hcl/variables.mdx
@@ -316,7 +316,7 @@ Then we can `lookup` in maps like in the following:
 
 ```hcl
 source "amazon-ebs" "example" {
-  source_ami    = "${lookup(var.amis, var.region)}"
+  source_ami    = "${lookup(var.amis, var.region, "ami-12345678")}"
   instance_type = "t2.micro"
 }
 ```
@@ -324,10 +324,19 @@ source "amazon-ebs" "example" {
 This introduces a new type of interpolation: a function call. The
 `lookup` function does a dynamic lookup in a map for a key. The
 key is `var.region`, which specifies that the value of the region
-variables is the key.
+variables is the key. The `lookup` function also requires a default.
 
 You can also do a static lookup of a map directly with
-`${var.amis["us-east-1"]}`.
+`${var.amis["us-east-1"]}` and even do the following (no
+default, so a failed lookup becomes an error):
+
+```hcl
+source "amazon-ebs" "example" {
+  source_ami    = var.amis[var.region]
+  instance_type = "t2.micro"
+}
+```
+
 
 ## Assigning Maps
 


### PR DESCRIPTION
- Add required default parameter to lookup function example
- Clarify that lookup function requires a default value
- Add example demonstrating modern HCL2 map access syntax
- Mention error behavior when lookup fails without default

## Description

I tried using a variable of type `map(string)` in packer following this guide:
https://developer.hashicorp.com/packer/guides/hcl/variables
This failed initially because the example didn't show the required default value.
