### PR TITLE
use latest image

### DIFF
--- a/content/terraform-mcp-server/v0.3.x/docs/mcp-server/deploy.mdx
+++ b/content/terraform-mcp-server/v0.3.x/docs/mcp-server/deploy.mdx
@@ -70,7 +70,7 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "--rm",
             "-e", "${input:tfe_token}",
             "-e", "${input:tfe_address}",
-            "hashicorp/terraform-mcp-server:0.3.0"
+            "hashicorp/terraform-mcp-server:latest"
           ]
         }
       },
@@ -105,7 +105,7 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
           "--rm",
           "-e", "${input:tfe_token}",
           "-e", "${input:tfe_address}",
-          "hashicorp/terraform-mcp-server:0.3.0"
+          "hashicorp/terraform-mcp-server:latest"
         ]
       }
     },
@@ -146,7 +146,7 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "--rm",
             "-e", "<<TFE_ADDRESS_HERE>>",
             "-e", "<<TFE_TOKEN_HERE>>",
-            "hashicorp/terraform-mcp-server:0.3.0"
+            "hashicorp/terraform-mcp-server:latest"
           ]
         }
       }
@@ -178,7 +178,7 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "--rm",
             "-e", "<<TFE_ADDRESS_HERE>>",
             "-e", "<<TFE_TOKEN_HERE>>",
-            "hashicorp/terraform-mcp-server:0.3.0"
+            "hashicorp/terraform-mcp-server:latest"
           ]
         }
       }
@@ -209,7 +209,7 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "--rm",
             "-e", "<<TFE_ADDRESS_HERE>>",
             "-e", "<<TFE_TOKEN_HERE>>",
-            "hashicorp/terraform-mcp-server:0.3.0"
+            "hashicorp/terraform-mcp-server:latest"
           ]
         }
       }
@@ -244,7 +244,7 @@ Set the `tfe_token` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "hashicorp/terraform-mcp-server:0.3.0"
+            "hashicorp/terraform-mcp-server:latest"
           ]
         }
       }
@@ -263,7 +263,7 @@ Set the `tfe_token` environment variable to your HCP Terraform or Terraform Ente
           "run",
           "-i",
           "--rm",
-          "hashicorp/terraform-mcp-server:0.3.0"
+          "hashicorp/terraform-mcp-server:latest"
         ]
       }
     }
@@ -291,7 +291,7 @@ Set the `tfe_token` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "hashicorp/terraform-mcp-server:0.3.0"
+            "hashicorp/terraform-mcp-server:latest"
           ]
         }
       }
@@ -321,7 +321,7 @@ Set the `tfe_token` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "hashicorp/terraform-mcp-server:0.3.0"
+            "hashicorp/terraform-mcp-server:latest"
           ]
         }
       }
@@ -350,7 +350,7 @@ Set the `tfe_token` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "hashicorp/terraform-mcp-server:0.3.0"
+            "hashicorp/terraform-mcp-server:latest"
           ]
         }
       }


### PR DESCRIPTION
The current version is 0.3.3.  I suggest we use the "latest" tag in place of a specific version so that we are always recommending the latest and greatest. 
