### PR TITLE
Andybaran tfp mcp server ver

### DIFF
--- a/content/terraform-mcp-server/v0.3.x/docs/mcp-server/deploy.mdx
+++ b/content/terraform-mcp-server/v0.3.x/docs/mcp-server/deploy.mdx
@@ -70,7 +70,7 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "--rm",
             "-e", "${input:tfe_token}",
             "-e", "${input:tfe_address}",
-            "hashicorp/terraform-mcp-server:latest"
+            "hashicorp/terraform-mcp-server"
           ]
         }
       },
@@ -105,7 +105,7 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
           "--rm",
           "-e", "${input:tfe_token}",
           "-e", "${input:tfe_address}",
-          "hashicorp/terraform-mcp-server:latest"
+          "hashicorp/terraform-mcp-server"
         ]
       }
     },
@@ -146,7 +146,7 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "--rm",
             "-e", "<<TFE_ADDRESS_HERE>>",
             "-e", "<<TFE_TOKEN_HERE>>",
-            "hashicorp/terraform-mcp-server:latest"
+            "hashicorp/terraform-mcp-server"
           ]
         }
       }
@@ -178,7 +178,7 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "--rm",
             "-e", "<<TFE_ADDRESS_HERE>>",
             "-e", "<<TFE_TOKEN_HERE>>",
-            "hashicorp/terraform-mcp-server:latest"
+            "hashicorp/terraform-mcp-server"
           ]
         }
       }
@@ -209,7 +209,7 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "--rm",
             "-e", "<<TFE_ADDRESS_HERE>>",
             "-e", "<<TFE_TOKEN_HERE>>",
-            "hashicorp/terraform-mcp-server:latest"
+            "hashicorp/terraform-mcp-server"
           ]
         }
       }
@@ -244,7 +244,7 @@ Set the `tfe_token` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "hashicorp/terraform-mcp-server:latest"
+            "hashicorp/terraform-mcp-server"
           ]
         }
       }
@@ -263,7 +263,7 @@ Set the `tfe_token` environment variable to your HCP Terraform or Terraform Ente
           "run",
           "-i",
           "--rm",
-          "hashicorp/terraform-mcp-server:latest"
+          "hashicorp/terraform-mcp-server"
         ]
       }
     }
@@ -291,7 +291,7 @@ Set the `tfe_token` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "hashicorp/terraform-mcp-server:latest"
+            "hashicorp/terraform-mcp-server"
           ]
         }
       }
@@ -321,7 +321,7 @@ Set the `tfe_token` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "hashicorp/terraform-mcp-server:latest"
+            "hashicorp/terraform-mcp-server"
           ]
         }
       }
@@ -350,7 +350,7 @@ Set the `tfe_token` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "hashicorp/terraform-mcp-server:latest"
+            "hashicorp/terraform-mcp-server"
           ]
         }
       }


### PR DESCRIPTION
Remove the image version tag and use the default of "latest" for consistency.  We do with the same with  [Vault MCP Server example](https://developer.hashicorp.com/vault/docs/mcp-server/deploy#run-in-docker)
