### PR TITLE
correct formatting on terraform secrets engine documentation

### DIFF
--- a/content/vault/v1.21.x/content/docs/secrets/terraform.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/terraform.mdx
@@ -66,13 +66,14 @@ functions. An operator or configuration management tool usually completes these 
     to the `ttl` and `max_ttl` setting on the role.
 
     You need to know your Terraform team ID or user ID to generate API tokens for that client:
-        - To find your team ID, use the 
-        [HCP Terraform Teams API](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/teams) 
-        or navigate to the **Teams** section in the HCP Terraform GUI.
-        - To find a user ID, use the
-        [Account Details 
-        API](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/account#show-the-current-user) 
-        or check your user profile in the HCP Terraform GUI.
+    
+    - To find your team ID, use the 
+    [HCP Terraform Teams API](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/teams) 
+    or navigate to the **Teams** section in the HCP Terraform GUI.
+    - To find a user ID, use the
+    [Account Details 
+    API](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/account#show-the-current-user) 
+    or check your user profile in the HCP Terraform GUI.
 
     ```shell-session
     $ vault write terraform/role/my-team-role \


### PR DESCRIPTION
### What
Correct formatting for HCP Terraform Secrets Engine. One of the paragraphs was incorrectly formatted as a shell-session

### Why
A paragraph in step 3 of the Quick Start was incorrectly formatted as a shell-session

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] Description links to related pull requests or issues, if any.

#### Content
- [N/A] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [N/A] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [N/A] Pages with related content are updated and link to this content when appropriate.
- [N/A] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [N/A] New pages have metadata (page name and description) at the top.
- [N/A] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [N/A] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [N/A] UI elements (button names, page names, etc.) are bolded.
- [X] The Vercel website preview successfully deployed.

#### Reviews
- [X] I or someone else reviewed the content for technical accuracy.
- [X] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
