### PR TITLE
Vault Radar: Update supported secret types and activeness status

### DIFF
--- a/content/hcp-docs/content/docs/vault-radar/manage/secret-types.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/manage/secret-types.mdx
@@ -188,6 +188,7 @@ Secret description | Has activeness check |
 | --- | --- |
 | Basic Auth Header | False |
 
+
 ### `BITBUCKET_APP_PASSWORD`
 Secret description | Has activeness check |
 | --- | --- |
@@ -812,6 +813,11 @@ Secret description | Has activeness check |
 
 ## I
 
+### `IBM_CLOUD_IAM_API_KEY`
+Secret description | Has activeness check |
+| --- | --- |
+| IBM Cloud IAM API key | True |
+
 ### `IEX_SECRET_API_TOKEN`
 Secret description | Has activeness check |
 | --- | --- |
@@ -903,7 +909,7 @@ Secret description | Has activeness check |
 ### `MAILCHIMP_API_KEY`
 Secret description | Has activeness check |
 | --- | --- |
-| Mailchimp API key | False |
+| Mailchimp API key | True |
 
 ### `MAILGUN_PRIVATE_API_KEY`
 Secret description | Has activeness check |
@@ -1257,6 +1263,11 @@ Secret description | Has activeness check |
 | PyPi API token | False |
 
 ## R
+
+### `RANCHER_SECRET_KEY`
+Secret description | Has activeness check |
+| --- | --- |
+| Rancher secret key | False |
 
 ### `REALLY_SIMPLE_SYSTEMS_ACCESS_TOKEN`
 Secret description | Has activeness check |


### PR DESCRIPTION
## Description
Vault Radar can now detect IBM Cloud IAM API Key and Rancher secret key and also supports activeness checks for Mailchimp API Key. 

### Requested review scope:

- [x] Content touched by the PR _only_ (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

### Review urgency:

- [ ] ASAP (bug fixes, broken content, imminent releases)
- [x] 3 days (small changes, easy reviews)
- [ ] 1 week (default)
- [ ] Best effort (very non-urgent)

## All updates:

I have:

- [x] Verified that all status checks have passed
- [x] Verified that preview environment has successfully deployed
- [x] Verified appropriate `label` applied (`hcp` + `product name`)
- [x] Added all required reviewers (code owners and external)

## Content checklist (optional)

Please do these things before requesting a review. I have:

- [ ] Made any associated code repositories public
- [ ] Added the `hashicorp-education/teamName` to any additional code or example repos as repo admin
- [ ] Added redirects for any moved or removed pages
- [ ] Spell checked the tutorial(s)
- [ ] Followed the [unified style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] Linted code snippets (Details per language [here](https://github.com/hashicorp/engineering-docs/blob/master/writing/markdown.md#code-blocks))
- [ ] Checked the steps for completeness (no steps are implied or hidden)
- [ ] Looked at the local or vercel build and checked each new or changed page for:
  - display on the product curriculum page
  - callout box formatting
  - code block highlighting
  - right-hand navigation
  - next and back buttons
  - URL path
