### PR TITLE
docs: Fix broken images

### DIFF
--- a/content/boundary/v0.21.x/content/docs/architecture/high-availability.mdx
+++ b/content/boundary/v0.21.x/content/docs/architecture/high-availability.mdx
@@ -23,7 +23,6 @@ The following ports should be available:
 
 The general architecture for the server infrastructure requires 3 controllers and 3 workers. Note that it is possible to run a controller and worker within the same process, but the guide here assumes separate deployments. The documentation here uses virtual machines running on Amazon EC2 as the example environment, but this use case can be extrapolated to almost any cloud platform to suit operator needs:
 
-![](/img/boundary-network.png)
 ![Boundary network diagram](/img/boundary-network_light.png#light-theme-only)
 ![Boundary network diagram](/img/boundary-network_dark.png#dark-theme-only)
 

--- a/content/boundary/v0.21.x/content/docs/architecture/system-requirements.mdx
+++ b/content/boundary/v0.21.x/content/docs/architecture/system-requirements.mdx
@@ -109,7 +109,8 @@ requirements, you can update the default listening ports using the resource's
 
 </Note>
 
-![Boundary network](/img/boundary-network.png)
+![Boundary network](/img/boundary-network_light.png#light-theme-only)
+![Boundary network](/img/boundary-network_dark.png#dark-theme-only)
 
 | Source          | Destination                 | Default destination port | protocol  | Purpose                                 |
 | --------------- | --------------------------- | ------------------------ | --------- | --------------------------------------  |


### PR DESCRIPTION
The light/dark images are not showing correctly on the [High availability](https://developer.hashicorp.com/boundary/docs/architecture/high-availability#architecture) and [System requirements](https://developer.hashicorp.com/boundary/docs/architecture/system-requirements#network-connectivity) pages. This PR fixes them to properly display based on the user's settings.

View the preview deployment:

- [High availability](https://unified-docs-frontend-preview-4bivnmpy3-hashicorp.vercel.app/boundary/docs/architecture/high-availability#architecture)
- [System requirements](https://unified-docs-frontend-preview-4bivnmpy3-hashicorp.vercel.app/boundary/docs/architecture/system-requirements#network-connectivity)
