### PR TITLE
Nomad Docs

### DIFF
--- a/content/nomad/v1.11.x/content/docs/deploy/task-driver/qemu.mdx
+++ b/content/nomad/v1.11.x/content/docs/deploy/task-driver/qemu.mdx
@@ -44,7 +44,7 @@ The `qemu` driver will set the following client attributes:
 
 - `driver.qemu` - Set to `1` if QEMU is found on the host node. Nomad determines
   this by executing `qemu-system-x86_64 -version` on the host and parsing the output
-- `driver.qemu.version` - Version of `qemu-system-x86_64`, ex: `2.4.0`
+- `driver.qemu.version` - Version of `qemu.config.fingerprint_emulator`, ex: `2.4.0`
 
 Here is an example of using these properties in a job file:
 
@@ -78,6 +78,8 @@ plugin "qemu" {
   including flags that provide the VM with access to host devices such
   as USB drives. Refer to the [QEMU documentation] for the available
   flags.
+- `fingerprint_emulator` (`string`: `qemu-system-x86_64`) - Specifies
+  the emulator binary used to fingerprint QEMU on the Nomad client.
 
 ## Resource Isolation
 

--- a/content/nomad/v1.11.x/content/docs/job-declare/task-driver/qemu.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-declare/task-driver/qemu.mdx
@@ -15,7 +15,8 @@ host machine to the guest virtual machine, and provides configuration for
 resource allocation.
 
 The `qemu` driver can execute any regular `qemu` image (e.g. `qcow`, `img`,
-`iso`), and is currently invoked with `qemu-system-x86_64`.
+`iso`), and is invoked with the QEMU binary specified by the `emulator`
+parameter.
 
 The driver requires the image to be accessible from the Nomad client via the
 [`artifact` downloader](/nomad/docs/job-specification/artifact).
@@ -31,6 +32,7 @@ task "webservice" {
 
   config {
     image_path        = "/path/to/my/linux.img"
+    machine_type      = "q35"
     accelerator       = "kvm"
     graceful_shutdown = true
     args              = ["-nodefaults", "-nodefconfig"]
@@ -43,7 +45,12 @@ The `qemu` driver supports the following configuration in the job spec:
 - `image_path` - The path to the downloaded image. In most cases this will just
   be the name of the image. However, if the supplied artifact is an archive that
   contains the image in a subfolder, the path will need to be the relative path
-  (`subdir/from_archive/my.img`).
+  (`subdir/from_archive/my.img`). This image is given an ID of "image0".
+
+- `emulator` `(string: "qemu-system-x86_64")` - The QEMU emulator binary used to
+  run the virtual machine.
+
+- `machine_type` `(string: "pc")` - Used to select the emulated machine by name.
 
 - `drive_interface` - (Optional) This option defines on which type of interface
   the drive is connected. Available types are: `ide`, `scsi`, `sd`, `mtd`,

--- a/content/nomad/v1.11.x/content/docs/upgrade/upgrade-specific.mdx
+++ b/content/nomad/v1.11.x/content/docs/upgrade/upgrade-specific.mdx
@@ -24,10 +24,13 @@ you reserve at least the amount of disk that is used by the host OS.
 
 #### QEMU driver
 
-The QEMU driver now uses host file paths for filesystem environment variables
-instead of relative container paths such as `/alloc` and `/local`. You may need
-to update job specs utilizing these variables to reflect the new values.
-
+In Nomad 1.11.1, `emulator` and `machine_type` were added to the task config,
+and `fingerprint_emulator` was added to the driver config. These default to the
+previously used values of `qemu-system-x86_64`, and `pc`. Previously, when using
+the `kvm` accelerator, the machine type `host` was forced. This is no longer true,
+the value for `machine_type` will be used. Additionally, if using resources.cores,
+with the `kvm` accelerator, the `-smp` was hardcoded to that number of cores. This
+is now only done if the user has not specified a custom -smp flag.
 
 ## Nomad 1.11.0
 


### PR DESCRIPTION
<!--
**Merge branch**

Make sure you create your PR against the correct **base** branch. For instructions, refer to
GitHub's **Change the branch range and destination repository guide** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

If your content is an update to:

- Currently published content

  Choose **base: main** when you are updating published documentation, and you
  want your changes published when the PR is merged. We publish Nomad content
  from the `main` branch.

- Upcoming Nomad release

  Choose the branch for the Nomad release that your content is for. Nomad
  release branches use the `nomad/<exact-release-number>` format. If you are not
  able to find the upcoming Nomad release branch that you are looking for,
  contact the tech writer that works with the Nomad team.

- Upcoming Nomad release but not sure which one

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Put an explanation in the **Description** section.

  The tech writer coordinates with Nomad engineering and updates
  the docs PR base branch when the code is slotted into an upcoming release.

**Backports**

This repo stores previous version docs in folders instead of branches. There are
no backport labels.  If you backported your code PR to previous branches, update
the docs content in the corresponding folders. For example, if the current
release is 1.10.x and you backported your code to 1.9.x and 1.8.x, update the docs content
in the v1.10.x, v1.9.x, and v1.8.x folders. If you can't find the relevant files in previous versions,
add a note to your PR description. The tech writer will help ensure that the previous versions
receive the correct updates.
-->

## Description

<!-- 
Please describe why you're making this change and point out any important details the reviewers
should be aware of. A robust description helps the tech writer create a fabulous release note.
If your code PR has a splendid description, link to the code PR in the links section so that
the tech writer can update this PR's description. 

Include the target release as well as prior versions if applicable.
-->

## Links
<!--
**Please link to the related Nomad repo code PR!** if there is one. 
The tech writer does look at the code PR description, Jira ticket, and/or GH issue before reviewing docs content.

Include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a docs bug fix, please ensure related issues are linked so they will close when this PR is
merged.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [NMD-1234] 

GitHub Issue: <issue-link>

Deploy previews: The bot does publish a root-level link to the deploy preview, 
but it's nice to include a direct link to your content so the reviewers don't have to navigate to your pages.
-->

Nomad Code PR:
Jira:
GitHub Issue:
Deploy Previews:

## Contributor checklists

Review urgency:

- [x] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [ ] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
