### PR TITLE
Remove CDKTF tutorial link from all navbars and fix formatting of the deprecation notice. 

### DIFF
--- a/content/terraform-cdk/v0.10.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.10.x/data/cdktf-nav-data.json
@@ -2,10 +2,6 @@
   { "heading": "CDK for Terraform" },
   { "title": "Overview", "path": "" },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {

--- a/content/terraform-cdk/v0.11.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.11.x/data/cdktf-nav-data.json
@@ -2,10 +2,6 @@
   { "heading": "CDK for Terraform" },
   { "title": "Overview", "path": "" },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {

--- a/content/terraform-cdk/v0.12.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.12.x/data/cdktf-nav-data.json
@@ -2,10 +2,6 @@
   { "heading": "CDK for Terraform" },
   { "title": "Overview", "path": "" },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {
@@ -68,7 +64,7 @@
         "title": "Stacks",
         "path": "concepts/stacks"
       }
-      
+
     ]
   },
   { "title": "Examples and Guides", "path": "examples" },

--- a/content/terraform-cdk/v0.13.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.13.x/data/cdktf-nav-data.json
@@ -2,10 +2,6 @@
   { "heading": "CDK for Terraform" },
   { "title": "Overview", "path": "" },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {
@@ -68,7 +64,7 @@
         "title": "Stacks",
         "path": "concepts/stacks"
       }
-      
+
     ]
   },
   { "title": "Examples and Guides", "path": "examples" },

--- a/content/terraform-cdk/v0.14.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.14.x/data/cdktf-nav-data.json
@@ -2,10 +2,6 @@
   { "heading": "CDK for Terraform" },
   { "title": "Overview", "path": "" },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {
@@ -68,7 +64,7 @@
         "title": "Stacks",
         "path": "concepts/stacks"
       }
-      
+
     ]
   },
   { "title": "Examples and Guides", "path": "examples" },

--- a/content/terraform-cdk/v0.15.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.15.x/data/cdktf-nav-data.json
@@ -2,10 +2,6 @@
   { "heading": "CDK for Terraform" },
   { "title": "Overview", "path": "" },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {
@@ -68,11 +64,11 @@
         "title": "Stacks",
         "path": "concepts/stacks"
       }
-      
+
     ]
   },
-  { 
-    "title": "Examples and Guides", 
+  {
+    "title": "Examples and Guides",
     "routes": [
       {
         "title": "Examples",
@@ -82,7 +78,7 @@
         "title": "Refactoring Stacks",
         "path": "examples-and-guides/refactoring"
       }
-    ] 
+    ]
   },
   {
     "title": "Create and Deploy Applications",

--- a/content/terraform-cdk/v0.16.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.16.x/data/cdktf-nav-data.json
@@ -2,10 +2,6 @@
   { "heading": "CDK for Terraform" },
   { "title": "Overview", "path": "" },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {
@@ -68,11 +64,11 @@
         "title": "Stacks",
         "path": "concepts/stacks"
       }
-      
+
     ]
   },
-  { 
-    "title": "Examples and Guides", 
+  {
+    "title": "Examples and Guides",
     "routes": [
       {
         "title": "Examples",
@@ -82,7 +78,7 @@
         "title": "Refactoring Stacks",
         "path": "examples-and-guides/refactoring"
       }
-    ] 
+    ]
   },
   {
     "title": "Create and Deploy Applications",

--- a/content/terraform-cdk/v0.17.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.17.x/data/cdktf-nav-data.json
@@ -2,10 +2,6 @@
   { "heading": "CDK for Terraform" },
   { "title": "Overview", "path": "" },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {
@@ -68,11 +64,11 @@
         "title": "Stacks",
         "path": "concepts/stacks"
       }
-      
+
     ]
   },
-  { 
-    "title": "Examples and Guides", 
+  {
+    "title": "Examples and Guides",
     "routes": [
       {
         "title": "Examples",
@@ -82,7 +78,7 @@
         "title": "Refactoring Stacks",
         "path": "examples-and-guides/refactoring"
       }
-    ] 
+    ]
   },
   {
     "title": "Create and Deploy Applications",

--- a/content/terraform-cdk/v0.18.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.18.x/data/cdktf-nav-data.json
@@ -2,10 +2,6 @@
   { "heading": "CDK for Terraform" },
   { "title": "Overview", "path": "" },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {

--- a/content/terraform-cdk/v0.18.x/docs/partials/deprecated.mdx
+++ b/content/terraform-cdk/v0.18.x/docs/partials/deprecated.mdx
@@ -1,9 +1,5 @@
-<Note>
-
 <Highlight title="Deprecation announcement">
 
 The Cloud Development Kit for Terraform is deprecated as of December 10, 2025. HashiCorp no longer supports or maintains the Cloud Development Kit for Terraform.
 
 </Highlight>
-
-</Note>

--- a/content/terraform-cdk/v0.19.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.19.x/data/cdktf-nav-data.json
@@ -7,10 +7,6 @@
     "path": ""
   },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {

--- a/content/terraform-cdk/v0.19.x/docs/partials/deprecated.mdx
+++ b/content/terraform-cdk/v0.19.x/docs/partials/deprecated.mdx
@@ -1,9 +1,5 @@
-<Note>
-
 <Highlight title="Deprecation announcement">
 
 The Cloud Development Kit for Terraform is deprecated as of December 10, 2025. HashiCorp no longer supports or maintains the Cloud Development Kit for Terraform.
 
 </Highlight>
-
-</Note>

--- a/content/terraform-cdk/v0.20.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.20.x/data/cdktf-nav-data.json
@@ -7,10 +7,6 @@
     "path": ""
   },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {

--- a/content/terraform-cdk/v0.20.x/docs/partials/deprecated.mdx
+++ b/content/terraform-cdk/v0.20.x/docs/partials/deprecated.mdx
@@ -1,9 +1,5 @@
-<Note>
-
 <Highlight title="Deprecation announcement">
 
 The Cloud Development Kit for Terraform is deprecated as of December 10, 2025. HashiCorp no longer supports or maintains the Cloud Development Kit for Terraform.
 
 </Highlight>
-
-</Note>

--- a/content/terraform-cdk/v0.21.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.21.x/data/cdktf-nav-data.json
@@ -7,10 +7,6 @@
     "path": ""
   },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {

--- a/content/terraform-cdk/v0.21.x/docs/partials/deprecated.mdx
+++ b/content/terraform-cdk/v0.21.x/docs/partials/deprecated.mdx
@@ -1,9 +1,5 @@
-<Note>
-
 <Highlight title="Deprecation announcement">
 
 The Cloud Development Kit for Terraform is deprecated as of December 10, 2025. HashiCorp no longer supports or maintains the Cloud Development Kit for Terraform.
 
 </Highlight>
-
-</Note>

--- a/content/terraform-cdk/v0.8.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.8.x/data/cdktf-nav-data.json
@@ -2,10 +2,6 @@
   { "heading": "CDK for Terraform" },
   { "title": "Overview", "path": "" },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {

--- a/content/terraform-cdk/v0.9.x/data/cdktf-nav-data.json
+++ b/content/terraform-cdk/v0.9.x/data/cdktf-nav-data.json
@@ -2,10 +2,6 @@
   { "heading": "CDK for Terraform" },
   { "title": "Overview", "path": "" },
   {
-    "title": "Get Started",
-    "href": "https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf"
-  },
-  {
     "title": "Concepts",
     "routes": [
       {


### PR DESCRIPTION
### What
1. I removed the "Get Started" CDKTF URL from all the navbars to make it less appetizing to click on.
2. I also fixed the formatting of the note so it wouldn't be nested anymore. 

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [x] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
