### PR TITLE
Fix typo in kv-get command metadata flag

### DIFF
--- a/content/vault/v1.21.x/content/docs/ui/web-cli.mdx
+++ b/content/vault/v1.21.x/content/docs/ui/web-cli.mdx
@@ -48,7 +48,7 @@ REPL command | Associated CLI command                  | REPL differences
 `list`       | [`list`](/vault/docs/commands/list)     | Issues GET requests with the `?list=true` query parameter rather than `LIST` requests
 `read`       | [`read`](/vault/docs/commands/read)     | None
 `write`      | [`write`](/vault/docs/commands/write)   | Does not support `@` syntax to set parameters and actions that require data structures as input are not supported
-`kv-get`     | [`kv get`](/vault/docs/commands/kv/get) | Only supports path syntax and KVv2 plugins, supports the `-metatdata` flag as shorthand for `-field=metadata`
+`kv-get`     | [`kv get`](/vault/docs/commands/kv/get) | Only supports path syntax and KVv2 plugins, supports the `-metadata` flag as shorthand for `-field=metadata`
 
 ## REPL-specific commands
 


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
