### PR TITLE
Update Oracle release notes to reflect enterprise-only and external nature of the plugin

### DIFF
--- a/content/vault/v1.21.x/content/docs/secrets/databases/oracle/release-notes.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/databases/oracle/release-notes.mdx
@@ -9,9 +9,12 @@ description: >-
 
 # Release notes: Oracle plugin
 
+[ce_repo]: https://github.com/hashicorp/vault-plugin-database-oracle
+
 Current<br />version | Edition    | Runtime  | Code source
 :------------------: | ---------- | -------- | -----------
 `0.13.0`             | Enterprise | External | Binary: `vault-plugin-database-oracle*`
+`0.10.2`             | Community  | External | [hashicorp/vault-plugin-database-oracle][ce_repo]
 
 
 ## October 6, 2025


### PR DESCRIPTION
The Oracle Database Plugin is enterprise only and external - I removed mention of the CE plugin and changed the runtime to external