### PR TITLE
Remove LTS upgrade path information from documentation

### DIFF
--- a/content/vault/v1.21.x/content/docs/enterprise/lts.mdx
+++ b/content/vault/v1.21.x/content/docs/enterprise/lts.mdx
@@ -156,15 +156,6 @@ If you upgrade to a non-LTS version,you are moving your Vault instance to a vers
 that lacks extended support. Non-LTS versions stop receiving updates once they leave
 the standard maintenance window.
 
-@include 'ld-images/lts/lts-upgrade-path.mdx'
-
-Version | Expected release | Standard maintenance ends  | Extended maintenance ends
-------- | ---------------- | -------------------------- | ---------------------
-1.19    | CY25 Q1          | CY26 Q1 (1.22 release)     | CY27 Q1 (1.25 release)
-1.18    | CY24 Q3          | CY25 Q3 (1.21 release)     | Not provided
-1.17    | CY24 Q2          | CY25 Q2 (1.20 release)     | Not provided
-1.16    | CY24 Q1          | CY25 Q1 (1.19 release)     | CY26 Q1 (1.22 release)
-
 If a newer version of Vault Enterprise includes features you want to take
 advantage of, you have two options:
 


### PR DESCRIPTION
Removed the LTS upgrade path table and associated include directive. Eventually we need to fully replace/update the LTS overview page with the ERA transition plan. This is meant to be a band-aid until then as customers are getting confused based on the image/table info