### PR TITLE
adding compatibility for Atos HSM

### DIFF
--- a/content/vault/v1.21.x/content/docs/partners/hsm.mdx
+++ b/content/vault/v1.21.x/content/docs/partners/hsm.mdx
@@ -39,7 +39,7 @@ functionality.
 | Partner           | Product                                | Auto unseal | Entropy augment | Seal wrap | Managed keys | Vault verified
 | ----------------- | -------------------------------------- | ----------- | --------------- | --------- |------------- | -------------
 | AliCloud          | AliCloud KMS                           | Yes         | **No**          | Yes       | **No**       | 0.11.2+
-| Atos              | Trustway Proteccio HSM                 | Yes         | Yes             | Yes       | **No**       | 1.9+
+| Atos              | Trustway Proteccio HSM                 | Yes         | Yes             | Yes       | Yes          | 1.20.4+
 | AWS               | AWS KMS                                | Yes         | Yes             | Yes       | Yes          | 0.9+
 | Blockdaemon       | Blockdaemon Builder Vault              | Yes         | **No**          | Yes       | **No**       | 1.17.5+          
 | Crypto4a          | QxEDGE&tm; HSP                         | Yes         | Yes             | Yes       | Yes          | 1.9+
@@ -66,7 +66,7 @@ functionality.
 <span style={{display:'block', textAlign:'right', fontSize:'12px'}}>
   <em>
     <b>Last Updated</b>:
-    May 03, 2023
+    January 09, 2026
   </em>
 </span>
 


### PR DESCRIPTION
DO NOT MERGE YET.
PR must be validated by R&D.

This PR changes the compatibility Matrix in order to show Vault compatibility with ATOS Trustway Proteccio HSM on Managed Keys feature as demonstrated by partner.