### PR TITLE
Clarifies that all decoders are applied

### DIFF
--- a/content/vault/v1.17.x/content/docs/configuration/listener/tcp/index.mdx
+++ b/content/vault/v1.17.x/content/docs/configuration/listener/tcp/index.mdx
@@ -265,19 +265,23 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   vault server is behind a reverse proxy.
 
 - `x_forwarded_for_client_cert_header_decoders` `(string: "")` –
-  Comma delimited list that specifies the decoders that will be used to decode the client certificate.
-  This is required if you use the [TLS Certificates Auth Method](/vault/docs/auth/cert) and your
-  vault server is behind a reverse proxy. The resulting certificate should be in DER format.
-  Available Values:
+  Comma delimited list that specifies the decoders that applied in order fully decode the client
+  certificate.  This is required if you use the
+  [TLS Certificates Auth Method](/vault/docs/auth/cert) and your vault server is behind a
+  reverse proxy. The resulting certificate should be in DER format. Available Values:
 
   - BASE64 - Runs Base64 decode
-  - DER - Converts a pem certificate to der
+  - DER - Converts a PEM certificate to DER
   - URL - Runs URL decode
 
   Known Values:
 
   - Traefik = "BASE64"
   - NGINX   = "URL,DER"
+
+  ~> **Warning**: while named "DER", the DER decoder builds the DER certificate out of a PEM
+  bundle.  It should always be applied last, and is only appropriate to use if the client
+  certificate includes the PEM wrapping (for instance, starting with `----- BEGIN`)
 
 - `x_forwarded_for_hop_skips` `(string: "0")` – The number of addresses that will be
   skipped from the _rear_ of the set of hops. For instance, for a header value

--- a/content/vault/v1.18.x/content/docs/configuration/listener/tcp/index.mdx
+++ b/content/vault/v1.18.x/content/docs/configuration/listener/tcp/index.mdx
@@ -266,19 +266,23 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   vault server is behind a reverse proxy.
 
 - `x_forwarded_for_client_cert_header_decoders` `(string: "")` –
-  Comma delimited list that specifies the decoders that will be used to decode the client certificate.
-  This is required if you use the [TLS Certificates Auth Method](/vault/docs/auth/cert) and your
-  vault server is behind a reverse proxy. The resulting certificate should be in DER format.
-  Available Values:
+  Comma delimited list that specifies the decoders that applied in order fully decode the client
+  certificate.  This is required if you use the
+  [TLS Certificates Auth Method](/vault/docs/auth/cert) and your vault server is behind a
+  reverse proxy. The resulting certificate should be in DER format. Available Values:
 
   - BASE64 - Runs Base64 decode
-  - DER - Converts a pem certificate to der
+  - DER - Converts a PEM certificate to DER
   - URL - Runs URL decode
 
   Known Values:
 
   - Traefik = "BASE64"
   - NGINX   = "URL,DER"
+
+  ~> **Warning**: while named "DER", the DER decoder builds the DER certificate out of a PEM
+  bundle.  It should always be applied last, and is only appropriate to use if the client
+  certificate includes the PEM wrapping (for instance, starting with `----- BEGIN`)
 
 - `x_forwarded_for_hop_skips` `(string: "0")` – The number of addresses that will be
   skipped from the _rear_ of the set of hops. For instance, for a header value

--- a/content/vault/v1.19.x/content/docs/configuration/listener/tcp/index.mdx
+++ b/content/vault/v1.19.x/content/docs/configuration/listener/tcp/index.mdx
@@ -266,19 +266,23 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   vault server is behind a reverse proxy.
 
 - `x_forwarded_for_client_cert_header_decoders` `(string: "")` –
-  Comma delimited list that specifies the decoders that will be used to decode the client certificate.
-  This is required if you use the [TLS Certificates Auth Method](/vault/docs/auth/cert) and your
-  vault server is behind a reverse proxy. The resulting certificate should be in DER format.
-  Available Values:
+  Comma delimited list that specifies the decoders that applied in order fully decode the client
+  certificate.  This is required if you use the
+  [TLS Certificates Auth Method](/vault/docs/auth/cert) and your vault server is behind a
+  reverse proxy. The resulting certificate should be in DER format. Available Values:
 
   - BASE64 - Runs Base64 decode
-  - DER - Converts a pem certificate to der
+  - DER - Converts a PEM certificate to DER
   - URL - Runs URL decode
 
   Known Values:
 
   - Traefik = "BASE64"
   - NGINX   = "URL,DER"
+
+  ~> **Warning**: while named "DER", the DER decoder builds the DER certificate out of a PEM
+  bundle.  It should always be applied last, and is only appropriate to use if the client
+  certificate includes the PEM wrapping (for instance, starting with `----- BEGIN`)
 
 - `x_forwarded_for_hop_skips` `(string: "0")` – The number of addresses that will be
   skipped from the _rear_ of the set of hops. For instance, for a header value

--- a/content/vault/v1.20.x/content/docs/configuration/listener/tcp/index.mdx
+++ b/content/vault/v1.20.x/content/docs/configuration/listener/tcp/index.mdx
@@ -266,19 +266,23 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   vault server is behind a reverse proxy.
 
 - `x_forwarded_for_client_cert_header_decoders` `(string: "")` –
-  Comma delimited list that specifies the decoders that will be used to decode the client certificate.
-  This is required if you use the [TLS Certificates Auth Method](/vault/docs/auth/cert) and your
-  vault server is behind a reverse proxy. The resulting certificate should be in DER format.
-  Available Values:
+  Comma delimited list that specifies the decoders that applied in order fully decode the client
+  certificate.  This is required if you use the
+  [TLS Certificates Auth Method](/vault/docs/auth/cert) and your vault server is behind a
+  reverse proxy. The resulting certificate should be in DER format. Available Values:
 
   - BASE64 - Runs Base64 decode
-  - DER - Converts a pem certificate to der
+  - DER - Converts a PEM certificate to DER
   - URL - Runs URL decode
 
   Known Values:
 
   - Traefik = "BASE64"
   - NGINX   = "URL,DER"
+
+  ~> **Warning**: while named "DER", the DER decoder builds the DER certificate out of a PEM
+  bundle.  It should always be applied last, and is only appropriate to use if the client
+  certificate includes the PEM wrapping (for instance, starting with `----- BEGIN`)
 
 - `x_forwarded_for_hop_skips` `(string: "0")` – The number of addresses that will be
   skipped from the _rear_ of the set of hops. For instance, for a header value

--- a/content/vault/v1.21.x/content/docs/configuration/listener/tcp/index.mdx
+++ b/content/vault/v1.21.x/content/docs/configuration/listener/tcp/index.mdx
@@ -266,19 +266,23 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   vault server is behind a reverse proxy.
 
 - `x_forwarded_for_client_cert_header_decoders` `(string: "")` –
-  Comma delimited list that specifies the decoders that will be used to decode the client certificate.
-  This is required if you use the [TLS Certificates Auth Method](/vault/docs/auth/cert) and your
-  vault server is behind a reverse proxy. The resulting certificate should be in DER format.
-  Available Values:
+  Comma delimited list that specifies the decoders that applied in order fully decode the client
+  certificate.  This is required if you use the
+  [TLS Certificates Auth Method](/vault/docs/auth/cert) and your vault server is behind a
+  reverse proxy. The resulting certificate should be in DER format. Available Values:
 
   - BASE64 - Runs Base64 decode
-  - DER - Converts a pem certificate to der
+  - DER - Converts a PEM certificate to DER
   - URL - Runs URL decode
 
   Known Values:
 
   - Traefik = "BASE64"
   - NGINX   = "URL,DER"
+
+  ~> **Warning**: while named "DER", the DER decoder builds the DER certificate out of a PEM
+  bundle.  It should always be applied last, and is only appropriate to use if the client
+  certificate includes the PEM wrapping (for instance, starting with `----- BEGIN`)
 
 - `x_forwarded_for_hop_skips` `(string: "0")` – The number of addresses that will be
   skipped from the _rear_ of the set of hops. For instance, for a header value


### PR DESCRIPTION
Recently a customer had issues with setting up X-Forwarded-For (vault behind a reverse proxy), and one of those issues was using a series of decoders "one of which should work".  Then leaving in DER (since the certificate was underneath it all a DER certificate).  The engineer and support were likewise confused.  This clarifies wording on how the decoders work - that each of them are run in order, and that the "DER" decoder is really a "PEM" decoder.
