### PR TITLE
Stacks CLI: link to subcommands from docs index

### DIFF
--- a/content/terraform/v1.13.x/docs/cli/commands/stacks/index.mdx
+++ b/content/terraform/v1.13.x/docs/cli/commands/stacks/index.mdx
@@ -13,19 +13,19 @@ The `terraform stacks` command lets you manage Terraform Stacks. Use the followi
 
 ## Commands
 
-- `init` - Initialize the Stack and prepare the configuration directory for further commands.
-- `validate` - Checks whether the local component and deployment configurations are valid.
-- `create` - Create a Stack in HCP Terraform.
-- `list` - List Stacks for a given organization or project.
-- `version` - Show the current Stacks plugin version.
-- `providers-lock` - Write out dependency locks for the providers your Stack configures.
-- `fmt` - Reformat your component configuration and deployment configuration to a canonical format.
+- [`init`](/terraform/cli/commands/stacks/init) - Initialize the Stack and prepare the configuration directory for further commands.
+- [`validate`](/terraform/cli/commands/stacks/validate) - Checks whether the local component and deployment configurations are valid.
+- [`create`](/terraform/cli/commands/stacks/create) - Create a Stack in HCP Terraform.
+- [`list`](/terraform/cli/commands/stacks/list) - List Stacks for a given organization or project.
+- [`version`](/terraform/cli/commands/stacks/version) - Show the current Stacks plugin version.
+- [`providers-lock`](/terraform/cli/commands/stacks/providers-lock) - Write out dependency locks for the providers your Stack configures.
+- [`fmt`](/terraform/cli/commands/stacks/fmt) - Reformat your component configuration and deployment configuration to a canonical format.
 
 ## Subcommands
 
-- `deployment-run` - Manage deployment runs for a Stack deployment.
-- `deployment-group` - Manage deployment groups.
-- `configuration` - Manage Stack configuration versions.
+- [`deployment-run`](/terraform/cli/commands/stacks/deployment-run) - Manage deployment runs for a Stack deployment.
+- [`deployment-group`](/terraform/cli/commands/stacks/deployment-group) - Manage deployment groups.
+- [`configuration`](/terraform/cli/commands/stacks/configuration) - Manage Stack configuration versions.
 
 ## Global flags
 

--- a/content/terraform/v1.14.x/docs/cli/commands/stacks/index.mdx
+++ b/content/terraform/v1.14.x/docs/cli/commands/stacks/index.mdx
@@ -13,19 +13,19 @@ The `terraform stacks` command lets you manage Terraform Stacks. Use the followi
 
 ## Commands
 
-- `init` - Initialize the Stack and prepare the configuration directory for further commands.
-- `validate` - Checks whether the local component and deployment configurations are valid.
-- `create` - Create a Stack in HCP Terraform.
-- `list` - List Stacks for a given organization or project.
-- `version` - Show the current Stacks plugin version.
-- `providers-lock` - Write out dependency locks for the providers your Stack configures.
-- `fmt` - Reformat your component configuration and deployment configuration to a canonical format.
+- [`init`](/terraform/cli/commands/stacks/init) - Initialize the Stack and prepare the configuration directory for further commands.
+- [`validate`](/terraform/cli/commands/stacks/validate) - Checks whether the local component and deployment configurations are valid.
+- [`create`](/terraform/cli/commands/stacks/create) - Create a Stack in HCP Terraform.
+- [`list`](/terraform/cli/commands/stacks/list) - List Stacks for a given organization or project.
+- [`version`](/terraform/cli/commands/stacks/version) - Show the current Stacks plugin version.
+- [`providers-lock`](/terraform/cli/commands/stacks/providers-lock) - Write out dependency locks for the providers your Stack configures.
+- [`fmt`](/terraform/cli/commands/stacks/fmt) - Reformat your component configuration and deployment configuration to a canonical format.
 
 ## Subcommands
 
-- `deployment-run` - Manage deployment runs for a Stack deployment.
-- `deployment-group` - Manage deployment groups.
-- `configuration` - Manage Stack configuration versions.
+- [`deployment-run`](/terraform/cli/commands/stacks/deployment-run) - Manage deployment runs for a Stack deployment.
+- [`deployment-group`](/terraform/cli/commands/stacks/deployment-group) - Manage deployment groups.
+- [`configuration`](/terraform/cli/commands/stacks/configuration) - Manage Stack configuration versions.
 
 ## Global flags
 

--- a/content/terraform/v1.15.x (alpha)/docs/cli/commands/stacks/index.mdx
+++ b/content/terraform/v1.15.x (alpha)/docs/cli/commands/stacks/index.mdx
@@ -13,19 +13,19 @@ The `terraform stacks` command lets you manage Terraform Stacks. Use the followi
 
 ## Commands
 
-- `init` - Initialize the Stack and prepare the configuration directory for further commands.
-- `validate` - Checks whether the local component and deployment configurations are valid.
-- `create` - Create a Stack in HCP Terraform.
-- `list` - List Stacks for a given organization or project.
-- `version` - Show the current Stacks plugin version.
-- `providers-lock` - Write out dependency locks for the providers your Stack configures.
-- `fmt` - Reformat your component configuration and deployment configuration to a canonical format.
+- [`init`](/terraform/cli/commands/stacks/init) - Initialize the Stack and prepare the configuration directory for further commands.
+- [`validate`](/terraform/cli/commands/stacks/validate) - Checks whether the local component and deployment configurations are valid.
+- [`create`](/terraform/cli/commands/stacks/create) - Create a Stack in HCP Terraform.
+- [`list`](/terraform/cli/commands/stacks/list) - List Stacks for a given organization or project.
+- [`version`](/terraform/cli/commands/stacks/version) - Show the current Stacks plugin version.
+- [`providers-lock`](/terraform/cli/commands/stacks/providers-lock) - Write out dependency locks for the providers your Stack configures.
+- [`fmt`](/terraform/cli/commands/stacks/fmt) - Reformat your component configuration and deployment configuration to a canonical format.
 
 ## Subcommands
 
-- `deployment-run` - Manage deployment runs for a Stack deployment.
-- `deployment-group` - Manage deployment groups.
-- `configuration` - Manage Stack configuration versions.
+- [`deployment-run`](/terraform/cli/commands/stacks/deployment-run) - Manage deployment runs for a Stack deployment.
+- [`deployment-group`](/terraform/cli/commands/stacks/deployment-group) - Manage deployment groups.
+- [`configuration`](/terraform/cli/commands/stacks/configuration) - Manage Stack configuration versions.
 
 ## Global flags
 


### PR DESCRIPTION
### What
Added links to stacks cli subcommand pages from stacks cli index.

### Why
The backticks used to list each subcommand renders links that go to nowhere; we want users to be able to navigate more easily.

