### PR TITLE
Fix LDAP Secrets Engine Example Commands

### DIFF
--- a/content/vault/v1.19.x/content/partials/ldap/account-checkin/api.mdx
+++ b/content/vault/v1.19.x/content/partials/ldap/account-checkin/api.mdx
@@ -1,13 +1,14 @@
 Make a `POST` call to
-[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-out-management)
-to request a service account:
+[`{mount_path}/library/{set_name}/check-in`](/vault/api-docs/secret/ldap#check-in-management)
+with the service account name to return the service account:
 
 ```shell-session
-$ curl                                                \
-  --request POST                                      \
-  --header    "X-Vault-Token: ${VAULT_TOKEN}"         \
-  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}" \
-  ${VAULT_ADDR}/v1/<mount_path>/library/<set_name>/checkout
+$ curl                                                     \
+  --request POST                                           \
+  --header    "X-Vault-Token: ${VAULT_TOKEN}"              \
+  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}"      \
+  --data '{"service_account_names": [<account_list>]}'     \
+  ${VAULT_ADDR}/v1/<mount_path>/library/<set_name>/check-in
 ```
 
 For example:
@@ -15,18 +16,21 @@ For example:
 <CodeBlockConfig hideClipboard="true" highlight="5">
 
 ```shell-session
-$ curl                                                \
-  --request POST                                      \
-  --header    "X-Vault-Token: ${VAULT_TOKEN}"         \
-  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}" \
-  ${VAULT_ADDR}/v1/devcreds/library/accounting-team/checkout
+$ curl                                                     \
+  --request POST                                           \
+  --header    "X-Vault-Token: ${VAULT_TOKEN}"              \
+  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}"      \
+  --data '{"service_account_names": ["fizz@example.com"]}' \
+  ${VAULT_ADDR}/v1/devcreds/library/accounting-team/check-in
 ```
 
 </CodeBlockConfig>
 
+
 <Tip>
 
-If the caller only has one account checked out, you can omit the account list
-and make an empty POST call to the endpoint.
+If the default checkout time is longer than you need, provide an explict `ttl`
+value so Vault can reclaim the account sooner if it becomes abandoned for some
+reason.
 
 </Tip>

--- a/content/vault/v1.19.x/content/partials/ldap/account-checkin/cli.mdx
+++ b/content/vault/v1.19.x/content/partials/ldap/account-checkin/cli.mdx
@@ -1,10 +1,9 @@
-Use `vault write` with the service account name and
-[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-in-management)
+Use `vault write` with the `-f` flag and
+[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-out-management)
 path to request a service account:
 
 ```shell-session
-$ vault write <mount_path>/library/<set_name>/check-in \
-  service_account_names=[<account_list>]
+$ vault write -f <mount_path>/library/<set_name>/check-out
 ```
 
 For example:
@@ -12,15 +11,24 @@ For example:
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ vault write -f devcreds/library/accounting-team/check-in \
-  service_account_names=["fizz@example.com"]
+$ vault write -f devcreds/library/accounting-team/check-out
+
+Key                     Value
+---                     -----
+lease_id                devcreds/library/accounting-team/check-out/EpuS8cX7uEsDzOwW9kkKOyGW
+lease_duration          10h
+lease_renewable         true
+password                ?@09AZKh03hBORZPJcTDgLfntlHqxLy29tcQjPVThzuwWAx/Twx4a2ZcRQRqrZ1w
+service_account_name    fizz@example.com
 ```
 
 </CodeBlockConfig>
 
+
 <Tip>
 
-If the caller only has one account checked out, you can omit the account list
-and use the `-f` flag to call the endpoint without explicit parameters.
+If the default checkout time is longer than you need, omit the `-f` flag and
+provide an explict `ttl` value so Vault can reclaim the account sooner if it
+becomes abandoned for some reason.
 
 </Tip>

--- a/content/vault/v1.19.x/content/partials/ldap/account-checkout/api.mdx
+++ b/content/vault/v1.19.x/content/partials/ldap/account-checkout/api.mdx
@@ -1,14 +1,13 @@
 Make a `POST` call to
-[`{mount_path}/library/{set_name}/check-in`](/vault/api-docs/secret/ldap#check-in-management)
-with the service account name to return the service account:
+[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-out-management)
+to request a service account:
 
 ```shell-session
-$ curl                                                     \
-  --request POST                                           \
-  --header    "X-Vault-Token: ${VAULT_TOKEN}"              \
-  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}"      \
-  --data '{"service_account_names": [<account_list>]}'     \
-  ${VAULT_ADDR}/v1/<mount_path>/library/<set_name>/check-in
+$ curl                                                \
+  --request POST                                      \
+  --header    "X-Vault-Token: ${VAULT_TOKEN}"         \
+  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}" \
+  ${VAULT_ADDR}/v1/<mount_path>/library/<set_name>/check-out
 ```
 
 For example:
@@ -16,21 +15,18 @@ For example:
 <CodeBlockConfig hideClipboard="true" highlight="5">
 
 ```shell-session
-$ curl                                                     \
-  --request POST                                           \
-  --header    "X-Vault-Token: ${VAULT_TOKEN}"              \
-  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}"      \
-  --data '{"service_account_names": ["fizz@example.com"]}' \
-  ${VAULT_ADDR}/v1/devcreds/library/accounting-team/check-in
+$ curl                                                \
+  --request POST                                      \
+  --header    "X-Vault-Token: ${VAULT_TOKEN}"         \
+  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}" \
+  ${VAULT_ADDR}/v1/devcreds/library/accounting-team/check-out
 ```
 
 </CodeBlockConfig>
 
-
 <Tip>
 
-If the default checkout time is longer than you need, provide an explict `ttl`
-value so Vault can reclaim the account sooner if it becomes abandoned for some
-reason.
+If the caller only has one account checked out, you can omit the account list
+and make an empty POST call to the endpoint.
 
 </Tip>

--- a/content/vault/v1.19.x/content/partials/ldap/account-checkout/cli.mdx
+++ b/content/vault/v1.19.x/content/partials/ldap/account-checkout/cli.mdx
@@ -1,9 +1,10 @@
-Use `vault write` with the `-f` flag and
-[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-out-management)
+Use `vault write` with the service account name and
+[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-in-management)
 path to request a service account:
 
 ```shell-session
-$ vault write -f <mount_path>/library/<set_name>/check-out
+$ vault write <mount_path>/library/<set_name>/check-in \
+  service_account_names=[<account_list>]
 ```
 
 For example:
@@ -11,24 +12,15 @@ For example:
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ vault write -f devcreds/library/accounting-team/check-out
-
-Key                     Value
----                     -----
-lease_id                devcreds/library/accounting-team/check-out/EpuS8cX7uEsDzOwW9kkKOyGW
-lease_duration          10h
-lease_renewable         true
-password                ?@09AZKh03hBORZPJcTDgLfntlHqxLy29tcQjPVThzuwWAx/Twx4a2ZcRQRqrZ1w
-service_account_name    fizz@example.com
+$ vault write -f devcreds/library/accounting-team/check-in \
+  service_account_names=["fizz@example.com"]
 ```
 
 </CodeBlockConfig>
 
-
 <Tip>
 
-If the default checkout time is longer than you need, omit the `-f` flag and
-provide an explict `ttl` value so Vault can reclaim the account sooner if it
-becomes abandoned for some reason.
+If the caller only has one account checked out, you can omit the account list
+and use the `-f` flag to call the endpoint without explicit parameters.
 
 </Tip>

--- a/content/vault/v1.20.x/content/partials/ldap/account-checkin/api.mdx
+++ b/content/vault/v1.20.x/content/partials/ldap/account-checkin/api.mdx
@@ -1,13 +1,14 @@
 Make a `POST` call to
-[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-out-management)
-to request a service account:
+[`{mount_path}/library/{set_name}/check-in`](/vault/api-docs/secret/ldap#check-in-management)
+with the service account name to return the service account:
 
 ```shell-session
-$ curl                                                \
-  --request POST                                      \
-  --header    "X-Vault-Token: ${VAULT_TOKEN}"         \
-  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}" \
-  ${VAULT_ADDR}/v1/<mount_path>/library/<set_name>/checkout
+$ curl                                                     \
+  --request POST                                           \
+  --header    "X-Vault-Token: ${VAULT_TOKEN}"              \
+  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}"      \
+  --data '{"service_account_names": [<account_list>]}'     \
+  ${VAULT_ADDR}/v1/<mount_path>/library/<set_name>/check-in
 ```
 
 For example:
@@ -15,18 +16,21 @@ For example:
 <CodeBlockConfig hideClipboard="true" highlight="5">
 
 ```shell-session
-$ curl                                                \
-  --request POST                                      \
-  --header    "X-Vault-Token: ${VAULT_TOKEN}"         \
-  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}" \
-  ${VAULT_ADDR}/v1/devcreds/library/accounting-team/checkout
+$ curl                                                     \
+  --request POST                                           \
+  --header    "X-Vault-Token: ${VAULT_TOKEN}"              \
+  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}"      \
+  --data '{"service_account_names": ["fizz@example.com"]}' \
+  ${VAULT_ADDR}/v1/devcreds/library/accounting-team/check-in
 ```
 
 </CodeBlockConfig>
 
+
 <Tip>
 
-If the caller only has one account checked out, you can omit the account list
-and make an empty POST call to the endpoint.
+If the default checkout time is longer than you need, provide an explict `ttl`
+value so Vault can reclaim the account sooner if it becomes abandoned for some
+reason.
 
 </Tip>

--- a/content/vault/v1.20.x/content/partials/ldap/account-checkin/cli.mdx
+++ b/content/vault/v1.20.x/content/partials/ldap/account-checkin/cli.mdx
@@ -1,10 +1,9 @@
-Use `vault write` with the service account name and
-[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-in-management)
+Use `vault write` with the `-f` flag and
+[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-out-management)
 path to request a service account:
 
 ```shell-session
-$ vault write <mount_path>/library/<set_name>/check-in \
-  service_account_names=[<account_list>]
+$ vault write -f <mount_path>/library/<set_name>/check-out
 ```
 
 For example:
@@ -12,15 +11,24 @@ For example:
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ vault write -f devcreds/library/accounting-team/check-in \
-  service_account_names=["fizz@example.com"]
+$ vault write -f devcreds/library/accounting-team/check-out
+
+Key                     Value
+---                     -----
+lease_id                devcreds/library/accounting-team/check-out/EpuS8cX7uEsDzOwW9kkKOyGW
+lease_duration          10h
+lease_renewable         true
+password                ?@09AZKh03hBORZPJcTDgLfntlHqxLy29tcQjPVThzuwWAx/Twx4a2ZcRQRqrZ1w
+service_account_name    fizz@example.com
 ```
 
 </CodeBlockConfig>
 
+
 <Tip>
 
-If the caller only has one account checked out, you can omit the account list
-and use the `-f` flag to call the endpoint without explicit parameters.
+If the default checkout time is longer than you need, omit the `-f` flag and
+provide an explict `ttl` value so Vault can reclaim the account sooner if it
+becomes abandoned for some reason.
 
 </Tip>

--- a/content/vault/v1.20.x/content/partials/ldap/account-checkout/api.mdx
+++ b/content/vault/v1.20.x/content/partials/ldap/account-checkout/api.mdx
@@ -1,14 +1,13 @@
 Make a `POST` call to
-[`{mount_path}/library/{set_name}/check-in`](/vault/api-docs/secret/ldap#check-in-management)
-with the service account name to return the service account:
+[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-out-management)
+to request a service account:
 
 ```shell-session
-$ curl                                                     \
-  --request POST                                           \
-  --header    "X-Vault-Token: ${VAULT_TOKEN}"              \
-  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}"      \
-  --data '{"service_account_names": [<account_list>]}'     \
-  ${VAULT_ADDR}/v1/<mount_path>/library/<set_name>/check-in
+$ curl                                                \
+  --request POST                                      \
+  --header    "X-Vault-Token: ${VAULT_TOKEN}"         \
+  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}" \
+  ${VAULT_ADDR}/v1/<mount_path>/library/<set_name>/check-out
 ```
 
 For example:
@@ -16,21 +15,18 @@ For example:
 <CodeBlockConfig hideClipboard="true" highlight="5">
 
 ```shell-session
-$ curl                                                     \
-  --request POST                                           \
-  --header    "X-Vault-Token: ${VAULT_TOKEN}"              \
-  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}"      \
-  --data '{"service_account_names": ["fizz@example.com"]}' \
-  ${VAULT_ADDR}/v1/devcreds/library/accounting-team/check-in
+$ curl                                                \
+  --request POST                                      \
+  --header    "X-Vault-Token: ${VAULT_TOKEN}"         \
+  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}" \
+  ${VAULT_ADDR}/v1/devcreds/library/accounting-team/check-out
 ```
 
 </CodeBlockConfig>
 
-
 <Tip>
 
-If the default checkout time is longer than you need, provide an explict `ttl`
-value so Vault can reclaim the account sooner if it becomes abandoned for some
-reason.
+If the caller only has one account checked out, you can omit the account list
+and make an empty POST call to the endpoint.
 
 </Tip>

--- a/content/vault/v1.20.x/content/partials/ldap/account-checkout/cli.mdx
+++ b/content/vault/v1.20.x/content/partials/ldap/account-checkout/cli.mdx
@@ -1,9 +1,10 @@
-Use `vault write` with the `-f` flag and
-[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-out-management)
+Use `vault write` with the service account name and
+[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-in-management)
 path to request a service account:
 
 ```shell-session
-$ vault write -f <mount_path>/library/<set_name>/check-out
+$ vault write <mount_path>/library/<set_name>/check-in \
+  service_account_names=[<account_list>]
 ```
 
 For example:
@@ -11,24 +12,15 @@ For example:
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ vault write -f devcreds/library/accounting-team/check-out
-
-Key                     Value
----                     -----
-lease_id                devcreds/library/accounting-team/check-out/EpuS8cX7uEsDzOwW9kkKOyGW
-lease_duration          10h
-lease_renewable         true
-password                ?@09AZKh03hBORZPJcTDgLfntlHqxLy29tcQjPVThzuwWAx/Twx4a2ZcRQRqrZ1w
-service_account_name    fizz@example.com
+$ vault write -f devcreds/library/accounting-team/check-in \
+  service_account_names=["fizz@example.com"]
 ```
 
 </CodeBlockConfig>
 
-
 <Tip>
 
-If the default checkout time is longer than you need, omit the `-f` flag and
-provide an explict `ttl` value so Vault can reclaim the account sooner if it
-becomes abandoned for some reason.
+If the caller only has one account checked out, you can omit the account list
+and use the `-f` flag to call the endpoint without explicit parameters.
 
 </Tip>

--- a/content/vault/v1.21.x/content/partials/ldap/account-checkin/api.mdx
+++ b/content/vault/v1.21.x/content/partials/ldap/account-checkin/api.mdx
@@ -1,13 +1,14 @@
 Make a `POST` call to
-[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-out-management)
-to request a service account:
+[`{mount_path}/library/{set_name}/check-in`](/vault/api-docs/secret/ldap#check-in-management)
+with the service account name to return the service account:
 
 ```shell-session
-$ curl                                                \
-  --request POST                                      \
-  --header    "X-Vault-Token: ${VAULT_TOKEN}"         \
-  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}" \
-  ${VAULT_ADDR}/v1/<mount_path>/library/<set_name>/checkout
+$ curl                                                     \
+  --request POST                                           \
+  --header    "X-Vault-Token: ${VAULT_TOKEN}"              \
+  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}"      \
+  --data '{"service_account_names": [<account_list>]}'     \
+  ${VAULT_ADDR}/v1/<mount_path>/library/<set_name>/check-in
 ```
 
 For example:
@@ -15,18 +16,21 @@ For example:
 <CodeBlockConfig hideClipboard="true" highlight="5">
 
 ```shell-session
-$ curl                                                \
-  --request POST                                      \
-  --header    "X-Vault-Token: ${VAULT_TOKEN}"         \
-  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}" \
-  ${VAULT_ADDR}/v1/devcreds/library/accounting-team/checkout
+$ curl                                                     \
+  --request POST                                           \
+  --header    "X-Vault-Token: ${VAULT_TOKEN}"              \
+  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}"      \
+  --data '{"service_account_names": ["fizz@example.com"]}' \
+  ${VAULT_ADDR}/v1/devcreds/library/accounting-team/check-in
 ```
 
 </CodeBlockConfig>
 
+
 <Tip>
 
-If the caller only has one account checked out, you can omit the account list
-and make an empty POST call to the endpoint.
+If the default checkout time is longer than you need, provide an explict `ttl`
+value so Vault can reclaim the account sooner if it becomes abandoned for some
+reason.
 
 </Tip>

--- a/content/vault/v1.21.x/content/partials/ldap/account-checkin/cli.mdx
+++ b/content/vault/v1.21.x/content/partials/ldap/account-checkin/cli.mdx
@@ -1,10 +1,9 @@
-Use `vault write` with the service account name and
-[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-in-management)
+Use `vault write` with the `-f` flag and
+[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-out-management)
 path to request a service account:
 
 ```shell-session
-$ vault write <mount_path>/library/<set_name>/check-in \
-  service_account_names=[<account_list>]
+$ vault write -f <mount_path>/library/<set_name>/check-out
 ```
 
 For example:
@@ -12,15 +11,24 @@ For example:
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ vault write -f devcreds/library/accounting-team/check-in \
-  service_account_names=["fizz@example.com"]
+$ vault write -f devcreds/library/accounting-team/check-out
+
+Key                     Value
+---                     -----
+lease_id                devcreds/library/accounting-team/check-out/EpuS8cX7uEsDzOwW9kkKOyGW
+lease_duration          10h
+lease_renewable         true
+password                ?@09AZKh03hBORZPJcTDgLfntlHqxLy29tcQjPVThzuwWAx/Twx4a2ZcRQRqrZ1w
+service_account_name    fizz@example.com
 ```
 
 </CodeBlockConfig>
 
+
 <Tip>
 
-If the caller only has one account checked out, you can omit the account list
-and use the `-f` flag to call the endpoint without explicit parameters.
+If the default checkout time is longer than you need, omit the `-f` flag and
+provide an explict `ttl` value so Vault can reclaim the account sooner if it
+becomes abandoned for some reason.
 
 </Tip>

--- a/content/vault/v1.21.x/content/partials/ldap/account-checkout/api.mdx
+++ b/content/vault/v1.21.x/content/partials/ldap/account-checkout/api.mdx
@@ -1,14 +1,13 @@
 Make a `POST` call to
-[`{mount_path}/library/{set_name}/check-in`](/vault/api-docs/secret/ldap#check-in-management)
-with the service account name to return the service account:
+[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-out-management)
+to request a service account:
 
 ```shell-session
-$ curl                                                     \
-  --request POST                                           \
-  --header    "X-Vault-Token: ${VAULT_TOKEN}"              \
-  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}"      \
-  --data '{"service_account_names": [<account_list>]}'     \
-  ${VAULT_ADDR}/v1/<mount_path>/library/<set_name>/check-in
+$ curl                                                \
+  --request POST                                      \
+  --header    "X-Vault-Token: ${VAULT_TOKEN}"         \
+  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}" \
+  ${VAULT_ADDR}/v1/<mount_path>/library/<set_name>/check-out
 ```
 
 For example:
@@ -16,21 +15,18 @@ For example:
 <CodeBlockConfig hideClipboard="true" highlight="5">
 
 ```shell-session
-$ curl                                                     \
-  --request POST                                           \
-  --header    "X-Vault-Token: ${VAULT_TOKEN}"              \
-  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}"      \
-  --data '{"service_account_names": ["fizz@example.com"]}' \
-  ${VAULT_ADDR}/v1/devcreds/library/accounting-team/check-in
+$ curl                                                \
+  --request POST                                      \
+  --header    "X-Vault-Token: ${VAULT_TOKEN}"         \
+  --namespace "X-Vault-Namespace: ${VAULT_NAMESPACE}" \
+  ${VAULT_ADDR}/v1/devcreds/library/accounting-team/check-out
 ```
 
 </CodeBlockConfig>
 
-
 <Tip>
 
-If the default checkout time is longer than you need, provide an explict `ttl`
-value so Vault can reclaim the account sooner if it becomes abandoned for some
-reason.
+If the caller only has one account checked out, you can omit the account list
+and make an empty POST call to the endpoint.
 
 </Tip>

--- a/content/vault/v1.21.x/content/partials/ldap/account-checkout/cli.mdx
+++ b/content/vault/v1.21.x/content/partials/ldap/account-checkout/cli.mdx
@@ -1,9 +1,10 @@
-Use `vault write` with the `-f` flag and
-[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-out-management)
+Use `vault write` with the service account name and
+[`{mount_path}/library/{set_name}/check-out`](/vault/api-docs/secret/ldap#check-in-management)
 path to request a service account:
 
 ```shell-session
-$ vault write -f <mount_path>/library/<set_name>/check-out
+$ vault write <mount_path>/library/<set_name>/check-in \
+  service_account_names=[<account_list>]
 ```
 
 For example:
@@ -11,24 +12,15 @@ For example:
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ vault write -f devcreds/library/accounting-team/check-out
-
-Key                     Value
----                     -----
-lease_id                devcreds/library/accounting-team/check-out/EpuS8cX7uEsDzOwW9kkKOyGW
-lease_duration          10h
-lease_renewable         true
-password                ?@09AZKh03hBORZPJcTDgLfntlHqxLy29tcQjPVThzuwWAx/Twx4a2ZcRQRqrZ1w
-service_account_name    fizz@example.com
+$ vault write -f devcreds/library/accounting-team/check-in \
+  service_account_names=["fizz@example.com"]
 ```
 
 </CodeBlockConfig>
 
-
 <Tip>
 
-If the default checkout time is longer than you need, omit the `-f` flag and
-provide an explict `ttl` value so Vault can reclaim the account sooner if it
-becomes abandoned for some reason.
+If the caller only has one account checked out, you can omit the account list
+and use the `-f` flag to call the endpoint without explicit parameters.
 
 </Tip>


### PR DESCRIPTION
The examples for LDAP libraries is wrong in 2 ways:
1. the checkin/ checkout example partials are in the wrong folder (out -> in, in -> out)
2. the correct action is `<path>/library/<library name>/check-out` (with a `-`). See [secret engine code](https://github.com/hashicorp/vault-plugin-secrets-openldap/blob/f41b294991c74a1520ca1d0115b860feceaf919c/path_checkouts.go#L26) for proof