### PR TITLE
nomad: update cni_path defaults

### DIFF
--- a/content/nomad/v1.11.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v1.11.x/content/docs/configuration/client.mdx
@@ -186,9 +186,9 @@ client {
 - `no_host_uuid` `(bool: true)` - By default a random node UUID will be
   generated, but setting this to `false` will use the system's UUID.
 
-- `cni_path` `(string: "/opt/cni/bin")` - Sets the search path that is used for
-  CNI plugin discovery. Multiple paths can be searched using colon delimited
-  paths
+- `cni_path` `(string: "/opt/cni/bin:/usr/libexec/cni")` - Sets the search path
+  that is used for CNI plugin discovery. Multiple paths can be searched using
+  colon delimited paths. CNI is only supported on Linux.
 
 - `cni_config_dir` `(string: "/opt/cni/config")` - Sets the directory where CNI
   network configuration is located. The client will use this path when fingerprinting


### PR DESCRIPTION
...and clarify it is only supported on Linux.

See hashicorp/nomad#27336

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [x] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
