### PR TITLE
docs: Add LDAP secrets to Vault integration

### DIFF
--- a/content/boundary/v0.21.x/content/docs/vault/index.mdx
+++ b/content/boundary/v0.21.x/content/docs/vault/index.mdx
@@ -30,11 +30,11 @@ There are three configuration options:
 - LDAP secrets
 - SSH certificates
 
-Generic secrets reference a Vault key-value path where static secrets are stored, such as username/password or SSH keypairs. You can broker generic secrets to users when they connect to targets.
+Generic secrets use the [Vault KV secrets engine](/vault/docs/secrets/kv) to reference a Vault key-value path where static secrets are stored, such as username/password or SSH keypairs. You can broker generic secrets to users when they connect to targets.
 
 LDAP secrets let you configure a credential library using the [Vault LDAP secrets engine](/vault/docs/secrets/ldap). You can integrate static and dynamic credentials with services that use the LDAP v3 protocol, including OpenLDAP, Active Directory, and IBM Resource Access Control Facility (RACF).
 
-SSH certificates have the advantages of using Vault as the certificate authority (CA) and being able to use the [Vault SSH Secrets Engine](/vault/docs/secrets/ssh).
+SSH certificates use the [Vault SSH Secrets Engine](/vault/docs/secrets/ssh) to sign or issue certificates. You can leverage Vault as a certificate authority (CA), or bring your own CA.
 
 You can inject generic secrets, LDAP secrets, and SSH certificates directly into Boundary sessions using an HCP Boundary or Boundary Enterprise deployment.
 


### PR DESCRIPTION
Support for the using the Vault LDAP secrets engine to manage credentials in Boundary was added in version 0.21.0. We added it to the release notes, domain model, and CLI docs, but did not update the Vault integration document where credential management is discussed in detail. 

This PR:

- Adds Vault LDAP information to **Credential management** and **Injected credentials** sections
- Fixes a spelling error
- Fixes an instance of passive voice
- Removes an H1 heading **Credentials** that only contained a link and moves the link to the More information section

[View the update in the preview deployment](https://unified-docs-frontend-preview-cvmvyyl90-hashicorp.vercel.app/boundary/docs/vault)
