### PR TITLE
Add explicit permissions to GHA sync-docs-for-tfe.yml

### DIFF
--- a/.github/workflows/sync-docs-for-tfe.yml
+++ b/.github/workflows/sync-docs-for-tfe.yml
@@ -25,7 +25,8 @@ on:
         value: ${{ jobs.sync-docs.outputs.diff_branch_pr_url }}
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   sync-docs:


### PR DESCRIPTION
Potential fix for [https://github.com/hashicorp/web-unified-docs/security/code-scanning/29](https://github.com/hashicorp/web-unified-docs/security/code-scanning/29)

In general, the fix is to explicitly specify minimal required `GITHUB_TOKEN` permissions in the workflow. Since this job interacts with the repository but uses a separate PAT (`secrets.TFE_GITHUB_TOKEN`) for write operations, the `GITHUB_TOKEN` can safely be limited to read-only repository contents.

The best fix here is to add a root-level `permissions` block, applied to all jobs, directly under the existing `name:` and `on:` keys. Based on the current steps, the job only needs to read repository contents (for checkouts); all writes are done via `secrets.TFE_GITHUB_TOKEN`. Therefore, set:

```yaml
permissions:
  contents: read
```

This change should be added near the top of `.github/workflows/sync-docs-for-tfe.yml`, after the `on:` block (or before it; both are valid as long as indentation is correct and it’s at the root). No imports or additional methods are needed; it’s a pure YAML configuration change. Functionality of the workflow remains unchanged because the job already uses a separate token for write operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
