### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -13,6 +13,9 @@ on:
   push:
     branches: ['main', 'develop']
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: 'Run Tests 🧪'


### PR DESCRIPTION
Potential fix for [https://github.com/hashicorp/web-unified-docs/security/code-scanning/11](https://github.com/hashicorp/web-unified-docs/security/code-scanning/11)

To fix this, explicitly restrict the GITHUB_TOKEN permissions to the minimum needed. These jobs only need to read repository contents (for `actions/checkout`) and do not interact with issues, pull requests, or other writable resources, so `contents: read` is sufficient.

The best way, without changing functionality, is to add a `permissions` block at the workflow root (top level, alongside `on` and `jobs`) so it applies to both `test` and `lint` jobs. Concretely, edit `.github/workflows/test-and-lint.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (ending at line 14) and the `jobs:` key (line 16). No other imports or configuration changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
