### PR TITLE
Add explicit permissions to GHA create-tfe-release-notes.yml

### DIFF
--- a/.github/workflows/create-tfe-release-notes.yml
+++ b/.github/workflows/create-tfe-release-notes.yml
@@ -2,6 +2,7 @@ name: Create TFE Release Notes
 run-name: Create changelog PR for TFE ${{ inputs.version }} ${{ inputs.dev-mode && 'in dev mode' || '' }}
 permissions:
   contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/hashicorp/web-unified-docs/security/code-scanning/27](https://github.com/hashicorp/web-unified-docs/security/code-scanning/27)

In general, the fix is to explicitly declare a `permissions:` block so that the `GITHUB_TOKEN` is limited to the least privilege required. This can be done at the workflow root (applies to all jobs that don’t override it) or per-job. Since both jobs likely only need to read and write repository contents and possibly create pull requests, we can start with `contents: write` at the workflow level, which is a safe and common baseline for workflows that push branches and open PRs. The called workflow (`sync-docs-for-tfe.yml`) can further refine its own permissions if needed.

The single best minimal change here is to add a workflow-level `permissions:` block near the top of `.github/workflows/create-tfe-release-notes.yml`, right after `run-name:` and before `on:`. This will ensure both `sync-docs` and `release-notes` jobs no longer rely on repository defaults. Given that this workflow’s scripts include “Turn branch into PR” and likely push branches / open PRs, we should allow `contents: write`. If in this repository PR creation uses the token only via git pushes and the GitHub API for PR creation, `contents: write` is sufficient and appropriately scoped.

No extra methods, imports, or external dependencies are required; this is purely a YAML configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
