### PR TITLE
Add explicit permissions to GHA test-and-lint.yml

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -13,6 +13,9 @@ on:
   push:
     branches: ['main', 'develop']
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: 'Run Tests 🧪'


### PR DESCRIPTION
Potential fix for [https://github.com/hashicorp/web-unified-docs/security/code-scanning/13](https://github.com/hashicorp/web-unified-docs/security/code-scanning/13)

In general, the fix is to explicitly define a `permissions` block to limit the GITHUB_TOKEN to the minimum required scopes. Here, both `test` and `lint` jobs only need to read the repository contents to check out code and run Node-based commands, so `contents: read` is sufficient.

The best way to fix this without changing existing functionality is to add a single `permissions` block at the workflow root (alongside `on:` and `jobs:`). That root-level block applies to all jobs that do not define their own permissions, so both `test` and `lint` will inherit `contents: read`. No job appears to need write access (no pushes, no issue or PR modifications), so we do not add any write scopes.

Concretely, in `.github/workflows/test-and-lint.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (ending at line 14) and the `jobs:` block (line 16). No imports or additional methods are needed, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
