### PR TITLE
Add explicit permissions to GHA copyright-headers-check.yml

### DIFF
--- a/.github/workflows/copyright-headers-check.yml
+++ b/.github/workflows/copyright-headers-check.yml
@@ -1,5 +1,8 @@
 name: 'Check Copyright Headers'
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/hashicorp/web-unified-docs/security/code-scanning/6](https://github.com/hashicorp/web-unified-docs/security/code-scanning/6)

In general, the fix is to explicitly declare a `permissions` block that limits the `GITHUB_TOKEN` to the minimum required scopes. This can be done at the root of the workflow (applying to all jobs) or at the individual job level. For this workflow, the job only checks copyright headers and does not need to write to the repository or interact with issues/PRs, so `contents: read` is sufficient.

The best minimal fix without changing functionality is to add a root-level `permissions` block just under the `name` (or under the `on:` block) setting `contents: read`. This will apply to all jobs (just `check-headers` here) and prevent the token from having unnecessary write permissions. No imports or additional methods are needed, as this is purely a YAML configuration change.

Concretely, in `.github/workflows/copyright-headers-check.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file, ensuring indentation is correct and the rest of the workflow remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
