### PR TITLE
Add explicit permissions to GHA algolia-prod.yml

### DIFF
--- a/.github/workflows/algolia-prod.yml
+++ b/.github/workflows/algolia-prod.yml
@@ -13,6 +13,8 @@ jobs:
     name: Setup and Update Algolia
     runs-on: ubuntu-latest
     if: github.repository == 'hashicorp/web-unified-docs'
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
Potential fix for [https://github.com/hashicorp/web-unified-docs/security/code-scanning/4](https://github.com/hashicorp/web-unified-docs/security/code-scanning/4)

In general, the fix is to explicitly define the `permissions` for the `GITHUB_TOKEN` in the workflow, either at the top level (for all jobs) or per job, and restrict them to the least privilege required. For this workflow, the job only needs to read repository contents (for checkout) and does not appear to modify issues, PRs, or repo settings. Therefore, `contents: read` is a safe and sufficient minimal permission set.

The best fix with no functional change is to add a `permissions:` block under the `setup-and-update-algolia` job, between the `if:` condition and the `steps:` block. This ensures that only this job is affected and clearly documents the least privilege in the same context where the problem was reported. Concretely, in `.github/workflows/algolia-prod.yml` around line 13, insert:

```yaml
    permissions:
      contents: read
```

indented to line up with `runs-on` and `if`. No additional imports, methods, or definitions are needed, as this is a pure workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
