### PR TITLE
Add explicit permissions to GHA copy-cloud-docs-for-tfe.yml

### DIFF
--- a/.github/workflows/copy-cloud-docs-for-tfe.yml
+++ b/.github/workflows/copy-cloud-docs-for-tfe.yml
@@ -1,7 +1,8 @@
 name: Copy Cloud Docs For TFE
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/hashicorp/web-unified-docs/security/code-scanning/5](https://github.com/hashicorp/web-unified-docs/security/code-scanning/5)

To fix this, explicitly define a minimal `permissions` block for the workflow so that the automatic `GITHUB_TOKEN` has only the access required. This should be added at the workflow level (top-level, alongside `name` and `on`) so it applies to all jobs, unless a job overrides it. Since all write operations here are done using `secrets.TFE_GITHUB_TOKEN` with `git` and `gh`, the workflow can likely restrict `GITHUB_TOKEN` to read-only repository contents.

The best minimal fix without changing existing behavior is:

- Add a top-level `permissions` section with `contents: read`. This is the standard least-privilege baseline for workflows that only need to read repository contents and do not rely on `GITHUB_TOKEN` for PR or issue writes.
- Place it between the `name:` and `on:` keys (or just before `jobs:`) to keep the YAML structure clear.
- No additional imports or methods are needed; this is a pure YAML configuration change.

Concretely, edit `.github/workflows/copy-cloud-docs-for-tfe.yml` near the start of the file to insert:

```yaml
permissions:
  contents: read
```

so the workflow’s default `GITHUB_TOKEN` is restricted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
