### PR TITLE
Nomad: memory oversubscription supports reserve-only requests

### DIFF
--- a/content/nomad/v1.10.x/content/docs/job-declare/task-driver/docker.mdx
+++ b/content/nomad/v1.10.x/content/docs/job-declare/task-driver/docker.mdx
@@ -270,7 +270,7 @@ The `docker` driver supports the following configuration in the job spec. Only
   resource configuration becomes a memory reservation passed to the Docker driver as
   [`--memory_reservation`][], and `memory_hard_limit` is passed as the
   [`--memory`][] hard limit. If [`resources.memory_max`][] is set, the highest
-  of the two limits will be used.
+  of the two limits is used.
 
 - `network_aliases` - (Optional) A list of network-scoped aliases, provide a way for a
   container to be discovered by an alternate name by any other container within

--- a/content/nomad/v1.10.x/content/docs/job-specification/resources.mdx
+++ b/content/nomad/v1.10.x/content/docs/job-specification/resources.mdx
@@ -117,11 +117,11 @@ the task may exceed the limit and be interrupted; if the task memory is too
 high, the cluster is left underutilized. Nomad drivers configure two separate
 memory limits:
 
-* The _limit_, or hard limit, represents the maximum memory the task can
+- The _limit_, or hard limit, represents the maximum memory the task can
   use. The operating system typically terminates the task if the task exceeds
   this limit. On Linux most task drivers implement the limit via the
   [`memory.max` cgroup][memory_cgroup].
-* The _reservation_ represents the task's typical memory usage. The operating
+- The _reservation_ represents the task's typical memory usage. The operating
   system provides best-effort memory protection for the reservation. On Linux
   most task drivers implement the reservation via [`memory.low`
   cgroup][memory_cgroup].
@@ -146,10 +146,6 @@ The `memory_max` limit attribute is currently supported by the official
 drivers. Consult the documentation of community-supported task drivers for their
 memory oversubscription support.
 
-Memory oversubscription by setting `memory_max` is opt-in. Nomad operators can
-enable [Memory Oversubscription in the scheduler
-configuration][api_sched_config]. Enterprise customers can use [Resource
-Quotas][quota_spec] to limit the memory oversubscription and enable or disable
 Memory oversubscription by setting `memory_max` is opt-in. Nomad operators can
 enable memory oversubscription in the scheduler configuration. Refer to the
 [`MemoryOversubscritionEnabled` parameter][api_sched_config] for details.

--- a/content/nomad/v1.11.x/content/docs/job-declare/task-driver/docker.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-declare/task-driver/docker.mdx
@@ -270,7 +270,7 @@ The `docker` driver supports the following configuration in the job spec. Only
   resource configuration becomes a memory reservation passed to the Docker driver as
   [`--memory_reservation`][], and `memory_hard_limit` is passed as the
   [`--memory`][] hard limit. If [`resources.memory_max`][] is set, the highest
-  of the two limits will be used unless `resources.memory_max` is -1, in which
+  of the two limits is used unless `resources.memory_max` is -1, in which
   case there is no hard limit.
 
 - `network_aliases` - (Optional) A list of network-scoped aliases, provide a way for a

--- a/content/nomad/v1.11.x/content/docs/job-specification/resources.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-specification/resources.mdx
@@ -117,11 +117,11 @@ the task may exceed the limit and be interrupted; if the task memory is too
 high, the cluster is left underutilized. Nomad drivers configure two separate
 memory limits:
 
-* The _limit_, or hard limit, represents the maximum memory the task can
+- The _limit_, or hard limit, represents the maximum memory the task can
   use. The operating system typically terminates the task if the task exceeds
   this limit. On Linux most task drivers implement the limit via the
   [`memory.max` cgroup][memory_cgroup].
-* The _reservation_ represents the task's typical memory usage. The operating
+- The _reservation_ represents the task's typical memory usage. The operating
   system provides best-effort memory protection for the reservation. On Linux
   most task drivers implement the reservation via [`memory.low`
   cgroup][memory_cgroup].
@@ -147,10 +147,6 @@ The `memory_max` limit attribute is currently supported by the official
 drivers. Consult the documentation of community-supported task drivers for their
 memory oversubscription support.
 
-Memory oversubscription by setting `memory_max` is opt-in. Nomad operators can
-enable [Memory Oversubscription in the scheduler
-configuration][api_sched_config]. Enterprise customers can use [Resource
-Quotas][quota_spec] to limit the memory oversubscription and enable or disable
 Memory oversubscription by setting `memory_max` is opt-in. Nomad operators can
 enable memory oversubscription in the scheduler configuration. Refer to the
 [`MemoryOversubscritionEnabled` parameter][api_sched_config] for details.

--- a/content/nomad/v1.8.x/content/docs/drivers/docker.mdx
+++ b/content/nomad/v1.8.x/content/docs/drivers/docker.mdx
@@ -264,7 +264,7 @@ The `docker` driver supports the following configuration in the job spec. Only
   resource configuration becomes a memory reservation passed to the Docker driver as
   [`--memory_reservation`][], and `memory_hard_limit` is passed as the
   [`--memory`][] hard limit. If [`resources.memory_max`][] is set, the highest
-  of the two limits will be used.
+  of the two limits is used.
 
 - `network_aliases` - (Optional) A list of network-scoped aliases, provide a way for a
   container to be discovered by an alternate name by any other container within

--- a/content/nomad/v1.8.x/content/docs/job-specification/resources.mdx
+++ b/content/nomad/v1.8.x/content/docs/job-specification/resources.mdx
@@ -117,11 +117,11 @@ the task may exceed the limit and be interrupted; if the task memory is too
 high, the cluster is left underutilized. Nomad drivers configure two separate
 memory limits:
 
-* The _limit_, or hard limit, represents the maximum memory the task can
+- The _limit_, or hard limit, represents the maximum memory the task can
   use. The operating system typically terminates the task if the task exceeds
   this limit. On Linux most task drivers implement the limit via the
   [`memory.max` cgroup][memory_cgroup].
-* The _reservation_ represents the task's typical memory usage. The operating
+- The _reservation_ represents the task's typical memory usage. The operating
   system provides best-effort memory protection for the reservation. On Linux
   most task drivers implement the reservation via [`memory.low`
   cgroup][memory_cgroup].
@@ -146,10 +146,6 @@ The `memory_max` limit attribute is currently supported by the official
 drivers. Consult the documentation of community-supported task drivers for their
 memory oversubscription support.
 
-Memory oversubscription by setting `memory_max` is opt-in. Nomad operators can
-enable [Memory Oversubscription in the scheduler
-configuration][api_sched_config]. Enterprise customers can use [Resource
-Quotas][quota_spec] to limit the memory oversubscription and enable or disable
 Memory oversubscription by setting `memory_max` is opt-in. Nomad operators can
 enable memory oversubscription in the scheduler configuration. Refer to the
 [`MemoryOversubscritionEnabled` parameter][api_sched_config] for details.

--- a/content/nomad/v1.9.x/content/docs/drivers/docker.mdx
+++ b/content/nomad/v1.9.x/content/docs/drivers/docker.mdx
@@ -264,7 +264,7 @@ The `docker` driver supports the following configuration in the job spec. Only
   resource configuration becomes a memory reservation passed to the Docker driver as
   [`--memory_reservation`][], and `memory_hard_limit` is passed as the
   [`--memory`][] hard limit. If [`resources.memory_max`][] is set, the highest
-  of the two limits will be used.
+  of the two limits is used.
 
 - `network_aliases` - (Optional) A list of network-scoped aliases, provide a way for a
   container to be discovered by an alternate name by any other container within

--- a/content/nomad/v1.9.x/content/docs/job-specification/resources.mdx
+++ b/content/nomad/v1.9.x/content/docs/job-specification/resources.mdx
@@ -117,11 +117,11 @@ the task may exceed the limit and be interrupted; if the task memory is too
 high, the cluster is left underutilized. Nomad drivers configure two separate
 memory limits:
 
-* The _limit_, or hard limit, represents the maximum memory the task can
+- The _limit_, or hard limit, represents the maximum memory the task can
   use. The operating system typically terminates the task if the task exceeds
   this limit. On Linux most task drivers implement the limit via the
   [`memory.max` cgroup][memory_cgroup].
-* The _reservation_ represents the task's typical memory usage. The operating
+- The _reservation_ represents the task's typical memory usage. The operating
   system provides best-effort memory protection for the reservation. On Linux
   most task drivers implement the reservation via [`memory.low`
   cgroup][memory_cgroup].
@@ -146,10 +146,6 @@ The `memory_max` limit attribute is currently supported by the official
 drivers. Consult the documentation of community-supported task drivers for their
 memory oversubscription support.
 
-Memory oversubscription by setting `memory_max` is opt-in. Nomad operators can
-enable [Memory Oversubscription in the scheduler
-configuration][api_sched_config]. Enterprise customers can use [Resource
-Quotas][quota_spec] to limit the memory oversubscription and enable or disable
 Memory oversubscription by setting `memory_max` is opt-in. Nomad operators can
 enable memory oversubscription in the scheduler configuration. Refer to the
 [`MemoryOversubscritionEnabled` parameter][api_sched_config] for details.


### PR DESCRIPTION
Reserve-only memory oversubscription has been supported in the Nomad control plane for a long time, but wasn't documented or plumbed through to several task drivers. We've added support for this. Update the documentation for memory oversubscription to note this is possible, and just generally clarify the difference between the limit and reservation.

## Links

Jira: https://hashicorp.atlassian.net/browse/NMD-911
PR: https://github.com/hashicorp/nomad/pull/27354

Deploy previews: 
* https://unified-docs-frontend-preview-9n0kzw18j-hashicorp.vercel.app/nomad/docs/job-specification/resources#memory-oversubscription
* https://unified-docs-frontend-preview-9n0kzw18j-hashicorp.vercel.app/nomad/docs/job-declare/task-driver/docker#memory_hard_limit
* 1.10.x backport for resources: https://unified-docs-frontend-preview-ljsxsplhd-hashicorp.vercel.app/nomad/docs/v1.10.x/job-specification/resources#memory-oversubscription
* 1.9.x backport for resources: https://unified-docs-frontend-preview-ljsxsplhd-hashicorp.vercel.app/nomad/docs/v1.9.x/job-specification/resources#memory-oversubscription
* 1.8.x backport for resources: https://unified-docs-frontend-preview-ljsxsplhd-hashicorp.vercel.app/nomad/docs/v1.8.x/job-specification/resources#memory-oversubscription
* 1.10.x backport for docker: https://unified-docs-frontend-preview-ljsxsplhd-hashicorp.vercel.app/nomad/docs/v1.10.x/job-declare/task-driver/docker#memory_hard_limit
* 1.9.x backport for docker: https://unified-docs-frontend-preview-ljsxsplhd-hashicorp.vercel.app/nomad/docs/v1.9.x/drivers/docker#memory_hard_limit
* 1.8.x backport for docker: https://unified-docs-frontend-preview-ljsxsplhd-hashicorp.vercel.app/nomad/docs/v1.8.x/drivers/docker#memory_hard_limit

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
