### PR TITLE
Update lock.mdx

### DIFF
--- a/content/terraform/v1.12.x/docs/cli/commands/providers/lock.mdx
+++ b/content/terraform/v1.12.x/docs/cli/commands/providers/lock.mdx
@@ -26,7 +26,7 @@ automatic approach may not be sufficient:
   be able to populate all of the possible package checksums for the selected
   provider versions.
 
-  If you use `terraform lock` to write the official release checksums for a
+  If you use `terraform providers lock` to write the official release checksums for a
   provider into the dependency lock file then future `terraform init` runs
   will verify the packages available in your selected mirror against the
   official checksums previously recorded, giving additional certainty that


### PR DESCRIPTION
fix: Typo `terraform lock` to `terraform providers lock`

Please go to the `Preview` tab and select the appropriate template:

* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
