### PR TITLE
Add -no-color flag to terraform fmt command documentation

### DIFF
--- a/content/terraform/v1.1.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.1.x/docs/cli/commands/fmt.mdx
@@ -59,4 +59,5 @@ The command-line flags are all optional. The list of available flags are:
 * `-diff` - Display diffs of formatting changes
 * `-check` - Check if the input is formatted. Exit status will be 0 if
   all input is properly formatted and non-zero otherwise.
+* `-no-color` - If specified, output won't contain any color.
 * `-recursive` - Also process files in subdirectories. By default, only the given directory (or current directory) is processed.

--- a/content/terraform/v1.10.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.10.x/docs/cli/commands/fmt.mdx
@@ -60,4 +60,5 @@ The `terraform fmt` command accepts the following arguments.
 | `-diff` | Displays the diffs of formatting changes. | Optional |
 | `-write=false` | Prevents the command from overwriting files. This behavior is implied by the `-check` flag or if the input is from `STDIN`. | Optional |
 | `-check` | Checks if the input is formatted. The exit status is `0` if the command's input is properly formatted. Otherwise, the exit status is non-zero, and the command outputs a list of improperly formatted file names. | Optional |
+| `-no-color` | If specified, output won't contain any color. | Optional |
 | `-recursive` | Processes files in subdirectories in addition to the current directory. By default, the command only processes the specified, or current, directory. | Optional |

--- a/content/terraform/v1.11.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.11.x/docs/cli/commands/fmt.mdx
@@ -59,4 +59,5 @@ The `terraform fmt` command accepts the following arguments.
 | `-diff` | Displays the diffs of formatting changes. | Optional |
 | `-write=false` | Prevents the command from overwriting files. This behavior is implied by the `-check` flag or if the input is from `STDIN`. | Optional |
 | `-check` | Checks if the input is formatted. The exit status is `0` if the command's input is properly formatted. Otherwise, the exit status is non-zero, and the command outputs a list of improperly formatted file names. | Optional |
+| `-no-color` | If specified, output won't contain any color. | Optional |
 | `-recursive` | Processes files in subdirectories in addition to the current directory. By default, the command only processes the specified, or current, directory. | Optional |

--- a/content/terraform/v1.12.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.12.x/docs/cli/commands/fmt.mdx
@@ -59,4 +59,5 @@ The `terraform fmt` command accepts the following arguments.
 | `-diff` | Displays the diffs of formatting changes. | Optional |
 | `-write=false` | Prevents the command from overwriting files. This behavior is implied by the `-check` flag or if the input is from `STDIN`. | Optional |
 | `-check` | Checks if the input is formatted. The exit status is `0` if the command's input is properly formatted. Otherwise, the exit status is non-zero, and the command outputs a list of improperly formatted file names. | Optional |
+| `-no-color` | If specified, output won't contain any color. | Optional |
 | `-recursive` | Processes files in subdirectories in addition to the current directory. By default, the command only processes the specified, or current, directory. | Optional |

--- a/content/terraform/v1.13.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.13.x/docs/cli/commands/fmt.mdx
@@ -59,4 +59,5 @@ The `terraform fmt` command accepts the following arguments.
 | `-diff` | Displays the diffs of formatting changes. | Optional |
 | `-write=false` | Prevents the command from overwriting files. This behavior is implied by the `-check` flag or if the input is from `STDIN`. | Optional |
 | `-check` | Checks if the input is formatted. The exit status is `0` if the command's input is properly formatted. Otherwise, the exit status is non-zero, and the command outputs a list of improperly formatted file names. | Optional |
+| `-no-color` | If specified, output won't contain any color. | Optional |
 | `-recursive` | Processes files in subdirectories in addition to the current directory. By default, the command only processes the specified, or current, directory. | Optional |

--- a/content/terraform/v1.14.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.14.x/docs/cli/commands/fmt.mdx
@@ -59,4 +59,5 @@ The `terraform fmt` command accepts the following arguments.
 | `-diff` | Displays the diffs of formatting changes. | Optional |
 | `-write=false` | Prevents the command from overwriting files. This behavior is implied by the `-check` flag or if the input is from `STDIN`. | Optional |
 | `-check` | Checks if the input is formatted. The exit status is `0` if the command's input is properly formatted. Otherwise, the exit status is non-zero, and the command outputs a list of improperly formatted file names. | Optional |
+| `-no-color` | If specified, output won't contain any color. | Optional |
 | `-recursive` | Processes files in subdirectories in addition to the current directory. By default, the command only processes the specified, or current, directory. | Optional |

--- a/content/terraform/v1.15.x (alpha)/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.15.x (alpha)/docs/cli/commands/fmt.mdx
@@ -59,4 +59,5 @@ The `terraform fmt` command accepts the following arguments.
 | `-diff` | Displays the diffs of formatting changes. | Optional |
 | `-write=false` | Prevents the command from overwriting files. This behavior is implied by the `-check` flag or if the input is from `STDIN`. | Optional |
 | `-check` | Checks if the input is formatted. The exit status is `0` if the command's input is properly formatted. Otherwise, the exit status is non-zero, and the command outputs a list of improperly formatted file names. | Optional |
+| `-no-color` | If specified, output won't contain any color. | Optional |
 | `-recursive` | Processes files in subdirectories in addition to the current directory. By default, the command only processes the specified, or current, directory. | Optional |

--- a/content/terraform/v1.2.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.2.x/docs/cli/commands/fmt.mdx
@@ -57,4 +57,5 @@ The command-line flags are all optional. The following flags are available:
 * `-diff` - Display diffs of formatting changes
 * `-check` - Check if the input is formatted. Exit status will be 0 if
   all input is properly formatted and non-zero otherwise.
+* `-no-color` - If specified, output won't contain any color.
 * `-recursive` - Also process files in subdirectories. By default, only the given directory (or current directory) is processed.

--- a/content/terraform/v1.3.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.3.x/docs/cli/commands/fmt.mdx
@@ -59,4 +59,5 @@ The command-line flags are all optional. The following flags are available:
 * `-write=false` - Don't overwrite the input files. (This is implied by `-check` or when the input is STDIN.)
 * `-diff` - Display diffs of formatting changes
 * `-check` - Check if the input is formatted. Exit status will be 0 if all input is properly formatted. If not, exit status will be non-zero and the command will output a list of filenames whose files are not properly formatted.
+* `-no-color` - If specified, output won't contain any color.
 * `-recursive` - Also process files in subdirectories. By default, only the given directory (or current directory) is processed.

--- a/content/terraform/v1.4.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.4.x/docs/cli/commands/fmt.mdx
@@ -59,4 +59,5 @@ The command-line flags are all optional. The following flags are available:
 * `-write=false` - Don't overwrite the input files. (This is implied by `-check` or when the input is STDIN.)
 * `-diff` - Display diffs of formatting changes.
 * `-check` - Check if the input is formatted. Exit status will be 0 if all input is properly formatted. If not, exit status will be non-zero and the command will output a list of filenames whose files are not properly formatted.
+* `-no-color` - If specified, output won't contain any color.
 * `-recursive` - Also process files in subdirectories. By default, only the given directory (or current directory) is processed.

--- a/content/terraform/v1.5.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.5.x/docs/cli/commands/fmt.mdx
@@ -59,4 +59,5 @@ The command-line flags are all optional. The following flags are available:
 * `-write=false` - Don't overwrite the input files. (This is implied by `-check` or when the input is STDIN.)
 * `-diff` - Display diffs of formatting changes.
 * `-check` - Check if the input is formatted. Exit status will be 0 if all input is properly formatted. If not, exit status will be non-zero and the command will output a list of filenames whose files are not properly formatted.
+* `-no-color` - If specified, output won't contain any color.
 * `-recursive` - Also process files in subdirectories. By default, only the given directory (or current directory) is processed.

--- a/content/terraform/v1.6.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.6.x/docs/cli/commands/fmt.mdx
@@ -63,4 +63,5 @@ The following flags are available:
 * `-write=false` - Don't overwrite the input files. (This is implied by `-check` or when the input is STDIN.)
 * `-diff` - Display diffs of formatting changes.
 * `-check` - Check if the input is formatted. Exit status will be 0 if all input is properly formatted. If not, exit status will be non-zero and the command will output a list of filenames whose files are not properly formatted.
+* `-no-color` - If specified, output won't contain any color.
 * `-recursive` - Also process files in subdirectories. By default, only the given directory (or current directory) is processed.

--- a/content/terraform/v1.7.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.7.x/docs/cli/commands/fmt.mdx
@@ -63,4 +63,5 @@ The following flags are available:
 * `-write=false` - Don't overwrite the input files. (This is implied by `-check` or when the input is STDIN.)
 * `-diff` - Display diffs of formatting changes.
 * `-check` - Check if the input is formatted. Exit status will be 0 if all input is properly formatted. If not, exit status will be non-zero and the command will output a list of filenames whose files are not properly formatted.
+* `-no-color` - If specified, output won't contain any color.
 * `-recursive` - Also process files in subdirectories. By default, only the given directory (or current directory) is processed.

--- a/content/terraform/v1.8.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.8.x/docs/cli/commands/fmt.mdx
@@ -63,4 +63,5 @@ The following flags are available:
 * `-write=false` - Don't overwrite the input files. (This is implied by `-check` or when the input is STDIN.)
 * `-diff` - Display diffs of formatting changes.
 * `-check` - Check if the input is formatted. Exit status will be 0 if all input is properly formatted. If not, exit status will be non-zero and the command will output a list of filenames whose files are not properly formatted.
+* `-no-color` - If specified, output won't contain any color.
 * `-recursive` - Also process files in subdirectories. By default, only the given directory (or current directory) is processed.

--- a/content/terraform/v1.9.x/docs/cli/commands/fmt.mdx
+++ b/content/terraform/v1.9.x/docs/cli/commands/fmt.mdx
@@ -63,4 +63,5 @@ The following flags are available:
 * `-write=false` - Don't overwrite the input files. (This is implied by `-check` or when the input is STDIN.)
 * `-diff` - Display diffs of formatting changes.
 * `-check` - Check if the input is formatted. Exit status will be 0 if all input is properly formatted. If not, exit status will be non-zero and the command will output a list of filenames whose files are not properly formatted.
+* `-no-color` - If specified, output won't contain any color.
 * `-recursive` - Also process files in subdirectories. By default, only the given directory (or current directory) is processed.


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Added the missing `-no-color` flag explanation to the `terraform fmt` command reference pages across all versions (v1.1.x through v1.15.x).

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
- ref: https://github.com/hashicorp/web-unified-docs/issues/1651

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->
<img width="754" height="158" alt="スクリーンショット 2026-01-17 18 03 15" src="https://github.com/user-attachments/assets/2bee0337-8111-4cf9-a74e-2d9df91c309b" />


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
