### PR TITLE
TF-33372: Adds Known Issue to v202504-1 

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/releases/2025/v202504-1.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/releases/2025/v202504-1.mdx
@@ -10,6 +10,9 @@ Last required release: [v202406-1 (776)](/terraform/enterprise/releases/2024/v20
 
 Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux `sha256:99244574d5a2094144af82635c8ba83fd67de9762d3537e8db0ad52c118ff455`
 
+## Known Issues
+1. (Updated 01/20/2026) Automatic product usage reporting may fail to report product utilization data back to HashiCorp. This issue is fixed in v202505-1.
+
 ## Highlights
 
 1. You can now authenticate to the PostgreSQL server using client certificates.

--- a/content/terraform-enterprise/1.0.x/docs/enterprise/releases/2025/v202505-1.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/releases/2025/v202505-1.mdx
@@ -32,6 +32,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 ## Bug Fixes
 1. The forgot password flow now presents the same message, regardless of whether a user exists or not, to avoid leaking whether a user with the provided email exists.
 1. Creating a new policy sets through the UI now correctly assign the runtime version you select.
+1. Fixed a bug in the automatic reporting of product usage data, ensuring that data is successfully sent back to HashiCorp.
 
 ## Security
 1. More than three failed attempts to verify two factor authentication now locks a user's account, and the user receives an email with unlock instructions.

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/releases/2025/v202504-1.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/releases/2025/v202504-1.mdx
@@ -10,6 +10,9 @@ Last required release: [v202406-1 (776)](/terraform/enterprise/releases/2024/v20
 
 Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux `sha256:99244574d5a2094144af82635c8ba83fd67de9762d3537e8db0ad52c118ff455`
 
+## Known Issues
+1. (Updated 01/20/2026) Automatic product usage reporting may fail to report product utilization data back to HashiCorp. This issue is fixed in v202505-1.
+
 ## Highlights
 
 1. You can now authenticate to the PostgreSQL server using client certificates.

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/releases/2025/v202505-1.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/releases/2025/v202505-1.mdx
@@ -32,6 +32,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 ## Bug Fixes
 1. The forgot password flow now presents the same message, regardless of whether a user exists or not, to avoid leaking whether a user with the provided email exists.
 1. Creating a new policy sets through the UI now correctly assign the runtime version you select.
+1. Fixed a bug in the automatic reporting of product usage data, ensuring that data is successfully sent back to HashiCorp.
 
 ## Security
 1. More than three failed attempts to verify two factor authentication now locks a user's account, and the user receives an email with unlock instructions.

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/releases/2025/v202504-1.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/releases/2025/v202504-1.mdx
@@ -10,6 +10,9 @@ Last required release: [v202406-1 (776)](/terraform/enterprise/releases/2024/v20
 
 Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux `sha256:99244574d5a2094144af82635c8ba83fd67de9762d3537e8db0ad52c118ff455`
 
+## Known Issues
+1. (Updated 01/20/2026) Automatic product usage reporting may fail to report product utilization data back to HashiCorp. This issue is fixed in v202505-1.
+
 ## Highlights
 
 1. You can now authenticate to the PostgreSQL server using client certificates.

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/releases/2025/v202504-1.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/releases/2025/v202504-1.mdx
@@ -10,6 +10,9 @@ Last required release: [v202406-1 (776)](/terraform/enterprise/releases/2024/v20
 
 Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux `sha256:99244574d5a2094144af82635c8ba83fd67de9762d3537e8db0ad52c118ff455`
 
+## Known Issues
+1. (Updated 01/20/2026) Automatic product usage reporting may fail to report product utilization data back to HashiCorp. This issue is fixed in v202505-1.
+
 ## Highlights
 
 1. You can now authenticate to the PostgreSQL server using client certificates.

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/releases/2025/v202505-1.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/releases/2025/v202505-1.mdx
@@ -32,6 +32,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 ## Bug Fixes
 1. The forgot password flow now presents the same message, regardless of whether a user exists or not, to avoid leaking whether a user with the provided email exists.
 1. Creating a new policy sets through the UI now correctly assign the runtime version you select.
+1. Fixed a bug in the automatic reporting of product usage data, ensuring that data is successfully sent back to HashiCorp.
 
 ## Security
 1. More than three failed attempts to verify two factor authentication now locks a user's account, and the user receives an email with unlock instructions.

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/releases/2025/v202504-1.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/releases/2025/v202504-1.mdx
@@ -10,6 +10,9 @@ Last required release: [v202406-1 (776)](/terraform/enterprise/releases/2024/v20
 
 Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux `sha256:99244574d5a2094144af82635c8ba83fd67de9762d3537e8db0ad52c118ff455`
 
+## Known Issues
+1. (Updated 01/20/2026) Automatic product usage reporting may fail to report product utilization data back to HashiCorp. This issue is fixed in v202505-1.
+
 ## Highlights
 
 1. You can now authenticate to the PostgreSQL server using client certificates.

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/releases/2025/v202505-1.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/releases/2025/v202505-1.mdx
@@ -32,6 +32,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 ## Bug Fixes
 1. The forgot password flow now presents the same message, regardless of whether a user exists or not, to avoid leaking whether a user with the provided email exists.
 1. Creating a new policy sets through the UI now correctly assign the runtime version you select.
+1. Fixed a bug in the automatic reporting of product usage data, ensuring that data is successfully sent back to HashiCorp.
 
 ## Security
 1. More than three failed attempts to verify two factor authentication now locks a user's account, and the user receives an email with unlock instructions.

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/releases/2025/v202504-1.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/releases/2025/v202504-1.mdx
@@ -10,6 +10,9 @@ Last required release: [v202406-1 (776)](/terraform/enterprise/releases/2024/v20
 
 Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux `sha256:99244574d5a2094144af82635c8ba83fd67de9762d3537e8db0ad52c118ff455`
 
+## Known Issues
+1. (Updated 01/20/2026) Automatic product usage reporting may fail to report product utilization data back to HashiCorp. This issue is fixed in v202505-1.
+
 ## Highlights
 
 1. You can now authenticate to the PostgreSQL server using client certificates.

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/releases/2025/v202505-1.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/releases/2025/v202505-1.mdx
@@ -32,6 +32,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 ## Bug Fixes
 1. The forgot password flow now presents the same message, regardless of whether a user exists or not, to avoid leaking whether a user with the provided email exists.
 1. Creating a new policy sets through the UI now correctly assign the runtime version you select.
+1. Fixed a bug in the automatic reporting of product usage data, ensuring that data is successfully sent back to HashiCorp.
 
 ## Security
 1. More than three failed attempts to verify two factor authentication now locks a user's account, and the user receives an email with unlock instructions.


### PR DESCRIPTION
[JIRA](https://hashicorp.atlassian.net/browse/TF-33372)

Context conversation: https://ibm-hashicorp.slack.com/archives/C09KZBKN0DQ/p1768925170296159

There's a known issue in the v202504-1 TFE release where automatic Census reporting fails to send data back to HashiCorp. This [problem](https://ibm-hashicorp.slack.com/archives/C09KZBKN0DQ/p1751470975791599?thread_ts=1751032874.083779&cid=C09KZBKN0DQ) stems from a Census schema registry version mismatch: `Basically TFE is is sending a field that doesn't exist in the version schema_version(2.0.0) mentioned, (it should have been 2.0.2).`.

This applies a known issue to all v202504-1 TFE releases and bug fix description in all v202505-1 TFE releases. 

Please go to the `Preview` tab and select the appropriate template:

* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
