### PR TITLE
PR Template: Update Nomad & Consul PR templates with info about deploy preview

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/consul_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/consul_pull_request_template.md
@@ -44,10 +44,8 @@ merged.
 
 Jira: [<jira-ticket-number>]  // for example, Jira: [CE-1001] GH-Jira integration generates the link and updates the Jira ticket.
 GitHub Issue: <issue-link>
-Deploy previews:
 
-The bot does publish a root-level link to the deploy preview, 
-but it's nice to include a direct link to your content so the reviewers don't have to navigate to your pages.
+The bot does publish a root-level link to the deploy preview. The link changes with each build.
 -->
 
 ## Contributor checklists

--- a/.github/PULL_REQUEST_TEMPLATE/nomad_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/nomad_pull_request_template.md
@@ -65,14 +65,12 @@ Jira: [<jira-ticket-number>]  // for example, Jira: [NMD-1234]
 
 GitHub Issue: <issue-link>
 
-Deploy previews: The bot does publish a root-level link to the deploy preview, 
-but it's nice to include a direct link to your content so the reviewers don't have to navigate to your pages.
+Deploy previews: The bot does publish a root-level link to the deploy preview, but the preview URL changes with each build.
 -->
 
 Nomad Code PR:
 Jira:
 GitHub Issue:
-Deploy Previews:
 
 ## Contributor checklists
 


### PR DESCRIPTION
Remove lines about adding deploy previews to the PR description because the deploy preview URL updates with each build. 