### PR TITLE
Update Codeowners for HCP IAM

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -53,7 +53,7 @@
 /content/hcp-docs/content/docs/boundary/ @hashicorp/boundary-education-approvers
 /content/hcp-docs/img/docs/boundary/ @hashicorp/boundary-education-approvers
 
-#HCP IAM
+# HCP IAM
 /content/hcp-docs/content/partials/hcp-administration/ @hashicorp/education @hashicorp/cloud-access-control @hashicorp/cloud-identity
 /content/hcp-docs/content/docs/hcp/iam/ @hashicorp/education @hashicorp/cloud-access-control @hashicorp/cloud-identity
 /content/hcp-docs/content/img/docs/hcp-core/ @hashicorp/education @hashicorp/cloud-access-control @hashicorp/cloud-identity


### PR DESCRIPTION
When the HCP docs were migrated to UDR, the CODEOWNERS file was updated separately for the Education team and the HCP IAM team. As a result, the permissions logic was set so that Runtime Education requires Engineer approval to merge docs updates. 

This PR updates the CODEOWNERS file to allow any member of the HashiCorp Education team to approve updates to the HCP IAM docs, unblocking the Education but leaving the IAM team with the ability to approve docs updates without us blocking them.