### PR TITLE
Doccument default change of raft_logstore.backend in Consul Docs

### DIFF
--- a/content/consul/v1.21.x/content/docs/reference/agent/configuration-file/raft.mdx
+++ b/content/consul/v1.21.x/content/docs/reference/agent/configuration-file/raft.mdx
@@ -18,9 +18,8 @@ The page provides reference information for Raft parameters in a Consul agent co
 
   - `backend` ((#raft_logstore_backend)) Specifies which storage
     engine to use to persist logs. Valid options are `boltdb` or `wal`. Default
-    is `boltdb`. The `wal` option specifies an experimental backend that
-    should be used with caution. Refer to
-    [Experimental WAL LogStore backend](/consul/docs/deploy/server/wal)
+    is `wal`. In versions of Consul prior to 0.21, this defaulted to boltdb.
+    Refer to [WAL LogStore backend](/consul/docs/deploy/server/wal)
     for more information.
 
   - `disable_log_cache` ((#raft_logstore_disable_log_cache)) Disables the in-memory cache for recent logs. We recommend using it for performance testing purposes, as no significant improvement has been measured when the cache is disabled. While the in-memory log cache theoretically prevents disk reads for recent logs, recent logs are also stored in the OS page cache, which does not slow either the `boltdb` or `wal` backend's ability to read them.

--- a/content/consul/v1.22.x/content/docs/reference/agent/configuration-file/raft.mdx
+++ b/content/consul/v1.22.x/content/docs/reference/agent/configuration-file/raft.mdx
@@ -18,9 +18,8 @@ The page provides reference information for Raft parameters in a Consul agent co
 
   - `backend` ((#raft_logstore_backend)) Specifies which storage
     engine to use to persist logs. Valid options are `boltdb` or `wal`. Default
-    is `boltdb`. The `wal` option specifies an experimental backend that
-    should be used with caution. Refer to
-    [Experimental WAL LogStore backend](/consul/docs/deploy/server/wal)
+    is `wal`. In versions of Consul prior to 0.21, this defaulted to boltdb.
+    Refer to [WAL LogStore backend](/consul/docs/deploy/server/wal)
     for more information.
 
   - `disable_log_cache` ((#raft_logstore_disable_log_cache)) Disables the in-memory cache for recent logs. We recommend using it for performance testing purposes, as no significant improvement has been measured when the cache is disabled. While the in-memory log cache theoretically prevents disk reads for recent logs, recent logs are also stored in the OS page cache, which does not slow either the `boltdb` or `wal` backend's ability to read them.


### PR DESCRIPTION


## Description

<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of. 

Include the target release as well as prior versions if applicable.
-->
The default of `raft_logstore.backend` had changed but was never doccumented in version 1.21.

## Links

[Make raft-wal default when resource-apis is active #19090](https://github.com/hashicorp/consul/pull/19090)

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [x] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
