### PR TITLE
document deprecated variables and outputs feature

### DIFF
--- a/content/terraform/v1.15.x (rc)/docs/language/block/module.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/block/module.mdx
@@ -31,6 +31,7 @@ A `module` block supports the following configuration:
   - [`depends_on`](#depends_on) &nbsp list of references
   - [`for_each`](#for_each): &nbsp map or set of strings | mutually exclusive with `count`
   - [`providers`](#providers) &nbsp map
+  - [`ignore_nested_deprecations`](#ignore_nested_deprecations) &nbsp boolean
 
 ## Complete configuration
 
@@ -53,6 +54,7 @@ module "<LABEL>" {
     "<provider-name-in-child-module>" = "<provider-name-from-parent-module>"
   }
   depends_on = [ <resource.address.reference> ]
+  ignore_nested_deprecations = <true|false>
 }
 ```
 
@@ -477,6 +479,28 @@ module "<LABEL>" {
 ```
 
 `depends_on` is a **meta-argument**. Meta-arguments are built into the Terraform language and control how Terraform creates resources. Refer to the [`depends_on` reference](/terraform/language/meta-arguments/depends_on) for details about how the argument works.
+
+### `ignore_nested_deprecations`
+
+<Note>
+
+Deprecated values are available in Terraform v1.15 and later.
+
+</Note>
+
+If the `ignore_nested_deprecations` argument is set to true, Terraform won't show any deprecation warnings within the module call or nested modules.
+
+```hcl
+module "<LABEL>" {
+  ignore_nested_deprecations = true
+}
+```
+
+#### Summary
+
+- Data type: Boolean
+- Default: false
+
 
 ## Examples
 

--- a/content/terraform/v1.15.x (rc)/docs/language/block/module.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/block/module.mdx
@@ -488,7 +488,7 @@ Deprecated values are available in Terraform v1.15 and later.
 
 </Note>
 
-If the `ignore_nested_deprecations` argument is set to true, Terraform won't show any deprecation warnings within the module call or nested modules.
+If the `ignore_nested_deprecations` argument is set to true, Terraform does not show deprecation warnings in the module call or nested modules.
 
 ```hcl
 module "<LABEL>" {

--- a/content/terraform/v1.15.x (rc)/docs/language/block/output.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/block/output.mdx
@@ -37,6 +37,7 @@ The `output` block supports the following arguments:
   - [`sensitive`](#sensitive) &nbsp; boolean
   - [`ephemeral`](#ephemeral) &nbsp; boolean
   - [`depends_on`](#depends_on) &nbsp; list of references
+  - [`deprecated`](#deprecated) &nbsp; string
   - [`precondition`](#precondition) &nbsp; block
     - [`condition`](#precondition) &nbsp; expression
     - [`error_message`](#precondition) &nbsp; string
@@ -53,6 +54,7 @@ output "<LABEL>" {
   sensitive   = <true|false>
   ephemeral   = <true|false>
   depends_on  = [<REFERENCE>]
+  deprecated  = "<STRING>"
 
   precondition {
     condition     = <EXPRESSION>
@@ -79,6 +81,7 @@ The following arguments are supported in an `output` block:
 | `sensitive` | Specifies if Terraform hides this value in CLI output. | Boolean | Optional |
 | `ephemeral` | Specifies whether to prevent storing this value in state. | Boolean | Optional |
 | `depends_on` | A list of explicit dependencies for this output. | List | Optional |
+| `deprecated` | Deprecation message for the output. Only valid within non-root modules. | String | Optional |
 | `precondition` | A condition to validate before computing the output or storing it in state. | Block | Optional |
 
 ### `type`
@@ -208,8 +211,37 @@ output "unique_name" {
 
 #### Summary
 
-- Data type: Type constraint
-- Default: `any`
+- Data type: List
+- Default: None
+
+### `deprecated`
+
+<Note>
+
+Deprecated outputs are available in Terraform v1.15 and later.
+
+</Note>
+
+The `deprecated` argument specifies the reason for deprecating an output. Terraform shows this reason when another module uses the output.
+You can only add the `deprecated` argument to `output` blocks in child modules, not in the root module.
+
+```hcl
+output "old_name" {
+  value      = <expression-to-evaluate>
+  deprecated = "Please use 'new_name' instead."
+}
+
+output "new_name" {
+  value = <expression-to-evaluate>
+}
+```
+
+Terraform does not show a deprecation warning inside the module that defines the output. Only module consumers see the warning. To suppress nested deprecation warnings for a module call, set the [`ignore_nested_deprecations` argument](/terraform/language/modules#ignore_nested_deprecations) on the `module` block.
+
+#### Summary
+
+- Data type: String
+- Default: None
 
 ### `precondition`
 

--- a/content/terraform/v1.15.x (rc)/docs/language/block/output.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/block/output.mdx
@@ -81,7 +81,7 @@ The following arguments are supported in an `output` block:
 | `sensitive` | Specifies if Terraform hides this value in CLI output. | Boolean | Optional |
 | `ephemeral` | Specifies whether to prevent storing this value in state. | Boolean | Optional |
 | `depends_on` | A list of explicit dependencies for this output. | List | Optional |
-| `deprecated` | Deprecation message for the output. Only valid within child modules. | String | Optional |
+| `deprecated` | Deprecation message for the output. Only valid in child modules. | String | Optional |
 | `precondition` | A condition to validate before computing the output or storing it in state. | Block | Optional |
 
 ### `type`
@@ -222,7 +222,7 @@ Deprecated outputs are available in Terraform v1.15 and later.
 
 </Note>
 
-The `deprecated` argument specifies the reason for deprecating an output. Terraform shows this reason when another module uses the output.
+The `deprecated` argument specifies the reason an output is deprecated. Terraform shows this reason when another module uses the output.
 You can only add the `deprecated` argument to `output` blocks in child modules, not in the root module.
 
 ```hcl
@@ -236,7 +236,7 @@ output "new_name" {
 }
 ```
 
-Terraform does not show a deprecation warning inside the module that defines the output. Only module consumers see the warning. To suppress nested deprecation warnings for a module call, set the [`ignore_nested_deprecations` argument](/terraform/language/modules#ignore_nested_deprecations) on the `module` block.
+Terraform does not show a deprecation warning inside the module that defines the output. Only module consumers see the warning. To suppress nested deprecation warnings for a module call, set the [`ignore_nested_deprecations` argument](/terraform/language/modules#ignore_nested_deprecations) in the `module` block.
 
 #### Summary
 

--- a/content/terraform/v1.15.x (rc)/docs/language/block/output.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/block/output.mdx
@@ -81,7 +81,7 @@ The following arguments are supported in an `output` block:
 | `sensitive` | Specifies if Terraform hides this value in CLI output. | Boolean | Optional |
 | `ephemeral` | Specifies whether to prevent storing this value in state. | Boolean | Optional |
 | `depends_on` | A list of explicit dependencies for this output. | List | Optional |
-| `deprecated` | Deprecation message for the output. Only valid within non-root modules. | String | Optional |
+| `deprecated` | Deprecation message for the output. Only valid within child modules. | String | Optional |
 | `precondition` | A condition to validate before computing the output or storing it in state. | Block | Optional |
 
 ### `type`

--- a/content/terraform/v1.15.x (rc)/docs/language/block/variable.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/block/variable.mdx
@@ -284,7 +284,7 @@ Deprecated variables are available in Terraform v1.15 and later.
 
 </Note>
 
-The `deprecated` argument specifies the reason for deprecating the variable. Terraform shows this reason when you set the variable in a root module or when a child module caller passes a value for the variable.
+The `deprecated` argument specifies the reason the variable is deprecated. Terraform shows this reason when you set the variable in a root module or when a child module caller passes a value for the variable.
 
 
 ```hcl

--- a/content/terraform/v1.15.x (rc)/docs/language/block/variable.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/block/variable.mdx
@@ -37,7 +37,8 @@ The `variable` block supports the following arguments:
   - [`sensitive`](#sensitive) &nbsp; boolean
   - [`nullable`](#nullable) &nbsp; boolean
   - [`ephemeral`](#ephemeral) &nbsp; boolean
-  - [`const`](#ephemeral) &nbsp; boolean
+  - [`const`](#const) &nbsp; boolean
+  - [`deprecated`](#deprecated) &nbsp; string
 
 ## Complete configuration
 
@@ -52,6 +53,7 @@ variable "<LABEL>" {
   nullable    = <true|false>
   ephemeral   = <true|false>
   const       = <true|false>
+  deprecated  = "<STRING>"
 
   validation {
     condition     = <EXPRESSION>
@@ -79,7 +81,8 @@ The following arguments are supported in a `variable` block:
 | `sensitive` | Specifies if Terraform hides this value in CLI output. | Boolean | Optional |
 | `nullable` | Specifies if the value of a variable can be `null`. | Boolean | Optional |
 | `ephemeral` | Specifies whether to prevent storing this value in state or plan files. | Boolean | Optional |
-| `const` | allows the variable to be used during early Terraform operations, such as initialization. | Boolean | Optional |
+| `const` | Allows the variable to be used during early Terraform operations, such as initialization. | Boolean | Optional |
+| `deprecated` | Deprecation message for the variable. | String | Optional |
 
 ### `type`
 
@@ -273,6 +276,33 @@ If `const` is `true` in a variable block, then that variable can only contain a 
 - Data type: Boolean
 - Default: `false`
 
+### `deprecated`
+
+<Note>
+
+Deprecated variables are available in Terraform v1.15 and later.
+
+</Note>
+
+The `deprecated` argument specifies the reason for deprecating the variable. Terraform shows this reason when you set the variable in a root module or when a child module caller passes a value for the variable.
+
+
+```hcl
+variable "old_input" {
+  type       = string
+  deprecated = "This variable is deprecated, please use 'new_input' instead."
+}
+
+variable "new_input" {
+  type    = list(string)
+  default = []
+}
+```
+
+#### Summary
+
+- Data type: String
+- Default: None
 ## Examples
 
 The following examples demonstrate common use cases for `variable` blocks.


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

Documented new `deprecated` field on output and variables and `ignore_nested_deprecations` on module calls.

- content/terraform/v1.15.x (alpha)/docs/language/block/module.mdx
- content/terraform/v1.15.x (alpha)/docs/language/block/output.mdx
- content/terraform/v1.15.x (alpha)/docs/language/block/variable.mdx


### Why
<!-- Explain why this change is necessary and how it benefits users. -->

We are about to add support for deprecating variables and outputs. Not yet merged, therefore this is a draft, but I wanted to get the documentation out of the way.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

### PRs

- [#38082 deprecation: limit deep unmarking for better performance](https://github.com/hashicorp/terraform/pull/38082)
- [#38077 add deprecation marks to resources based on schema](https://github.com/hashicorp/terraform/pull/38077)
- [#38052 add extra origin information for deprecation diagnostics](https://github.com/hashicorp/terraform/pull/38052)
- [#38001 variable and output deprecation](https://github.com/hashicorp/terraform/pull/38001)
- [#38000 Add deprecation surpression tracking](https://github.com/hashicorp/terraform/pull/38000)
- [#37999 add deprecation marks](https://github.com/hashicorp/terraform/pull/37999)


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance.  (N/A)
- [x] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. (N/A)
- [x] New pages have metadata (page name and description) at the top. (N/A)
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. (N/A)
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded. (N/A)
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
