### PR TITLE
docs: Clarify worker compatibility

### DIFF
--- a/content/boundary/v0.21.x/content/docs/enterprise/supported-versions.mdx
+++ b/content/boundary/v0.21.x/content/docs/enterprise/supported-versions.mdx
@@ -22,8 +22,8 @@ Release updates for Boundary Enterprise can be found at https://releases.hashico
 
 ## Control plane and worker compatibility
 
-Although major releases are supported as outlined within the support periods section above, within a Boundary Enterprise deployment API backwards compatibility is only supported between the control plane and workers from the prior “major release”. Using a worker with version that is newer than the control plane they connect to is not supported.
-All workers within an environment must be on the same version.
+Although major releases are supported as outlined within the support periods section above, within a Boundary Enterprise deployment API backwards compatibility is only supported between the control plane and workers from the prior “major release”. Using a worker with a version that is newer than the control plane they connect to is not supported.
+Workers should be kept within one major release of the control plane version, and upgraded to the same version as the control plane as soon as possible.
 
 For example, Boundary workers version 0.19.0 are compatible with a Boundary control plane running Boundary 0.20.0.
 However, they will not have compatibility once the control plane is updated to version 0.21.0 or above.


### PR DESCRIPTION
Per [SPE-1428](https://hashicorp.atlassian.net/browse/SPE-1428), there is some conflicting information about worker compatibility with the control plane in the Boundary Ent supported versions doc. This PR clarifies that workers are supported within 1 major release of the control plane version.

[Slack context](https://ibm-hashicorp.slack.com/archives/C09KZ5C3D2N/p1768583891484699)

[View the update in the preview deployment](https://unified-docs-frontend-preview-j6zaxtc0k-hashicorp.vercel.app/boundary/docs/enterprise/supported-versions#control-plane-and-worker-compatibility)

[SPE-1428]: https://hashicorp.atlassian.net/browse/SPE-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ