### PR TITLE
Nomad Docs: Add version redirects for load balancer pages version pick list 1.9, 1.8 entries

### DIFF
--- a/content/nomad/v1.11.x/redirects.jsonc
+++ b/content/nomad/v1.11.x/redirects.jsonc
@@ -1163,7 +1163,7 @@
   },
   // pick list links. 1.4 changed to api-docs/acl/tokens
    {
-    "source": "/nomad/api-docs/:version(v1\\.(?:9|8|7|6|5|4)\\.x)/acl-tokenss",
+    "source": "/nomad/api-docs/:version(v1\\.(?:9|8|7|6|5|4)\\.x)/acl-tokens",
     "destination": "/nomad/api-docs/:version/acl/tokens",
     "permanent": true,
   },
@@ -1175,6 +1175,33 @@
   {
     "source": "/nomad/api-docs/:version(v0\\.(?:11|12)\\.x)/acl/tokens",
     "destination": "/nomad/api-docs/:version/acl-tokens",
+    "permanent": true,
+  },
+  // pick list links for load balance pages. 1.11, 1.10 exist but prior should 
+  // point to tutorials site
+  {
+    "source": "/nomad/docs/:version(v1\\.(?:9|8)\\.x)/networking/load-balancer",
+    "destination": "/nomad/tutorials/archive/load-balancing",
+    "permanent": true,
+  },
+  {
+    "source": "/nomad/docs/:version(v1\\.(?:9|8)\\.x)/networking/load-balancer/fabio",
+    "destination": "/nomad/tutorials/archive/load-balancing-fabio",
+    "permanent": true,
+  },
+  {
+    "source": "/nomad/docs/:version(v1\\.(?:9|8)\\.x)/networking/load-balancer/haproxy",
+    "destination": "/nomad/tutorials/archive/load-balancing-haproxy",
+    "permanent": true,
+  },
+  {
+    "source": "/nomad/docs/:version(v1\\.(?:9|8)\\.x)/networking/load-balancer/nginx",
+    "destination": "/nomad/tutorials/archive/load-balancing-nginx",
+    "permanent": true,
+  },
+  {
+    "source": "/nomad/docs/:version(v1\\.(?:9|8)\\.x)/networking/load-balancer/traefik",
+    "destination": "/nomad/tutorials/archive/load-balancing-traefik",
     "permanent": true,
   },
 ]


### PR DESCRIPTION
## Description

Add redirects for load balancer pages version pick list. The content exists in 1.11, 1.10, but 1.9 and 1.8 need redirect to archived tutorials pages. Currently, 404 result if I am on a load balancer page and select 1.9 or 1.8 version from version pick list.

---

<img width="750" height="364" alt="image" src="https://github.com/user-attachments/assets/60f90b9a-5fed-45c0-8ef3-0ba1900e4349" />

---

| Page                                         | Pick list version | Redirects to                                    |
|----------------------------------------------|-------------------|-------------------------------------------------|
| /nomad/docs/networking/load-balancer         | 1.9, 1.8          | /nomad/tutorials/archive/load-balancing         |
| /nomad/docs/networking/load-balancer/fabio   | 1.9, 1.8          | /nomad/tutorials/archive/load-balancing-fabio   |
| /nomad/docs/networking/load-balancer/haproxy | 1.9, 1.8          | /nomad/tutorials/archive/load-balancing-haproxy |
| /nomad/docs/networking/load-balancer/nginx   | 1.9, 1.8          | /nomad/tutorials/archive/load-balancing-nginx   |
| /nomad/docs/networking/load-balancer/traefik | 1.9, 1.8          | /nomad/tutorials/archive/load-balancing-traefik |

## Links

Jira: [CE-1112]


## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CE-1112]: https://hashicorp.atlassian.net/browse/CE-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ