### PR TITLE
feat: add date metadata to terraform-plugin-log docs

### DIFF
--- a/content/terraform-plugin-log/v0.4.x/docs/plugin/log/index.mdx
+++ b/content/terraform-plugin-log/v0.4.x/docs/plugin/log/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Logging: Overview"
 description: >-
   Learn about logging with Terraform Providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Logging

--- a/content/terraform-plugin-log/v0.4.x/docs/plugin/log/managing.mdx
+++ b/content/terraform-plugin-log/v0.4.x/docs/plugin/log/managing.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Managing Log Output'
 description: >-
   Filter log outputs by subsystem and verbosity level. Set the log format and output path.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Managing Log Output

--- a/content/terraform-plugin-log/v0.4.x/docs/plugin/log/writing.mdx
+++ b/content/terraform-plugin-log/v0.4.x/docs/plugin/log/writing.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Writing Log Output'
 description: >-
   Write logs from your provider that help users debug issues and understand operations.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Log Output

--- a/content/terraform-plugin-log/v0.5.x/docs/plugin/log/index.mdx
+++ b/content/terraform-plugin-log/v0.5.x/docs/plugin/log/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Logging: Overview"
 description: >-
   Learn about logging with Terraform Providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Logging

--- a/content/terraform-plugin-log/v0.5.x/docs/plugin/log/managing.mdx
+++ b/content/terraform-plugin-log/v0.5.x/docs/plugin/log/managing.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Managing Log Output'
 description: >-
   Filter log outputs by subsystem and verbosity level. Set the log format and output path.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Managing Log Output

--- a/content/terraform-plugin-log/v0.5.x/docs/plugin/log/writing.mdx
+++ b/content/terraform-plugin-log/v0.5.x/docs/plugin/log/writing.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Writing Log Output'
 description: >-
   Write logs from your provider that help users debug issues and understand operations.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Log Output

--- a/content/terraform-plugin-log/v0.6.x/docs/plugin/log/filtering.mdx
+++ b/content/terraform-plugin-log/v0.6.x/docs/plugin/log/filtering.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Filtering Log Output'
 description: >-
   Omit or mask specific log information from your provider to hide sensitive data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Filtering Log Output

--- a/content/terraform-plugin-log/v0.6.x/docs/plugin/log/index.mdx
+++ b/content/terraform-plugin-log/v0.6.x/docs/plugin/log/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Logging: Overview"
 description: >-
   Learn about logging with Terraform Providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Logging

--- a/content/terraform-plugin-log/v0.6.x/docs/plugin/log/managing.mdx
+++ b/content/terraform-plugin-log/v0.6.x/docs/plugin/log/managing.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Managing Log Output'
 description: >-
   Filter log outputs by subsystem and verbosity level. Set the log format and output path.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Managing Log Output

--- a/content/terraform-plugin-log/v0.6.x/docs/plugin/log/writing.mdx
+++ b/content/terraform-plugin-log/v0.6.x/docs/plugin/log/writing.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Writing Log Output'
 description: >-
   Write logs from your provider that help users debug issues and understand operations.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Log Output

--- a/content/terraform-plugin-log/v0.7.x/docs/plugin/log/filtering.mdx
+++ b/content/terraform-plugin-log/v0.7.x/docs/plugin/log/filtering.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Filtering Log Output'
 description: >-
   Omit or mask specific log information from your provider to hide sensitive data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Filtering Log Output

--- a/content/terraform-plugin-log/v0.7.x/docs/plugin/log/index.mdx
+++ b/content/terraform-plugin-log/v0.7.x/docs/plugin/log/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Logging: Overview"
 description: >-
   Learn about logging with Terraform Providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Logging

--- a/content/terraform-plugin-log/v0.7.x/docs/plugin/log/managing.mdx
+++ b/content/terraform-plugin-log/v0.7.x/docs/plugin/log/managing.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Managing Log Output'
 description: >-
   Filter log outputs by subsystem and verbosity level. Set the log format and output path.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Managing Log Output

--- a/content/terraform-plugin-log/v0.7.x/docs/plugin/log/writing.mdx
+++ b/content/terraform-plugin-log/v0.7.x/docs/plugin/log/writing.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Writing Log Output'
 description: >-
   Write logs from your provider that help users debug issues and understand operations.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Log Output

--- a/content/terraform-plugin-log/v0.8.x/docs/plugin/log/filtering.mdx
+++ b/content/terraform-plugin-log/v0.8.x/docs/plugin/log/filtering.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Filtering Log Output'
 description: >-
   Omit or mask specific log information from your provider to hide sensitive data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Filtering Log Output

--- a/content/terraform-plugin-log/v0.8.x/docs/plugin/log/index.mdx
+++ b/content/terraform-plugin-log/v0.8.x/docs/plugin/log/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Logging: Overview"
 description: >-
   Enable and filter log output for debugging. Write provider logic to generate helpful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-log/v0.8.x/docs/plugin/log/managing.mdx
+++ b/content/terraform-plugin-log/v0.8.x/docs/plugin/log/managing.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Managing Log Output'
 description: >-
   Filter log outputs by subsystem and verbosity level. Set the log format and output path.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Managing Log Output

--- a/content/terraform-plugin-log/v0.8.x/docs/plugin/log/writing.mdx
+++ b/content/terraform-plugin-log/v0.8.x/docs/plugin/log/writing.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Writing Log Output'
 description: >-
   Write logs from your provider that help users debug issues and understand operations.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Log Output

--- a/content/terraform-plugin-log/v0.9.x/docs/plugin/log/filtering.mdx
+++ b/content/terraform-plugin-log/v0.9.x/docs/plugin/log/filtering.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Filtering Log Output'
 description: >-
   Omit or mask specific log information from your provider to hide sensitive data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Filtering Log Output

--- a/content/terraform-plugin-log/v0.9.x/docs/plugin/log/index.mdx
+++ b/content/terraform-plugin-log/v0.9.x/docs/plugin/log/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Logging: Overview"
 description: >-
   Enable and filter log output for debugging. Write provider logic to generate helpful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-log/v0.9.x/docs/plugin/log/managing.mdx
+++ b/content/terraform-plugin-log/v0.9.x/docs/plugin/log/managing.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Managing Log Output'
 description: >-
   Filter log outputs by subsystem and verbosity level. Set the log format and output path.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Managing Log Output

--- a/content/terraform-plugin-log/v0.9.x/docs/plugin/log/writing.mdx
+++ b/content/terraform-plugin-log/v0.9.x/docs/plugin/log/writing.mdx
@@ -2,6 +2,10 @@
 page_title: 'Home - Plugin Development: Writing Log Output'
 description: >-
   Write logs from your provider that help users debug issues and understand operations.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Log Output


### PR DESCRIPTION
### Description

This PR adds date metadata to the terraform-plugin-log documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715

### Testing

Check that terraform-plugin-log docs look normal in the preview: https://unified-docs-frontend-preview-b1cg1yf7e-hashicorp.vercel.app/terraform/plugin/log