### PR TITLE
feat: add date metadata to terraform-plugin-mux docs

### DIFF
--- a/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.19.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.19.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T14:47:07-04:00
+last_modified: 2025-05-16T14:47:07-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.19.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.19.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T14:47:07-04:00
+last_modified: 2025-05-16T14:47:07-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.19.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.19.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T14:47:07-04:00
+last_modified: 2025-05-16T14:47:07-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.19.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.19.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T14:47:07-04:00
+last_modified: 2025-05-16T14:47:07-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.19.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.19.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T14:47:07-04:00
+last_modified: 2025-05-16T14:47:07-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.20.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.20.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-28T16:21:40-04:00
+last_modified: 2025-05-28T16:21:40-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.20.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.20.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-28T16:21:40-04:00
+last_modified: 2025-05-28T16:21:40-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.20.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.20.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-28T16:21:40-04:00
+last_modified: 2025-05-28T16:21:40-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.20.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.20.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-28T16:21:40-04:00
+last_modified: 2025-05-28T16:21:40-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.20.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.20.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-28T16:21:40-04:00
+last_modified: 2025-05-28T16:21:40-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.21.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.21.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T13:35:16-05:00
+last_modified: 2025-09-23T13:35:16-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.21.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.21.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T13:35:16-05:00
+last_modified: 2025-09-23T13:35:16-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.21.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.21.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T13:35:16-05:00
+last_modified: 2025-09-23T13:35:16-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.21.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.21.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T13:35:16-05:00
+last_modified: 2025-09-23T13:35:16-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.21.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.21.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T13:35:16-05:00
+last_modified: 2025-09-23T13:35:16-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5

--- a/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 5 Providers

--- a/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining Protocol Version 6 Providers

--- a/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/index.mdx
@@ -2,6 +2,10 @@
 page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Combining and Translating Providers

--- a/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 5 to 6

--- a/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Translating Protocol Version 6 to 5


### PR DESCRIPTION
### Description

This PR adds date metadata to the terraform-plugin-mux documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715

### Testing

Check that terraform-plugin-mux docs look normal in the preview: https://unified-docs-frontend-preview-iebzeqh75-hashicorp.vercel.app/terraform/plugin/mux