### PR TITLE
feat: add date metadata to terraform-migrate docs

### DIFF
--- a/content/terraform-migrate/v1.0.x/docs/migrate/authenticate.mdx
+++ b/content/terraform-migrate/v1.0.x/docs/migrate/authenticate.mdx
@@ -2,6 +2,10 @@
 page_title: Authenticate `tf-migrate`
 description: >-
   Learn how to authenticate tf-migrate to migrate existing state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-07T22:55:42-04:00
+last_modified: 2025-08-08T10:51:30-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Authenticate `tf-migrate`

--- a/content/terraform-migrate/v1.0.x/docs/migrate/index.mdx
+++ b/content/terraform-migrate/v1.0.x/docs/migrate/index.mdx
@@ -2,6 +2,10 @@
 page_title: Migrate to HCP Terraform
 description: >-
   The tf-migrate CLI migrates existing Terraform state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-07T22:55:42-04:00
+last_modified: 2025-08-08T11:46:17-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Migrate to HCP Terraform

--- a/content/terraform-migrate/v1.0.x/docs/migrate/install.mdx
+++ b/content/terraform-migrate/v1.0.x/docs/migrate/install.mdx
@@ -2,6 +2,10 @@
 page_title: Install tf-migrate
 description: >-
   Install the tf-migrate CLI tool to migrate existing state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-07T22:55:42-04:00
+last_modified: 2025-08-08T10:51:30-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install `tf-migrate`

--- a/content/terraform-migrate/v1.0.x/docs/migrate/reference/configuration.mdx
+++ b/content/terraform-migrate/v1.0.x/docs/migrate/reference/configuration.mdx
@@ -2,6 +2,10 @@
 page_title: Configuration file reference
 description: >-
   Configure `tf-migrate` to control how it migrates your state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-07T22:55:42-04:00
+last_modified: 2025-08-08T10:11:57-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate` configuration file reference

--- a/content/terraform-migrate/v1.0.x/docs/migrate/reference/execute.mdx
+++ b/content/terraform-migrate/v1.0.x/docs/migrate/reference/execute.mdx
@@ -2,6 +2,10 @@
 page_title: tf-migrate execute reference
 description: >-
   The `tf-migrate execute` command runs a prepared migration to migrate locally existing state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-07T22:55:42-04:00
+last_modified: 2025-08-07T22:55:42-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate execute` reference

--- a/content/terraform-migrate/v1.0.x/docs/migrate/reference/prepare.mdx
+++ b/content/terraform-migrate/v1.0.x/docs/migrate/reference/prepare.mdx
@@ -2,6 +2,10 @@
 page_title: tf-migrate prepare reference
 description: >-
   The `tf-migrate prepare` command creates a plan to migrate your Terraform Community Edition state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-07T22:55:42-04:00
+last_modified: 2025-08-08T10:11:57-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate prepare` reference

--- a/content/terraform-migrate/v1.1.x/docs/migrate/authenticate.mdx
+++ b/content/terraform-migrate/v1.1.x/docs/migrate/authenticate.mdx
@@ -2,6 +2,10 @@
 page_title: Authenticate `tf-migrate`
 description: >-
   Learn how to authenticate tf-migrate to migrate existing state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-06T16:33:48-04:00
+last_modified: 2025-08-08T10:51:30-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Authenticate `tf-migrate`

--- a/content/terraform-migrate/v1.1.x/docs/migrate/index.mdx
+++ b/content/terraform-migrate/v1.1.x/docs/migrate/index.mdx
@@ -2,6 +2,10 @@
 page_title: Migrate to HCP Terraform
 description: >-
   The tf-migrate CLI migrates existing Terraform state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-05T23:39:26-07:00
+last_modified: 2025-08-08T11:46:17-04:00
+# END AUTO GENERATED METADATA
 ---
 
 #  Migrate to HCP Terraform

--- a/content/terraform-migrate/v1.1.x/docs/migrate/install.mdx
+++ b/content/terraform-migrate/v1.1.x/docs/migrate/install.mdx
@@ -2,6 +2,10 @@
 page_title: Install tf-migrate
 description: >-
   Learn how to install the Terraform migrate tf-migrate CLI tool.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-06T16:33:48-04:00
+last_modified: 2025-08-08T10:51:30-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install `tf-migrate`

--- a/content/terraform-migrate/v1.1.x/docs/migrate/reference/configuration.mdx
+++ b/content/terraform-migrate/v1.1.x/docs/migrate/reference/configuration.mdx
@@ -2,6 +2,10 @@
 page_title: Configuration file reference
 description: >-
   You can configure `tf-migrate` to control how it migrate your state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-05T23:39:26-07:00
+last_modified: 2025-08-05T23:39:26-07:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate` configuration file reference

--- a/content/terraform-migrate/v1.1.x/docs/migrate/reference/execute.mdx
+++ b/content/terraform-migrate/v1.1.x/docs/migrate/reference/execute.mdx
@@ -2,6 +2,10 @@
 page_title: tf-migrate execute reference
 description: >-
   The `tf-migrate execute` command runs a prepared migration plan to move local state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-05T23:39:26-07:00
+last_modified: 2025-08-08T10:11:57-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate execute` reference

--- a/content/terraform-migrate/v1.1.x/docs/migrate/reference/prepare.mdx
+++ b/content/terraform-migrate/v1.1.x/docs/migrate/reference/prepare.mdx
@@ -2,6 +2,10 @@
 page_title: tf-migrate prepare reference
 description: >-
   The `tf-migrate prepare` command gathers information and creates a plan to migrate your Terraform Community Edition state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-05T23:39:26-07:00
+last_modified: 2025-08-05T23:39:26-07:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate prepare` reference

--- a/content/terraform-migrate/v1.2.x/docs/migrate/authenticate.mdx
+++ b/content/terraform-migrate/v1.2.x/docs/migrate/authenticate.mdx
@@ -2,6 +2,10 @@
 page_title: Authenticate `tf-migrate`
 description: >-
   Learn how to authenticate tf-migrate to migrate existing state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-19T02:33:25-04:00
+last_modified: 2025-08-20T11:57:37-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Authenticate `tf-migrate`

--- a/content/terraform-migrate/v1.2.x/docs/migrate/index.mdx
+++ b/content/terraform-migrate/v1.2.x/docs/migrate/index.mdx
@@ -2,6 +2,10 @@
 page_title: Migrate to HCP Terraform
 description: >-
   The tf-migrate CLI migrates existing Terraform state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-19T02:33:25-04:00
+last_modified: 2025-08-19T02:33:25-04:00
+# END AUTO GENERATED METADATA
 ---
 
 #  Migrate to HCP Terraform

--- a/content/terraform-migrate/v1.2.x/docs/migrate/install.mdx
+++ b/content/terraform-migrate/v1.2.x/docs/migrate/install.mdx
@@ -2,6 +2,10 @@
 page_title: Install tf-migrate
 description: >-
   Learn how to install the Terraform migrate tf-migrate CLI tool.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-19T02:33:25-04:00
+last_modified: 2025-08-19T02:33:25-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install `tf-migrate`

--- a/content/terraform-migrate/v1.2.x/docs/migrate/reference/configuration.mdx
+++ b/content/terraform-migrate/v1.2.x/docs/migrate/reference/configuration.mdx
@@ -2,6 +2,10 @@
 page_title: Configuration file reference
 description: >-
   You can configure `tf-migrate` to control how it migrate your state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-19T02:33:25-04:00
+last_modified: 2025-08-19T02:33:25-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate` configuration file reference

--- a/content/terraform-migrate/v1.2.x/docs/migrate/reference/execute.mdx
+++ b/content/terraform-migrate/v1.2.x/docs/migrate/reference/execute.mdx
@@ -2,6 +2,10 @@
 page_title: tf-migrate execute reference
 description: >-
   The `tf-migrate execute` command runs a prepared migration plan to move local state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-19T02:33:25-04:00
+last_modified: 2025-08-19T02:33:25-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate execute` reference

--- a/content/terraform-migrate/v1.2.x/docs/migrate/reference/prepare.mdx
+++ b/content/terraform-migrate/v1.2.x/docs/migrate/reference/prepare.mdx
@@ -2,6 +2,10 @@
 page_title: tf-migrate prepare reference
 description: >-
   The `tf-migrate prepare` command gathers information and creates a plan to migrate your Terraform Community Edition state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-08-19T02:33:25-04:00
+last_modified: 2025-08-19T02:33:25-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate prepare` reference

--- a/content/terraform-migrate/v2.0.x/docs/migrate/authenticate.mdx
+++ b/content/terraform-migrate/v2.0.x/docs/migrate/authenticate.mdx
@@ -2,6 +2,10 @@
 page_title: Authenticate `tf-migrate`
 description: >-
   Learn how to authenticate tf-migrate to migrate existing state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-06T08:59:10-05:00
+last_modified: 2025-11-06T08:59:10-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Authenticate `tf-migrate`

--- a/content/terraform-migrate/v2.0.x/docs/migrate/index.mdx
+++ b/content/terraform-migrate/v2.0.x/docs/migrate/index.mdx
@@ -2,6 +2,10 @@
 page_title: Migrate to HCP Terraform
 description: >-
   The tf-migrate CLI migrates existing Terraform state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-06T08:59:10-05:00
+last_modified: 2025-12-04T08:49:13-05:00
+# END AUTO GENERATED METADATA
 ---
 
 #  Migrate to HCP Terraform

--- a/content/terraform-migrate/v2.0.x/docs/migrate/install.mdx
+++ b/content/terraform-migrate/v2.0.x/docs/migrate/install.mdx
@@ -2,6 +2,10 @@
 page_title: Install tf-migrate
 description: >-
   Learn how to install the Terraform migrate tf-migrate CLI tool.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-06T08:59:10-05:00
+last_modified: 2025-11-06T08:59:10-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install `tf-migrate`

--- a/content/terraform-migrate/v2.0.x/docs/migrate/reference/cli/execute.mdx
+++ b/content/terraform-migrate/v2.0.x/docs/migrate/reference/cli/execute.mdx
@@ -2,6 +2,10 @@
 page_title: tf-migrate execute reference
 description: >-
   The `tf-migrate execute` command runs a prepared migration plan to move local state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-06T08:59:10-05:00
+last_modified: 2025-11-06T08:59:10-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate execute` reference

--- a/content/terraform-migrate/v2.0.x/docs/migrate/reference/cli/modules/create.mdx
+++ b/content/terraform-migrate/v2.0.x/docs/migrate/reference/cli/modules/create.mdx
@@ -2,6 +2,10 @@
 page_title: tf-migrate modules create reference
 description: >-
   The `tf-migrate modules create` command converts your Terraform root module into a child modules so that it can be deployed as a Stack.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-06T08:59:10-05:00
+last_modified: 2025-12-04T08:49:13-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate modules create` reference

--- a/content/terraform-migrate/v2.0.x/docs/migrate/reference/cli/prepare.mdx
+++ b/content/terraform-migrate/v2.0.x/docs/migrate/reference/cli/prepare.mdx
@@ -2,6 +2,10 @@
 page_title: tf-migrate prepare reference
 description: >-
   The `tf-migrate prepare` command gathers information and creates a plan to migrate your Terraform Community Edition state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-06T08:59:10-05:00
+last_modified: 2025-11-06T08:59:10-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate prepare` reference

--- a/content/terraform-migrate/v2.0.x/docs/migrate/reference/cli/stacks/cleanup.mdx
+++ b/content/terraform-migrate/v2.0.x/docs/migrate/reference/cli/stacks/cleanup.mdx
@@ -2,6 +2,10 @@
 page_title: tf-migrate stacks cleanup reference
 description: >-
   The `tf-migrate stacks cleanup` command deletes a deployed Stack.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-06T08:59:10-05:00
+last_modified: 2025-12-04T08:49:13-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate stacks cleanup` reference

--- a/content/terraform-migrate/v2.0.x/docs/migrate/reference/cli/stacks/execute.mdx
+++ b/content/terraform-migrate/v2.0.x/docs/migrate/reference/cli/stacks/execute.mdx
@@ -2,6 +2,10 @@
 page_title: tf-migrate stacks execute reference
 description: >-
   The `tf-migrate stacks execute` command runs a prepared migration plan to move your HCP Terraform workspace to a Stack.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-06T08:59:10-05:00
+last_modified: 2025-12-04T08:49:13-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate stacks execute` reference

--- a/content/terraform-migrate/v2.0.x/docs/migrate/reference/cli/stacks/prepare.mdx
+++ b/content/terraform-migrate/v2.0.x/docs/migrate/reference/cli/stacks/prepare.mdx
@@ -2,6 +2,10 @@
 page_title: tf-migrate stacks prepare reference
 description: >-
   The `tf-migrate stacks prepare` command creates a plan to migrate your HCP Terraform workspace to a Stack.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-06T08:59:10-05:00
+last_modified: 2025-12-04T08:49:13-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate stacks prepare` reference

--- a/content/terraform-migrate/v2.0.x/docs/migrate/reference/configuration.mdx
+++ b/content/terraform-migrate/v2.0.x/docs/migrate/reference/configuration.mdx
@@ -2,6 +2,10 @@
 page_title: Configuration file reference
 description: >-
   You can configure `tf-migrate` to control how it migrate your state to HCP Terraform or Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-06T08:59:10-05:00
+last_modified: 2025-11-06T08:59:10-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # `tf-migrate` configuration file reference

--- a/content/terraform-migrate/v2.0.x/docs/migrate/releases/v2_0.mdx
+++ b/content/terraform-migrate/v2.0.x/docs/migrate/releases/v2_0.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: tf-migrate 2.0 release notes
 description: Learn about the changes in tf-migrate version 2.0
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-06T08:59:10-05:00
+last_modified: 2025-11-06T08:59:10-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # tf-migrate v2.0 release notes

--- a/content/terraform-migrate/v2.0.x/docs/migrate/stacks.mdx
+++ b/content/terraform-migrate/v2.0.x/docs/migrate/stacks.mdx
@@ -2,6 +2,10 @@
 page_title: Migrate workspaces to a Stack
 description: >-
   Learn how to use `tf-migrate` to migrate one or more HCP Terraform workspaces to a Stack
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-06T08:59:10-05:00
+last_modified: 2025-12-04T08:49:13-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Migrate workspaces to a Stack


### PR DESCRIPTION
### Description

This PR adds date metadata to the terraform-migrate documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715

### Testing

Check that terraform-migrate docs look normal in the preview: https://unified-docs-frontend-preview-pmiwrszd8-hashicorp.vercel.app/terraform/migrate
