### PR TITLE
feat: add date metadata for terraform-plugin-testing-docs

### DIFF
--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/testing-api.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Configuration'
 description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Configuration

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Bool Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float32 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float32 Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan or state for use in Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int32 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int32 Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # List Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Map Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # NotNull Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Null Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Number Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Object Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Set Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # String Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Tuple Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Tuple Known Value Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Plan Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output Plan Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource Plan Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom State Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # State Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output State Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource State Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform JSON Paths'
 description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform JSON Paths

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Version Checks'
 description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Version Checks

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Value Comparers'
 description: >-
     How to use value comparers in the testing module.
     Value comparers define a comparison for a resource attribute, or output value for use in State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Value Comparers

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Configuration'
 description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Configuration

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/ephemeral-resources.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/ephemeral-resources.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Ephemeral Resources'
 description: >-
     Guidance on how to test ephemeral resources and data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Bool Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float32 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float32 Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan or state for use in Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int32 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int32 Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # List Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Map Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # NotNull Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Null Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Number Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Object Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Set Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # String Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Tuple Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Tuple Known Value Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Plan Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output Plan Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource Plan Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom State Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # State Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output State Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource State Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform JSON Paths'
 description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform JSON Paths

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Version Checks'
 description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Version Checks

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Value Comparers'
 description: >-
     How to use value comparers in the testing module.
     Value comparers define a comparison for a resource attribute, or output value for use in State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Value Comparers

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Configuration'
 description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Configuration

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/ephemeral-resources.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/ephemeral-resources.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Ephemeral Resources'
 description: >-
     Guidance on how to test ephemeral resources and data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Bool Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float32 Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float32 Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan or state for use in Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int32 Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int32 Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # List Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Map Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # NotNull Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Null Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Number Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Object Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Set Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # String Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Tuple Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Tuple Known Value Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Plan Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output Plan Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource Plan Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom State Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # State Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output State Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource State Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform JSON Paths'
 description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform JSON Paths

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Version Checks'
 description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Version Checks

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Value Comparers'
 description: >-
     How to use value comparers in the testing module.
     Value comparers define a comparison for a resource attribute, or output value for use in State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Value Comparers

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.12.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-19T09:28:23-04:00
+last_modified: 2025-03-19T09:28:23-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Configuration'
 description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Configuration

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/continuous-integration.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/continuous-integration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Acceptance Testing: Continuous Integration'
 description:
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: Continuous Integration

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/environment-variables.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/environment-variables.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Environment Variables'
 description: |-
   Reference for environment variables that control aspects of acceptance test
   execution.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Testing: Environment Variables

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/ephemeral-resources.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/ephemeral-resources.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Ephemeral Resources'
 description: >-
     Guidance on how to test ephemeral resources and data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/import-mode.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/import-mode.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Import mode'
 description: |-
   _Import_ mode is used for testing resource functionality to import existing
   infrastructure into a Terraform statefile, using real Terraform import logic.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: Import mode

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-19T11:26:31-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Bool Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float32 Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float32 Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan or state for use in Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int32 Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int32 Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # List Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Map Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # NotNull Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Null Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Number Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Object Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Set Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # String Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Tuple Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Tuple Known Value Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Plan Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output Plan Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource Plan Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom State Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # State Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output State Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource State Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform JSON Paths'
 description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform JSON Paths

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Version Checks'
 description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Version Checks

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Value Comparers'
 description: >-
     How to use value comparers in the testing module.
     Value comparers define a comparison for a resource attribute, or output value for use in State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Value Comparers

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Write acceptance tests and unit tests with the terraform-plugin-testing Go
   module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plugin Testing

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-08-20T17:01:56+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.13.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-16T15:12:51-04:00
+last_modified: 2025-05-16T15:12:51-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Configuration'
 description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Configuration

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/continuous-integration.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/continuous-integration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Acceptance Testing: Continuous Integration'
 description:
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: Continuous Integration

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/environment-variables.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/environment-variables.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Environment Variables'
 description: |-
   Reference for environment variables that control aspects of acceptance test
   execution.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Testing: Environment Variables

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/ephemeral-resources.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/ephemeral-resources.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Ephemeral Resources'
 description: >-
     Guidance on how to test ephemeral resources and data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/import-mode.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/import-mode.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Import mode'
 description: |-
   _Import_ mode is used for testing resource functionality to import existing
   infrastructure into a Terraform statefile, using real Terraform import logic.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: Import mode

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Bool Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float32 Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float32 Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan or state for use in Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int32 Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int32 Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # List Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Map Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # NotNull Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Null Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Number Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Object Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Set Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan and State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # String Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Tuple Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Tuple Known Value Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Plan Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output Plan Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource Plan Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/query-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/query-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Query Checks'
 description: >-
   Query Checks are test assertions that can inspect the query results during a TestStep. Custom Query Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-12-04T13:12:26+01:00
+last_modified: 2025-12-04T13:31:52+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Query Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/query-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/query-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Query Checks'
 description: >-
   Query Checks are test assertions that can inspect the query results during a Query TestStep. The testing module
   provides built-in Query Checks for common use-cases, and custom Query Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-12-04T13:12:26+01:00
+last_modified: 2025-12-10T08:53:06+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Query Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/query-checks/query-result.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/query-checks/query-result.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Query Result Checks'
 description: >-
   Query Checks are test assertions that can inspect the query results during a TestStep. The testing module
   provides built-in Query Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-12-04T13:12:26+01:00
+last_modified: 2025-12-10T08:53:06+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Query Result Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/query-mode.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/query-mode.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Query mode'
 description: |-
     _Query_ mode is used for testing list resources using Terraform query.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-12-04T13:12:26+01:00
+last_modified: 2025-12-04T13:12:26+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: Query mode

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom State Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # State Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output State Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource State Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-12-04T13:12:26+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform JSON Paths'
 description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform JSON Paths

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Version Checks'
 description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Version Checks

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Value Comparers'
 description: >-
     How to use value comparers in the testing module.
     Value comparers define a comparison for a resource attribute, or output value for use in State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Value Comparers

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Write acceptance tests and unit tests with the terraform-plugin-testing Go
   module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plugin Testing

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.14.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-11-25T14:07:10+01:00
+last_modified: 2025-11-25T14:07:10+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, but custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, but custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Version Checks'
 description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Version Checks

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, but custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform JSON Paths'
 description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform JSON Paths

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Version Checks'
 description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Version Checks

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Configuration'
 description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Configuration

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, but custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform JSON Paths'
 description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform JSON Paths

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Version Checks'
 description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Version Checks

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Configuration'
 description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Configuration

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Plan Checks

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output Plan Checks

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource Plan Checks

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform JSON Paths'
 description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform JSON Paths

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Version Checks'
 description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Version Checks

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Configuration'
 description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Configuration

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Bool Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan for use in Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # List Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Map Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # NotNull Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Null Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Number Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Object Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Set Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # String Known Value Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Plan Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output Plan Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource Plan Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom State Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # State Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output State Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource State Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform JSON Paths'
 description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform JSON Paths

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Version Checks'
 description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Version Checks

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Configuration'
 description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Configuration

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Bool Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan for use in Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # List Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Map Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # NotNull Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Null Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Number Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Object Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Set Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # String Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Tuple Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Tuple Known Value Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Plan Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output Plan Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource Plan Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom State Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # State Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output State Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource State Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform JSON Paths'
 description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform JSON Paths

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Version Checks'
 description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Version Checks

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Configuration'
 description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Configuration

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Bool Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float32 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float32 Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Float64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan for use in Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int32 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int32 Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Int64 Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # List Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Map Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # NotNull Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Null Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Number Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Object Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Set Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # String Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Tuple Value Checks for use with Plan Checks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Tuple Known Value Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom Plan Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plan Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output Plan Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource Plan Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Custom State Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # State Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Output State Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resource State Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform JSON Paths'
 description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform JSON Paths

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Terraform Version Checks'
 description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Version Checks

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/migrating.mdx
@@ -2,6 +2,10 @@
 page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing module'
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing


### PR DESCRIPTION
### Description

This PR adds date metadata to the terraform-plugin-testing documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715

### Testing

Check that terraform-plugin-testing docs look normal in the preview: https://unified-docs-frontend-preview-imk29sd60-hashicorp.vercel.app/terraform/plugin/testing
