### PR TITLE
feat: add date metadata for sentinel docs

### DIFF
--- a/content/sentinel/v0.13.x/content/sentinel/docs/changelog/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/changelog/index.mdx
@@ -6,6 +6,10 @@ description: >-
   This are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.13.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/commands/apply.mdx
@@ -6,6 +6,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.13.x/content/sentinel/docs/commands/config.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/commands/config.mdx
@@ -6,6 +6,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.13.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,6 +4,10 @@ sidebar_title: '<code>fmt</code>'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.13.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.13.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/commands/test.mdx
@@ -4,6 +4,10 @@ sidebar_title: '<code>test</code>'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.13.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,6 +4,10 @@ sidebar_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.13.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.13.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.13.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/concepts/language.mdx
@@ -4,6 +4,10 @@ sidebar_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.13.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,6 +8,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.13.x/content/sentinel/docs/consul/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/consul/index.mdx
@@ -7,6 +7,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.13.x/content/sentinel/docs/extending/dev.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/extending/dev.mdx
@@ -7,6 +7,10 @@ description: >-
   with the path to the plugin, the name of the import, and any arguments needed
   to launch the plugin.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Developing an Import Plugin

--- a/content/sentinel/v0.13.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Import Plugins
 sidebar_current: docs-extending
 description: Imports allow a Sentinel policy to access external data and add new functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import Plugins

--- a/content/sentinel/v0.13.x/content/sentinel/docs/extending/install.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/extending/install.mdx
@@ -7,6 +7,10 @@ description: >-
   with the path to the plugin, the name of the import, and any arguments needed
   to launch the plugin.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Installing Import Plugins

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/append.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/delete.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/error.mdx
@@ -6,6 +6,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/index.mdx
@@ -4,6 +4,10 @@ sidebar_title: Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/keys.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/length.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/print.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/range.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/values.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.13.x/content/sentinel/docs/guides/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/guides/index.mdx
@@ -3,6 +3,10 @@ page_title: Documentation
 sidebar_current: guides-index
 description: TODO Guides
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Guides

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,6 +6,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/http.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/json.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/strings.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/time.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/types.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/units.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.13.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.13.x/content/sentinel/docs/internals/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/internals/index.mdx
@@ -4,6 +4,10 @@ sidebar_title: Internals
 sidebar_current: docs-internals
 description: Imports allow a Sentinel policy to access external data and add new functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Internals

--- a/content/sentinel/v0.13.x/content/sentinel/docs/internals/plugins.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/internals/plugins.mdx
@@ -4,6 +4,10 @@ sidebar_title: Plugins
 sidebar_current: docs-internals-plugins
 description: Imports allow a Sentinel policy to access external data and add new functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plugin Internals

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,6 +6,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/functions.mdx
@@ -4,6 +4,10 @@ sidebar_title: Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/imports.mdx
@@ -6,6 +6,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/index.mdx
@@ -8,6 +8,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/lists.mdx
@@ -4,6 +4,10 @@ sidebar_title: Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,6 +4,10 @@ sidebar_title: Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/loops.mdx
@@ -6,6 +6,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/maps.mdx
@@ -6,6 +6,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/parameters.mdx
@@ -6,6 +6,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/scope.mdx
@@ -4,6 +4,10 @@ sidebar_title: Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/slices.mdx
@@ -6,6 +6,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/spec.mdx
@@ -4,6 +4,10 @@ sidebar_title: Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/undefined.mdx
@@ -6,6 +6,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/values.mdx
@@ -4,6 +4,10 @@ sidebar_title: Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/variables.mdx
@@ -4,6 +4,10 @@ sidebar_title: Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.13.x/content/sentinel/docs/nomad/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/nomad/index.mdx
@@ -7,6 +7,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.13.x/content/sentinel/docs/terraform/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/terraform/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel can be used with Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.13.x/content/sentinel/docs/vault/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/vault/index.mdx
@@ -7,6 +7,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/basic.mdx
@@ -7,6 +7,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,6 +4,10 @@ sidebar_title: Debugging
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/index.mdx
@@ -8,6 +8,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/rules.mdx
@@ -7,6 +7,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/testing.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,6 +4,10 @@ sidebar_title: Your First Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,6 +4,10 @@ sidebar_title: Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,6 +4,10 @@ sidebar_title: Installing the CLI
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,6 +4,10 @@ sidebar_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,6 +4,10 @@ sidebar_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.13.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.13.x/content/sentinel/intro/what/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/what/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.13.x/content/sentinel/intro/why/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/why/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.14.x/content/sentinel/docs/changelog/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/changelog/index.mdx
@@ -6,6 +6,10 @@ description: >-
   This are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.14.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/commands/apply.mdx
@@ -6,6 +6,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.14.x/content/sentinel/docs/commands/config.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/commands/config.mdx
@@ -6,6 +6,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.14.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,6 +4,10 @@ sidebar_title: '<code>fmt</code>'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.14.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.14.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/commands/test.mdx
@@ -4,6 +4,10 @@ sidebar_title: '<code>test</code>'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.14.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,6 +4,10 @@ sidebar_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.14.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.14.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.14.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/concepts/language.mdx
@@ -4,6 +4,10 @@ sidebar_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.14.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,6 +8,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.14.x/content/sentinel/docs/consul/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/consul/index.mdx
@@ -7,6 +7,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.14.x/content/sentinel/docs/extending/dev.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/extending/dev.mdx
@@ -7,6 +7,10 @@ description: >-
   with the path to the plugin, the name of the import, and any arguments needed
   to launch the plugin.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Developing an Import Plugin

--- a/content/sentinel/v0.14.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Import Plugins
 sidebar_current: docs-extending
 description: Imports allow a Sentinel policy to access external data and add new functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import Plugins

--- a/content/sentinel/v0.14.x/content/sentinel/docs/extending/install.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/extending/install.mdx
@@ -7,6 +7,10 @@ description: >-
   with the path to the plugin, the name of the import, and any arguments needed
   to launch the plugin.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Installing Import Plugins

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/append.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/delete.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/error.mdx
@@ -6,6 +6,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/index.mdx
@@ -4,6 +4,10 @@ sidebar_title: Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/keys.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/length.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/print.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/range.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/values.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.14.x/content/sentinel/docs/guides/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/guides/index.mdx
@@ -3,6 +3,10 @@ page_title: Documentation
 sidebar_current: guides-index
 description: TODO Guides
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Guides

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,6 +6,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/http.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/json.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/strings.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/time.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/types.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/units.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.14.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.14.x/content/sentinel/docs/internals/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/internals/index.mdx
@@ -4,6 +4,10 @@ sidebar_title: Internals
 sidebar_current: docs-internals
 description: Imports allow a Sentinel policy to access external data and add new functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Internals

--- a/content/sentinel/v0.14.x/content/sentinel/docs/internals/plugins.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/internals/plugins.mdx
@@ -4,6 +4,10 @@ sidebar_title: Plugins
 sidebar_current: docs-internals-plugins
 description: Imports allow a Sentinel policy to access external data and add new functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Plugin Internals

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,6 +6,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/functions.mdx
@@ -4,6 +4,10 @@ sidebar_title: Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/imports.mdx
@@ -6,6 +6,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/index.mdx
@@ -8,6 +8,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/lists.mdx
@@ -4,6 +4,10 @@ sidebar_title: Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,6 +4,10 @@ sidebar_title: Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/loops.mdx
@@ -6,6 +6,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/maps.mdx
@@ -6,6 +6,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/parameters.mdx
@@ -6,6 +6,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/scope.mdx
@@ -4,6 +4,10 @@ sidebar_title: Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/slices.mdx
@@ -6,6 +6,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/spec.mdx
@@ -4,6 +4,10 @@ sidebar_title: Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/undefined.mdx
@@ -6,6 +6,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/values.mdx
@@ -4,6 +4,10 @@ sidebar_title: Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/variables.mdx
@@ -4,6 +4,10 @@ sidebar_title: Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.14.x/content/sentinel/docs/nomad/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/nomad/index.mdx
@@ -7,6 +7,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.14.x/content/sentinel/docs/terraform/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/terraform/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel can be used with Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.14.x/content/sentinel/docs/vault/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/vault/index.mdx
@@ -7,6 +7,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/basic.mdx
@@ -7,6 +7,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,6 +4,10 @@ sidebar_title: Debugging
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/index.mdx
@@ -8,6 +8,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/rules.mdx
@@ -7,6 +7,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/testing.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,6 +4,10 @@ sidebar_title: Your First Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,6 +4,10 @@ sidebar_title: Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,6 +4,10 @@ sidebar_title: Installing the CLI
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,6 +4,10 @@ sidebar_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,6 +4,10 @@ sidebar_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.14.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.14.x/content/sentinel/intro/what/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/what/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.14.x/content/sentinel/intro/why/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/why/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.15.x/content/sentinel/docs/changelog/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/changelog/index.mdx
@@ -6,6 +6,10 @@ description: >-
   This are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.15.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/commands/apply.mdx
@@ -6,6 +6,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.15.x/content/sentinel/docs/commands/config.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/commands/config.mdx
@@ -6,6 +6,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.15.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,6 +4,10 @@ sidebar_title: '<code>fmt</code>'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.15.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.15.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/commands/test.mdx
@@ -4,6 +4,10 @@ sidebar_title: '<code>test</code>'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.15.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,6 +4,10 @@ sidebar_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.15.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.15.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.15.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/concepts/language.mdx
@@ -4,6 +4,10 @@ sidebar_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.15.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,6 +8,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.15.x/content/sentinel/docs/consul/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/consul/index.mdx
@@ -7,6 +7,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.15.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.15.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/extending/internals.mdx
@@ -5,6 +5,10 @@ sidebar_title: Internals
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.15.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/extending/modules.mdx
@@ -6,6 +6,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.15.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,6 +7,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/append.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/delete.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/error.mdx
@@ -6,6 +6,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/index.mdx
@@ -4,6 +4,10 @@ sidebar_title: Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/keys.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/length.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/print.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/range.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/values.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.15.x/content/sentinel/docs/guides/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/guides/index.mdx
@@ -3,6 +3,10 @@ page_title: Documentation
 sidebar_current: guides-index
 description: TODO Guides
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Guides

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,6 +6,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/http.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/json.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/strings.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/time.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/types.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/units.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.15.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,6 +6,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/functions.mdx
@@ -4,6 +4,10 @@ sidebar_title: Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/imports.mdx
@@ -6,6 +6,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/index.mdx
@@ -8,6 +8,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/lists.mdx
@@ -4,6 +4,10 @@ sidebar_title: Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,6 +4,10 @@ sidebar_title: Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/loops.mdx
@@ -6,6 +6,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/maps.mdx
@@ -6,6 +6,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/parameters.mdx
@@ -6,6 +6,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/scope.mdx
@@ -4,6 +4,10 @@ sidebar_title: Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/slices.mdx
@@ -6,6 +6,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/spec.mdx
@@ -4,6 +4,10 @@ sidebar_title: Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/undefined.mdx
@@ -6,6 +6,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/values.mdx
@@ -4,6 +4,10 @@ sidebar_title: Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/variables.mdx
@@ -4,6 +4,10 @@ sidebar_title: Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.15.x/content/sentinel/docs/nomad/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/nomad/index.mdx
@@ -7,6 +7,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.15.x/content/sentinel/docs/terraform/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/terraform/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel can be used with Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.15.x/content/sentinel/docs/vault/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/vault/index.mdx
@@ -7,6 +7,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/basic.mdx
@@ -7,6 +7,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,6 +4,10 @@ sidebar_title: Debugging
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/index.mdx
@@ -8,6 +8,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/rules.mdx
@@ -7,6 +7,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/testing.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,6 +4,10 @@ sidebar_title: Your First Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,6 +4,10 @@ sidebar_title: Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,6 +4,10 @@ sidebar_title: Installing the CLI
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,6 +4,10 @@ sidebar_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,6 +4,10 @@ sidebar_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.15.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.15.x/content/sentinel/intro/what/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/what/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.15.x/content/sentinel/intro/why/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/why/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.16.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/changelog.mdx
@@ -6,6 +6,10 @@ description: >-
   This are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.16.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/commands/apply.mdx
@@ -6,6 +6,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.16.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,6 +4,10 @@ sidebar_title: '<code>fmt</code>'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.16.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.16.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/commands/test.mdx
@@ -4,6 +4,10 @@ sidebar_title: '<code>test</code>'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.16.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,6 +4,10 @@ sidebar_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.16.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.16.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.16.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/concepts/language.mdx
@@ -4,6 +4,10 @@ sidebar_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.16.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,6 +8,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.16.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/configuration/index.mdx
@@ -6,6 +6,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.16.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,6 +6,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.16.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/consul.mdx
@@ -7,6 +7,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.16.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.16.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/extending/internals.mdx
@@ -5,6 +5,10 @@ sidebar_title: Internals
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.16.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/extending/modules.mdx
@@ -6,6 +6,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.16.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,6 +7,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/append.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/delete.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/error.mdx
@@ -6,6 +6,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/index.mdx
@@ -4,6 +4,10 @@ sidebar_title: Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/keys.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/length.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/print.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/range.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/values.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.16.x/content/sentinel/docs/guides/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/guides/index.mdx
@@ -3,6 +3,10 @@ page_title: Documentation
 sidebar_current: guides-index
 description: TODO Guides
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Guides

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,6 +6,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/http.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/json.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/strings.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/time.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/types.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/units.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/version.mdx
@@ -6,6 +6,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.16.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,6 +6,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/functions.mdx
@@ -4,6 +4,10 @@ sidebar_title: Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/imports.mdx
@@ -6,6 +6,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/index.mdx
@@ -8,6 +8,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/lists.mdx
@@ -4,6 +4,10 @@ sidebar_title: Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,6 +4,10 @@ sidebar_title: Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/loops.mdx
@@ -6,6 +6,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/maps.mdx
@@ -6,6 +6,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/parameters.mdx
@@ -6,6 +6,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/scope.mdx
@@ -4,6 +4,10 @@ sidebar_title: Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/slices.mdx
@@ -6,6 +6,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/spec.mdx
@@ -4,6 +4,10 @@ sidebar_title: Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/undefined.mdx
@@ -6,6 +6,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/values.mdx
@@ -4,6 +4,10 @@ sidebar_title: Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/variables.mdx
@@ -4,6 +4,10 @@ sidebar_title: Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.16.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/nomad.mdx
@@ -7,6 +7,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.16.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/terraform.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel can be used with Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.16.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/vault.mdx
@@ -7,6 +7,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/basic.mdx
@@ -7,6 +7,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,6 +4,10 @@ sidebar_title: Debugging
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/index.mdx
@@ -8,6 +8,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/rules.mdx
@@ -7,6 +7,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/testing.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,6 +4,10 @@ sidebar_title: Your First Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,6 +4,10 @@ sidebar_title: Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,6 +4,10 @@ sidebar_title: Installing the CLI
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,6 +4,10 @@ sidebar_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,6 +4,10 @@ sidebar_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.16.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.16.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/what.mdx
@@ -6,6 +6,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.16.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/why.mdx
@@ -6,6 +6,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.17.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/changelog.mdx
@@ -6,6 +6,10 @@ description: >-
   This are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.17.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/commands/apply.mdx
@@ -6,6 +6,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.17.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,6 +4,10 @@ sidebar_title: '<code>fmt</code>'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.17.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.17.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/commands/test.mdx
@@ -4,6 +4,10 @@ sidebar_title: '<code>test</code>'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.17.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,6 +4,10 @@ sidebar_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.17.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.17.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.17.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/concepts/language.mdx
@@ -4,6 +4,10 @@ sidebar_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.17.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,6 +8,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.17.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/configuration/index.mdx
@@ -6,6 +6,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.17.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,6 +6,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.17.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/consul.mdx
@@ -7,6 +7,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.17.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.17.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/extending/internals.mdx
@@ -5,6 +5,10 @@ sidebar_title: Internals
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.17.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/extending/modules.mdx
@@ -6,6 +6,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.17.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,6 +7,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/append.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/delete.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/error.mdx
@@ -6,6 +6,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/index.mdx
@@ -4,6 +4,10 @@ sidebar_title: Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/keys.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/length.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/print.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/range.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/values.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.17.x/content/sentinel/docs/guides.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/guides.mdx
@@ -3,6 +3,10 @@ page_title: Documentation
 sidebar_current: guides-index
 description: TODO Guides
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Guides

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/base64.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,6 +6,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/http.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/json.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/strings.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/time.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/types.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/units.mdx
@@ -4,6 +4,10 @@ sidebar_title: 'units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/version.mdx
@@ -6,6 +6,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.17.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,6 +6,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/functions.mdx
@@ -4,6 +4,10 @@ sidebar_title: Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/imports.mdx
@@ -6,6 +6,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/index.mdx
@@ -8,6 +8,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/lists.mdx
@@ -4,6 +4,10 @@ sidebar_title: Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,6 +4,10 @@ sidebar_title: Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/loops.mdx
@@ -6,6 +6,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/maps.mdx
@@ -6,6 +6,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/parameters.mdx
@@ -6,6 +6,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/scope.mdx
@@ -4,6 +4,10 @@ sidebar_title: Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/slices.mdx
@@ -6,6 +6,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/spec.mdx
@@ -4,6 +4,10 @@ sidebar_title: Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/undefined.mdx
@@ -6,6 +6,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/values.mdx
@@ -4,6 +4,10 @@ sidebar_title: Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/variables.mdx
@@ -4,6 +4,10 @@ sidebar_title: Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.17.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/nomad.mdx
@@ -7,6 +7,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.17.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/terraform.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel can be used with Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.17.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/vault.mdx
@@ -7,6 +7,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/basic.mdx
@@ -7,6 +7,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,6 +4,10 @@ sidebar_title: Debugging
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/index.mdx
@@ -8,6 +8,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/rules.mdx
@@ -7,6 +7,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/testing.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,6 +6,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,6 +4,10 @@ sidebar_title: Your First Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,6 +4,10 @@ sidebar_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,6 +4,10 @@ sidebar_title: Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,6 +4,10 @@ sidebar_title: Installing the CLI
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,6 +4,10 @@ sidebar_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,6 +4,10 @@ sidebar_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.17.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.17.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/what.mdx
@@ -6,6 +6,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.17.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/why.mdx
@@ -6,6 +6,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.18.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   This are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.18.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.18.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.18.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.18.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.18.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.18.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.18.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.18.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.18.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.18.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.18.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.18.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.18.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.18.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.18.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.18.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.18.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.18.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.18.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel can be used with Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.18.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -3,6 +3,10 @@ page_title: Your First Sentinel Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/index.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/install.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/logic.mdx
@@ -3,6 +3,10 @@ page_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/rules.mdx
@@ -3,6 +3,10 @@ page_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.18.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.18.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/what.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.18.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.19.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   This are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.19.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.19.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.19.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.19.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.19.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.19.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.19.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.19.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.19.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.19.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.19.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.19.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.19.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.19.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.19.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.19.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.19.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.19.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.19.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.19.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.19.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel can be used with Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.19.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -3,6 +3,10 @@ page_title: Your First Sentinel Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/index.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/install.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/logic.mdx
@@ -3,6 +3,10 @@ page_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/rules.mdx
@@ -3,6 +3,10 @@ page_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.19.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.19.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/what.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.19.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.20.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   This are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.20.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.20.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.20.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.20.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.20.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.20.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.20.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.20.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.20.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.20.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.20.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.20.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.20.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.20.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.20.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.20.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.20.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.20.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.20.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.20.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.20.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel can be used with Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.20.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -3,6 +3,10 @@ page_title: Your First Sentinel Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/index.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/install.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/logic.mdx
@@ -3,6 +3,10 @@ page_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/rules.mdx
@@ -3,6 +3,10 @@ page_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.20.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.20.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/what.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.20.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.21.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   This are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.21.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.21.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.21.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.21.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.21.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.21.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.21.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.21.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.21.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.21.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.21.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.21.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.21.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.21.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.21.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.21.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.21.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.21.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.21.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.21.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.21.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel can be used with Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.21.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -3,6 +3,10 @@ page_title: Your First Sentinel Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/index.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/install.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/logic.mdx
@@ -3,6 +3,10 @@ page_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/rules.mdx
@@ -3,6 +3,10 @@ page_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.21.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.21.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/what.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.21.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.22.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   These are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.22.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.22.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.22.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.22.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.22.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.22.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.22.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.22.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.22.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.22.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.22.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.22.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.22.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.22.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.22.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.22.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.22.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.22.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.22.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.22.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.22.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel can be used with Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.22.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -3,6 +3,10 @@ page_title: Your First Sentinel Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/index.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/install.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/logic.mdx
@@ -3,6 +3,10 @@ page_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/rules.mdx
@@ -3,6 +3,10 @@ page_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.22.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.22.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/what.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.22.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.23.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   These are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.23.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.23.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.23.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.23.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.23.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.23.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.23.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.23.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.23.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.23.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.23.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.23.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.23.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.23.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.23.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.23.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.23.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.23.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/index.mdx
@@ -3,6 +3,10 @@ page_title: Features
 sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Features

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/index.mdx
@@ -3,6 +3,10 @@ page_title: terraform
 sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # terraform feature

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v1 - terraform - Features
 sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v1

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v2

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v1

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v2

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v1 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v1

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v2

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.23.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.23.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.23.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel can be used with Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.23.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -3,6 +3,10 @@ page_title: Your First Sentinel Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/index.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/install.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/logic.mdx
@@ -3,6 +3,10 @@ page_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/rules.mdx
@@ -3,6 +3,10 @@ page_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.23.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.23.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/what.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.23.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.24.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   These are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.24.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.24.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.24.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.24.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.24.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.24.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.24.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.24.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.24.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.24.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.24.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.24.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.24.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.24.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.24.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.24.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.24.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.24.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/index.mdx
@@ -3,6 +3,10 @@ page_title: Features
 sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Features

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/index.mdx
@@ -3,6 +3,10 @@ page_title: terraform
 sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # terraform feature

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v1 - terraform - Features
 sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v1

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v2

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v1

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v2

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v1 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v1

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v2

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.24.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.24.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.24.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel can be used with Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.24.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -3,6 +3,10 @@ page_title: Your First Sentinel Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/index.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/install.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/logic.mdx
@@ -3,6 +3,10 @@ page_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/rules.mdx
@@ -3,6 +3,10 @@ page_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.24.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.24.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/what.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.24.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.25.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   These are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.25.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.25.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.25.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.25.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.25.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.25.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.25.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.25.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.25.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.25.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.25.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.25.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.25.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.25.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.25.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.25.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.25.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.25.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/index.mdx
@@ -3,6 +3,10 @@ page_title: Features
 sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Features

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/index.mdx
@@ -3,6 +3,10 @@ page_title: terraform
 sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # terraform feature

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v1 - terraform - Features
 sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v1

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v2

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v1

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v2

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v1 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v1

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v2

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.25.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.25.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.25.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Use Sentinel with Terraform Cloud and Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.25.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -3,6 +3,10 @@ page_title: Your First Sentinel Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/index.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/install.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/logic.mdx
@@ -3,6 +3,10 @@ page_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/rules.mdx
@@ -3,6 +3,10 @@ page_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.25.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.25.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/what.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.25.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.26.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   These are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.26.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.26.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.26.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.26.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.26.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.26.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.26.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.26.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.26.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.26.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.26.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.26.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.26.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.26.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.26.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.26.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.26.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.26.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/index.mdx
@@ -3,6 +3,10 @@ page_title: Features
 sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Features

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/index.mdx
@@ -3,6 +3,10 @@ page_title: terraform
 sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # terraform feature

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v1 - terraform - Features
 sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v1

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v2

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v1

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v2

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v1 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v1

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v2

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/compare.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/compare.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Compare'
 sidebar_current: docs-funcs-compare
 description: The built-in function `compare` compares two values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: compare

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/collection/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/collection/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection'
 sidebar_current: docs-imports-collection
 description: The collection import provides useful helpers for working with maps and lists.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/collection/lists.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/collection/lists.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection/lists'
 sidebar_current: docs-imports-collection-lists
 description: The collection/lists import provides useful helpers for working with lists.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection/lists

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/collection/maps.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/collection/maps.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection/maps'
 sidebar_current: docs-imports-collection-maps
 description: The collection/maps import provides useful helpers for working with maps.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection/maps

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.26.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.26.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.26.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Use Sentinel with HCP Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.26.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -3,6 +3,10 @@ page_title: Your First Sentinel Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/index.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/install.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/logic.mdx
@@ -3,6 +3,10 @@ page_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/rules.mdx
@@ -3,6 +3,10 @@ page_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.26.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.26.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/what.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.26.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.27.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   These are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.27.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.27.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.27.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.27.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.27.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.27.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.27.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.27.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.27.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.27.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.27.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.27.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.27.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.27.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.27.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.27.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.27.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.27.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/index.mdx
@@ -3,6 +3,10 @@ page_title: Features
 sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Features

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/index.mdx
@@ -3,6 +3,10 @@ page_title: terraform
 sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # terraform feature

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v1 - terraform - Features
 sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v1

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v2

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v1

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v2

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v1 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v1

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v2

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/compare.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/compare.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Compare'
 sidebar_current: docs-funcs-compare
 description: The built-in function `compare` compares two values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: compare

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/collection/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/collection/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection'
 sidebar_current: docs-imports-collection
 description: The collection import provides useful helpers for working with maps and lists.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/collection/lists.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/collection/lists.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection/lists'
 sidebar_current: docs-imports-collection-lists
 description: The collection/lists import provides useful helpers for working with lists.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection/lists

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/collection/maps.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/collection/maps.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection/maps'
 sidebar_current: docs-imports-collection-maps
 description: The collection/maps import provides useful helpers for working with maps.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection/maps

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.27.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.27.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.27.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Use Sentinel with HCP Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.27.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -3,6 +3,10 @@ page_title: Your First Sentinel Policy
 sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Your First Sentinel Policy

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/index.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Getting Started With Sentinel

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/install.mdx
@@ -3,6 +3,10 @@ page_title: Install Sentinel CLI - Getting Started
 sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Install Sentinel CLI

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/logic.mdx
@@ -3,6 +3,10 @@ page_title: Logic
 sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logic

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -3,6 +3,10 @@ page_title: Next Steps
 sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Next Steps

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/rules.mdx
@@ -3,6 +3,10 @@ page_title: Rules
 sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/testing.mdx
@@ -3,6 +3,10 @@ page_title: Testing
 sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.27.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/index.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-home
 description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.27.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/what.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.27.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: intro
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.28.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   These are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.28.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.28.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.28.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.28.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.28.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.28.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.28.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.28.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.28.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.28.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.28.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.28.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.28.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.28.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.28.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.28.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.28.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.28.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/index.mdx
@@ -3,6 +3,10 @@ page_title: Features
 sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Features

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/index.mdx
@@ -3,6 +3,10 @@ page_title: terraform
 sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # terraform feature

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v1 - terraform - Features
 sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v1

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v2

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v1

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v2

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v1 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v1

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v2

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/compare.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/compare.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Compare'
 sidebar_current: docs-funcs-compare
 description: The built-in function `compare` compares two values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: compare

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/collection/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/collection/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection'
 sidebar_current: docs-imports-collection
 description: The collection import provides useful helpers for working with maps and lists.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/collection/lists.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/collection/lists.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection/lists'
 sidebar_current: docs-imports-collection-lists
 description: The collection/lists import provides useful helpers for working with lists.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection/lists

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/collection/maps.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/collection/maps.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection/maps'
 sidebar_current: docs-imports-collection-maps
 description: The collection/maps import provides useful helpers for working with maps.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection/maps

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.28.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.28.x/content/sentinel/docs/intro.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/intro.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in 
   existing software to enable fine-grained, logic-based policy decisions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.28.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.28.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Use Sentinel with HCP Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.28.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.28.x/content/sentinel/docs/why.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.29.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   These are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.29.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.29.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.29.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.29.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.29.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.29.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.29.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.29.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.29.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.29.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.29.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.29.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.29.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.29.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.29.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.29.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.29.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.29.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.29.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/features/index.mdx
@@ -3,6 +3,10 @@ page_title: Features
 sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Features

--- a/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/index.mdx
@@ -3,6 +3,10 @@ page_title: terraform
 sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # terraform feature

--- a/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v1 - terraform - Features
 sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v1

--- a/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v2

--- a/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v1

--- a/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v2

--- a/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v1 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v1

--- a/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v2

--- a/content/sentinel/v0.29.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.29.x/content/sentinel/docs/functions/compare.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/functions/compare.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Compare'
 sidebar_current: docs-funcs-compare
 description: The built-in function `compare` compares two values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: compare

--- a/content/sentinel/v0.29.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.29.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.29.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.29.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.29.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.29.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.29.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.29.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/collection/index.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/collection/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection'
 sidebar_current: docs-imports-collection
 description: The collection import provides useful helpers for working with maps and lists.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/collection/lists.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/collection/lists.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection/lists'
 sidebar_current: docs-imports-collection-lists
 description: The collection/lists import provides useful helpers for working with lists.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection/lists

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/collection/maps.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/collection/maps.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection/maps'
 sidebar_current: docs-imports-collection-maps
 description: The collection/maps import provides useful helpers for working with maps.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection/maps

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.29.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.29.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.29.x/content/sentinel/docs/intro.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/intro.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in 
   existing software to enable fine-grained, logic-based policy decisions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.29.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.29.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.29.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Use Sentinel with HCP Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.29.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.29.x/content/sentinel/docs/why.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.29.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.29.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.29.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.29.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.29.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.29.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.29.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.29.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.30.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   These are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.30.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.30.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.30.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.30.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.30.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.30.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.30.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.30.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.30.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.30.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.30.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.30.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.30.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.30.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.30.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.30.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.30.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.30.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.30.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/features/index.mdx
@@ -3,6 +3,10 @@ page_title: Features
 sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Features

--- a/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/index.mdx
@@ -3,6 +3,10 @@ page_title: terraform
 sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # terraform feature

--- a/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v1 - terraform - Features
 sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v1

--- a/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v2

--- a/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v1

--- a/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v2

--- a/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v1 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v1

--- a/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v2

--- a/content/sentinel/v0.30.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.30.x/content/sentinel/docs/functions/compare.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/functions/compare.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Compare'
 sidebar_current: docs-funcs-compare
 description: The built-in function `compare` compares two values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: compare

--- a/content/sentinel/v0.30.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.30.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.30.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.30.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.30.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.30.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.30.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.30.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/collection/index.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/collection/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection'
 sidebar_current: docs-imports-collection
 description: The collection import provides useful helpers for working with maps and lists.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/collection/lists.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/collection/lists.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection/lists'
 sidebar_current: docs-imports-collection-lists
 description: The collection/lists import provides useful helpers for working with lists.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection/lists

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/collection/maps.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/collection/maps.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection/maps'
 sidebar_current: docs-imports-collection-maps
 description: The collection/maps import provides useful helpers for working with maps.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection/maps

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.30.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.30.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.30.x/content/sentinel/docs/intro.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/intro.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in 
   existing software to enable fine-grained, logic-based policy decisions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.30.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.30.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.30.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Use Sentinel with HCP Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.30.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.30.x/content/sentinel/docs/why.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.30.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.30.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.30.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.30.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.30.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.30.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.30.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.30.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces

--- a/content/sentinel/v0.40.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   These are the public release notes for the Sentinel runtime. See this document
   for the latest updates.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Runtime Release Notes

--- a/content/sentinel/v0.40.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/commands/apply.mdx
@@ -5,6 +5,10 @@ description: >-
   The `sentinel apply` command is used to execute a policy locally for
   development purposes.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `apply`

--- a/content/sentinel/v0.40.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/commands/fmt.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: fmt'
 sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `fmt`

--- a/content/sentinel/v0.40.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/commands/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides a `sentinel` command-line interface (CLI) for developing and
   testing policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Commands

--- a/content/sentinel/v0.40.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/commands/test.mdx
@@ -3,6 +3,10 @@ page_title: 'Command: test'
 sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Command: `test`

--- a/content/sentinel/v0.40.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -3,6 +3,10 @@ page_title: Enforcement Levels
 sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enforcement Levels

--- a/content/sentinel/v0.40.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/concepts/imports.mdx
@@ -3,6 +3,10 @@ page_title: Imports
 sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.40.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/concepts/index.mdx
@@ -3,6 +3,10 @@ page_title: Basic Concepts
 sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Basic Concepts

--- a/content/sentinel/v0.40.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/concepts/language.mdx
@@ -3,6 +3,10 @@ page_title: Policy Language
 sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Language

--- a/content/sentinel/v0.40.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -7,6 +7,10 @@ description: >-
   software development best practices can be adopted such as version control,
   automated testing, and automated deployment.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy as Code

--- a/content/sentinel/v0.40.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/configuration/index.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration file can be used to control the
   behavior of the simulator during apply and test operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel CLI Configuration File Syntax

--- a/content/sentinel/v0.40.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/configuration/overrides.mdx
@@ -5,6 +5,10 @@ description: >-
   The Sentinel CLI's configuration can be overriden using override files.
   Override files merge additional settings into existing configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Override Files

--- a/content/sentinel/v0.40.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -5,6 +5,10 @@ description: >-
   There are a number of options for formatting the URL provided to the
   source attribute on policy and module blocks.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Remote Sources

--- a/content/sentinel/v0.40.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/consul.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies are applied during writes to
   the KV Store.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Consul

--- a/content/sentinel/v0.40.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/extending/index.mdx
@@ -3,6 +3,10 @@ page_title: Extending Sentinel
 sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel

--- a/content/sentinel/v0.40.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/extending/internals.mdx
@@ -4,6 +4,10 @@ page_title: >-
 sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Internals

--- a/content/sentinel/v0.40.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/extending/modules.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-modules
 description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Modules

--- a/content/sentinel/v0.40.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/extending/plugins.mdx
@@ -6,6 +6,10 @@ description: >-
   Plugins allow you to write imports as standalone executables, allowing you to
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Plugins

--- a/content/sentinel/v0.40.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/extending/static-imports.mdx
@@ -5,6 +5,10 @@ sidebar_current: docs-extending-static-imports
 description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Extending Sentinel: Static Imports

--- a/content/sentinel/v0.40.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/features/index.mdx
@@ -3,6 +3,10 @@ page_title: Features
 sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Features

--- a/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/index.mdx
@@ -3,6 +3,10 @@ page_title: terraform
 sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # terraform feature

--- a/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v1 - terraform - Features
 sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v1

--- a/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfconfig/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfconfig/v2

--- a/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v1

--- a/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -7,6 +7,10 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfplan/v2

--- a/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v1 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v1

--- a/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -3,6 +3,10 @@ page_title: tfstate/v2 - terraform - Features
 sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate/v2

--- a/content/sentinel/v0.40.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/functions/append.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Append'
 sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: append

--- a/content/sentinel/v0.40.x/content/sentinel/docs/functions/compare.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/functions/compare.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Compare'
 sidebar_current: docs-funcs-compare
 description: The built-in function `compare` compares two values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: compare

--- a/content/sentinel/v0.40.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/functions/delete.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: delete'
 sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: delete

--- a/content/sentinel/v0.40.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/functions/error.mdx
@@ -5,6 +5,10 @@ description: >-
   The built-in function `error` is used to exit immediately with an error
   message.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: error

--- a/content/sentinel/v0.40.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/functions/index.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Builtin Functions
 sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Builtin Functions

--- a/content/sentinel/v0.40.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/functions/keys.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: keys'
 sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: keys

--- a/content/sentinel/v0.40.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/functions/length.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Length'
 sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: length

--- a/content/sentinel/v0.40.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/functions/print.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: print'
 sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: print

--- a/content/sentinel/v0.40.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/functions/range.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: Range'
 sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: range

--- a/content/sentinel/v0.40.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/functions/values.mdx
@@ -3,6 +3,10 @@ page_title: 'Sentinel Language - Builtin Function: values'
 sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Builtin Function: values

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/base64.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: base64'
 sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: base64

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/collection/index.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/collection/index.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection'
 sidebar_current: docs-imports-collection
 description: The collection import provides useful helpers for working with maps and lists.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/collection/lists.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/collection/lists.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection/lists'
 sidebar_current: docs-imports-collection-lists
 description: The collection/lists import provides useful helpers for working with lists.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection/lists

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/collection/maps.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/collection/maps.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: collection/maps'
 sidebar_current: docs-imports-collection-maps
 description: The collection/maps import provides useful helpers for working with maps.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: collection/maps

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/decimal.mdx
@@ -5,6 +5,10 @@ description: |-
   The decimal import provides functions for operating on numbers represented
   as decimals.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: decimal

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/http.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: http'
 sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: http

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Standard Imports are the built-in imports that are available to all Sentinel
   policies.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Standard Imports

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/json.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: json'
 sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: json

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/runtime.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: runtime'
 sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: runtime

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: sockaddr'
 sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: sockaddr

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/strings.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: strings'
 sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: strings

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/time.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: time'
 sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: time

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/types.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: types'
 sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: types

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/units.mdx
@@ -3,6 +3,10 @@ page_title: 'Import: units'
 sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: units

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/version.mdx
@@ -5,6 +5,10 @@ description: |-
   The version import provides functions for parsing versions and version constraints,
   and verifying versions against a set of constraints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Import: version

--- a/content/sentinel/v0.40.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/index.mdx
@@ -4,6 +4,10 @@ page_title: 'Documentation'
 sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Documentation

--- a/content/sentinel/v0.40.x/content/sentinel/docs/intro.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/intro.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in 
   existing software to enable fine-grained, logic-based policy decisions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Introduction to Sentinel

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/arithmetic.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel supports arithmetic operators for integers and floats. Sentinel
   supports sum, difference, product, quotient, and remainder.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Arithmetic

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/boolexpr.mdx
@@ -5,6 +5,10 @@ description: >-
   Boolean expressions are expressions that evaluate to a boolean value from the
   result of a combination of one or more comparisons and logical operators.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Boolean Expressions

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/collection-operations.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-collection-operations
 description: |-
   Operations for interacting with collections (list, map).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Collection Operations

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/conditionals.mdx
@@ -4,6 +4,10 @@ sidebar_current: docs-language-conditional
 description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Conditionals

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/functions.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Functions
 sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Functions

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/imports.mdx
@@ -5,6 +5,10 @@ description: >-
   Imports enable a Sentinel policy to access reusable libraries and external
   data and functions.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Imports

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/index.mdx
@@ -7,6 +7,10 @@ description: |-
   and be productive within an hour. Learning Sentinel doesn't require any
   formal programming experience.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/lists.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Lists
 sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Lists

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/logging-errors.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Logging and Errors
 sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Logging and Errors

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/loops.mdx
@@ -5,6 +5,10 @@ description: >-
   Loop statements allow you to execute a body of code for each element in a
   collection or for some fixed number of times.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-10-10T13:09:20-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Loops

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/maps.mdx
@@ -5,6 +5,10 @@ description: >-
   Maps are a collection of zero or more key/value pairs. These are useful for
   storing values that are looked up by a unique key.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Maps

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/parameters.mdx
@@ -5,6 +5,10 @@ description: >-
   Parameteres allow a Sentinel policy to describe variables that are expected
   to be supplied by the calling application, in addition to any default value.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Parameters

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/rules.mdx
@@ -5,6 +5,10 @@ description: >-
   Rules form the basis of a policy by representing behavior that is either
   passing or failing (true or false).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Rules

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/scope.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Scope
 sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Scope

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/slices.mdx
@@ -5,6 +5,10 @@ description: >-
   Slices are an efficient way to create a substring or sublist from an existing
   string or list, respectively.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Slices

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/spec.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language Specification
 sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sentinel Language Specification

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/undefined.mdx
@@ -5,6 +5,10 @@ description: >-
   The value `undefined` is a special value representing undefined behavior or an
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Undefined

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/values.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Values
 sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Values

--- a/content/sentinel/v0.40.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/language/variables.mdx
@@ -3,6 +3,10 @@ page_title: Sentinel Language - Variables
 sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Language: Variables

--- a/content/sentinel/v0.40.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/nomad.mdx
@@ -6,6 +6,10 @@ description: >-
   advanced policy enforcement. Sentinel policies can currently execute on job
   submission (creation, update).
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Nomad

--- a/content/sentinel/v0.40.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/terraform.mdx
@@ -5,6 +5,10 @@ description: >-
   Use Sentinel with HCP Terraform and Terraform Enterprise to enforce policy
   on Terraform configurations, states, and plans.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform

--- a/content/sentinel/v0.40.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/vault.mdx
@@ -6,6 +6,10 @@ description: >-
   provide Role Governing Policies (RGPs) and Endpoint Governing Policies (EGPs)
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Vault

--- a/content/sentinel/v0.40.x/content/sentinel/docs/why.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/why.mdx
@@ -5,6 +5,10 @@ description: >-
   Welcome to the intro guide to Sentinel! This guide is the best place to start
   with Sentinel.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Why Sentinel?

--- a/content/sentinel/v0.40.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/writing/basic.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Basics

--- a/content/sentinel/v0.40.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/writing/debugging.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging

--- a/content/sentinel/v0.40.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/writing/imports.mdx
@@ -3,6 +3,10 @@ page_title: Writing Sentinel Policy
 sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Imports

--- a/content/sentinel/v0.40.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/writing/index.mdx
@@ -7,6 +7,10 @@ description: >-
   effectively control access to many systems using Sentinel's powerful features.
   Basic concepts that are important to understand for Vault usage.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Sentinel Policy

--- a/content/sentinel/v0.40.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/writing/rules.mdx
@@ -6,6 +6,10 @@ description: >-
   for creating complex policies. This page will explain the basics of writing
   Sentinel policies to get started.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Rules

--- a/content/sentinel/v0.40.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/writing/testing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel has a built-in test framework to validate a policy behaves as
   expected.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing

--- a/content/sentinel/v0.40.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/writing/tracing.mdx
@@ -5,6 +5,10 @@ description: >-
   Sentinel provides execution traces to better understand the execution of a
   policy.
 layout: docs
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-17T13:35:48-05:00
+last_modified: 2025-09-17T13:35:48-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Traces


### PR DESCRIPTION
### Description

This PR adds date metadata to the sentinel documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715

### Testing

Check that sentinel docs look normal in the preview: https://unified-docs-frontend-preview-dy0mg27p4-hashicorp.vercel.app/sentinel