### PR TITLE
feat: add date metadata for terraform-plugin-sdk docs

### DIFF
--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 # Depending on Providers

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin Best Practices

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Naming Best Practices
 description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Naming

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Non-Go Providers

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Handling Sensitive Values in State

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 # Versioning and Changelog

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T14:21:02-06:00
+last_modified: 2025-03-06T14:21:02-06:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Depending on Providers

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin Best Practices

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Naming Best Practices
 description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Naming

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Non-Go Providers

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Handling Sensitive Values in State

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Versioning and Changelog

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Depending on Providers

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin Best Practices

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Naming Best Practices
 description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Naming

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Non-Go Providers

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Handling Sensitive Values in State

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Versioning and Changelog

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Depending on Providers

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin Best Practices

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Naming Best Practices
 description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Naming

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Non-Go Providers

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Handling Sensitive Values in State

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Versioning and Changelog

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Depending on Providers

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin Best Practices

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Naming Best Practices
 description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Naming

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Non-Go Providers

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Handling Sensitive Values in State

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Versioning and Changelog

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Depending on Providers

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin Best Practices

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Naming Best Practices
 description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Naming

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Non-Go Providers

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Handling Sensitive Values in State

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Versioning and Changelog

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Depending on Providers

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin Best Practices

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Naming Best Practices
 description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Naming

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Non-Go Providers

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Handling Sensitive Values in State

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Versioning and Changelog

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Depending on Providers

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin Best Practices

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Naming Best Practices
 description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Naming

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Non-Go Providers

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Handling Sensitive Values in State

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Versioning and Changelog

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Depending on Providers

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin Best Practices

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Naming Best Practices
 description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Naming

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Non-Go Providers

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Handling Sensitive Values in State

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Versioning and Changelog

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Depending on Providers

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin Best Practices

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Naming Best Practices
 description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Naming

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Non-Go Providers

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Handling Sensitive Values in State

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Versioning and Changelog

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Depending on Providers

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin Best Practices

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Naming Best Practices
 description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 ## Naming

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Writing Non-Go Providers

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Handling Sensitive Values in State

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Versioning and Changelog

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Data Consistency Errors

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Data Consistency Errors

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Data Consistency Errors

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Data Consistency Errors

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Data Consistency Errors

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Data Consistency Errors

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Data Consistency Errors

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Data Consistency Errors

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2026-01-14T15:19:01-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-14T15:35:42-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Data Consistency Errors

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/write-only-arguments.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/write-only-arguments.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Write-only Arguments
 description: Implementing write-only arguments within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Write-only Arguments

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-03-06T10:49:53-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-03-06T10:49:53-05:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2026-01-14T15:19:01-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Data Consistency Errors

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/identity.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/identity.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Identity
 description: Implementing identity within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Identity

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/write-only-arguments.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/write-only-arguments.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Write-only Arguments
 description: Implementing write-only arguments within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Write-only Arguments

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-05-20T08:33:01-04:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-05-20T08:33:01-04:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deprecations, Removals, and Renames

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -4,6 +4,10 @@ description: |-
   "Drift" describes changes to infrastructure outside of Terraform. Learn how
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Detecting Drift

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 <Highlight>

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/debugging.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Debugging SDKv2 Providers

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -3,6 +3,10 @@ page_title: Terraform 0.12 Compatibility for Providers
 description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform 0.12 Compatibility for Providers

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDK v2 Upgrade Guide

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2026-01-14T15:19:01-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Plugin SDKv2

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # HTTP Transport

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/logging/index.mdx
@@ -2,6 +2,10 @@
 page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Customizing Differences

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Data Consistency Errors

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/identity.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/identity.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Identity
 description: Implementing identity within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Identity

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/import.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Import
 description: Implementing resource import support.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Import

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/index.mdx
@@ -3,6 +3,10 @@ page_title: Resources - Guides
 description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/list.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/list.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - List
 description: Implementing List on an SDKv2 resource.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-12-10T09:29:12+01:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - List

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Retries and Customizable Timeouts

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - State Migration
 description: Migrating state values within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - State Migration

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/write-only-arguments.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/write-only-arguments.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Resources - Write-only Arguments
 description: Implementing write-only arguments within resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Resources - Write-only Arguments

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schemas
 description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Schema Behaviors
 description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Behaviors

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -3,6 +3,10 @@ page_title: Home - Plugin Development
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Schemas Methods

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -4,6 +4,10 @@ description: |-
   Schemas define plugin behavior and attributes. The schema `type` attribute
   defines what kind of values users can provide in their configuration for an
   element.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Schema Attributes and Types

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Acceptance Testing
 description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: Sweepers'
 description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Sweepers

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestCase'
 description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestCases

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -3,6 +3,10 @@ page_title: 'Plugin Development - Acceptance Testing: TestStep'
 description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Acceptance Tests: TestSteps

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/index.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing
 description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Terraform Plugins

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing API
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing API

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Testing Patterns
 description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-09-23T21:34:11+02:00
+# END AUTO GENERATED METADATA
 ---
 
 # Testing Patterns

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -3,6 +3,10 @@ page_title: Plugin Development - Unit Testing
 description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-09-23T21:34:11+02:00
+last_modified: 2025-11-19T09:33:54-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Unit Testing


### PR DESCRIPTION
### Description

This PR adds date metadata to the terraform-plugin-sdk documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715

### Testing

Check that terraform-plugin-sdk docs look normal in the preview: https://unified-docs-frontend-preview-bvc95lk5h-hashicorp.vercel.app/terraform/plugin/sdkv2
