### PR TITLE
Add policy-update-patterns attribute to policy sets API reference

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/policy-sets.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/policy-sets.mdx
@@ -99,6 +99,7 @@ Properties without a default value are required.
 | `data.relationships.policies.data[]`                  | array\[object] | `[]`       | A list of resource identifier objects that defines which policies are members of the policy set. These objects must contain `id` and `type` properties, and the `type` property must be `policies`. For example, `{ "id": "pol-u3S5p2Uwk21keu1s", "type": "policies" }`.                                                                                                                                                                                                                                                                                         |
 | `data.attributes.agent-enabled`                       | boolean        | `false`    | Only valid for `sentinel` policy sets. Whether this policy set should run as a policy evaluation in the HCP Terraform agent.                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `data.attributes.policy-tool-version`                 | string         | `latest`   | The version of the tool that HCP Terraform uses to evaluate policies. You can only set a policy tool version for 'sentinel' policy sets if `agent-enabled` is `true`.                                                                                                                                                                                                                                                                                                                                                                                         |
+| `data.attributes.policy-update-patterns`              | array\[string]  | `[]`       | A list of glob patterns specifying which file changes trigger policy set updates. Patterns are relative to the repository root, and you can specify a maximum of 100 patterns. This attribute is only valid when you specify a VCS repository for the policy set.                                                                                                                                                                                                                                                                                                |
 
 ### Sample Payload
 
@@ -115,6 +116,10 @@ Properties without a default value are required.
       "policy-tool-version": "0.23.0",
       "overridable": true,
       "policies-path": "/policy-sets/foo",
+      "policy-update-patterns": [
+        "policies/cost-management/**/*.sentinel",
+        "policies/shared/**/*.sentinel"
+      ],
       "vcs-repo": {
         "branch": "main",
         "identifier": "hashicorp/my-policy-sets",
@@ -202,6 +207,10 @@ curl \
       "overridable": true,
       "workspace-count": 1,
       "policies-path": "/policy-sets/foo",
+      "policy-update-patterns": [
+        "policies/cost-management/**/*.sentinel",
+        "policies/shared/**/*.sentinel"
+      ],
       "versioned": true,
       "vcs-repo": {
         "branch": "main",
@@ -334,6 +343,10 @@ curl \
         "overridable": true,
         "workspace-count": 1,
         "policies-path": "/policy-sets/foo",
+        "policy-update-patterns": [
+          "policies/cost-management/**/*.sentinel",
+          "policies/shared/**/*.sentinel"
+        ],
         "versioned": true,
         "vcs-repo": {
           "branch": "main",
@@ -461,6 +474,10 @@ curl --request GET \
       "policy-count": 0,
       "workspace-count": 1,
       "policies-path": "/policy-sets/foo",
+      "policy-update-patterns": [
+        "policies/cost-management/**/*.sentinel",
+        "policies/shared/**/*.sentinel"
+      ],
       "versioned": true,
       "vcs-repo": {
         "branch": "main",
@@ -618,7 +635,8 @@ Properties without a default value are required.
 | `data.relationships.workspaces`                      | array\[object] | (previous value) | An array of references to workspaces that the policy set should be assigned to. Sending an empty array clears all workspace assignments. You can only specify this attribute when `data.attributes.global` is `false`.                                                                                       |
 | `data.relationships.workspace-exclusions`            | array\[object] | (previous value) | An array of references to excluded workspaces that HCP Terraform will not enforce this policy set upon. Sending an empty array clears all exclusions assignments.                                                                                                                                          | 
 | `data.attributes.agent-enabled`                      | boolean        | `false`          | Only valid for `sentinel` policy sets. Whether this policy set should run as a policy evaluation in the HCP Terraform agent.                                                                                                                                                                               |
-|`data.attributes.policy-tool-version`                 | string         | `latest`         | The version of the tool that HCP Terraform uses to evaluate policies. You can only set a policy tool version for 'sentinel' policy sets if `agent-enabled` is `true`.                                                                                                                                |
+| `data.attributes.policy-tool-version`                | string         | `latest`         | The version of the tool that HCP Terraform uses to evaluate policies. You can only set a policy tool version for 'sentinel' policy sets if `agent-enabled` is `true`.                                                                                                                                |
+| `data.attributes.policy-update-patterns`             | array[string]  | (previous value) | A list of glob patterns specifying which file changes trigger policy set updates. Patterns are relative to the repository root, and you can specify a maximum of 100 patterns. This attribute is only valid when you specify a VCS repository for the policy set.                                          |
 
 
 ### Sample Payload


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Added documentation for the new `policy-update-patterns` API attribute in the Policy Sets API reference.

Changed page: /terraform/cloud-docs/api-docs/policy-sets

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
This documents a new API attribute that allows users to specify glob patterns for triggering policy set updates from VCS repositories. Previously, any file change in the repository would trigger a policy set update. With policy-update-patterns, users can limit updates to specific file paths (e.g., policies/cost-management/**/*.sentinel), giving them finer control over when policy sets are refreshed.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
