### PR TITLE
docs: Clarify permissions required for audit log streaming

### DIFF
--- a/content/hcp-docs/content/docs/boundary/audit-logging.mdx
+++ b/content/hcp-docs/content/docs/boundary/audit-logging.mdx
@@ -19,6 +19,15 @@ The captured data includes the user ID of the user performing the operation, the
 
 Audit logs allow administrators to track user activity and enable security teams to ensure compliance in accordance with regulatory requirements.
 
+<Note>
+
+You must authenticate to HCP as an organization-level service principal to enable audit log streaming.
+If you attempt to enable audit logs as a project-level service principal, you receive an error.
+
+Refer to [HCP audit log streaming](/hcp/docs/hcp/audit-log) for additional guidance and constraints.
+
+</Note>
+
 The documentation outlines the steps required to enable and configure audit log streaming to the supported providers AWS CloudWatch and Datadog. You can stream logs to one account at a time.
 
 ## Configure streaming with AWS CloudWatch
@@ -210,3 +219,7 @@ You can update the configuration of the existing audit log streaming. For exampl
 ## Retention
 
 HCP Boundary stores the audit logs for a minimum of one year within the platform. HCP began archiving audit logs in October of 2022. The logs are available after the deletion of the cluster that created them. Please submit a request to the [HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/requests/new) if you need access to logs from deleted clusters or have further questions.
+
+## More information
+
+Refer to [HCP audit log streaming](/hcp/docs/hcp/audit-log) for additional information about creating and managing audit logs.


### PR DESCRIPTION
From a Slack conversation:

https://ibm-hashicorp.slack.com/archives/C09KW615X9T/p1770129075416459

Internal users reported difficulty enabling audit log streaming in HCP Boundary because they did not have permissions at the org level. We do document the requirement to authenticate as an org-level principal in the generic HCP overview of audit log streaming, but Boundary users might not be aware of that topic. 

This PR:

- Adds a note to explain you will receive an error if you try to enable audit log streaming as a project-level principal. The note includes a link to the HCP audit log streaming overview topic.
- Adds a More information section to the bottom of the topic with an additional link to the HCP audit log streaming overview.

[View the update in the preview deployment ](https://unified-docs-frontend-preview-7k0102y2x-hashicorp.vercel.app/hcp/docs/boundary/audit-logging)