### PR TITLE
Consul Docs

### DIFF
--- a/content/consul/v1.22.x/content/docs/concept/gossip.mdx
+++ b/content/consul/v1.22.x/content/docs/concept/gossip.mdx
@@ -15,7 +15,7 @@ For more information about the underlying architecture, refer to [control plane 
 
 Serf is a gossip protocol that Consul implements in datacenter operations. Consul uses it to manage membership and broadcast messages to the cluster. There are two types of gossip pools available to Consul:
 
-- _The LAN gossip pool_ is enabled by default. It communications with all nodes in a single datacenter to share membership information. Consul uses the LAN gossip pool to automatically discover servers and distribute failure detection throughout the cluster. It also supports fast and reliable event broadcasts. The LAN gossip pool is required, and operates on port `8301` by default.
+- _The LAN gossip pool_ is enabled by default. It communicates with all nodes in a single datacenter to share membership information. Consul uses the LAN gossip pool to automatically discover servers and distribute failure detection throughout the cluster. It also supports fast and reliable event broadcasts. The LAN gossip pool is required, and operates on port `8301` by default.
 - _The WAN gossip pool_ extends agent gossip to operate between a primary datacenter and one or more secondary datacenters in a WAN-federated environment. Membership information provided by the WAN pool allows servers to perform cross-datacenter requests. The WAN gossip pool operates on port `8302` by default.
 
 ## Gossip encryption key


### PR DESCRIPTION
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)

Changed 'communications' to 'communicates' to correct a grammatical error (#1758).

