### PR TITLE
feat: add docs metadata for terraform-mcp-server docs

### DIFF
--- a/content/terraform-mcp-server/v0.3.x/docs/mcp-server/deploy.mdx
+++ b/content/terraform-mcp-server/v0.3.x/docs/mcp-server/deploy.mdx
@@ -2,6 +2,10 @@
 page_title: Deploy the Terraform model context protocol (MCP) server 
 description: |-
  Learn how to deploy the Terraform MCP server, which helps you write configuration using LLM responses sourced from the Terraform registry.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-10-03T12:52:08-07:00
+last_modified: 2026-01-02T09:52:24-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deploy the Terraform MCP server

--- a/content/terraform-mcp-server/v0.3.x/docs/mcp-server/index.mdx
+++ b/content/terraform-mcp-server/v0.3.x/docs/mcp-server/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform MCP server overview
 description: Learn about the Terraform model context protocol (MCP) server and how it can help you write Terraform configuration using AI.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-10-03T12:52:08-07:00
+last_modified: 2025-10-07T15:13:08-07:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform MCP server overview

--- a/content/terraform-mcp-server/v0.3.x/docs/mcp-server/prompt.mdx
+++ b/content/terraform-mcp-server/v0.3.x/docs/mcp-server/prompt.mdx
@@ -2,6 +2,10 @@
 page_title: Prompt an AI model connected to the Terraform MCP server   
 description: |-
  Learn how to prompt your AI model connected to the Terraform MCP server to answer questions about Terraform configuration using code stored in the Terraform registry
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-10-03T12:52:08-07:00
+last_modified: 2025-10-03T12:52:08-07:00
+# END AUTO GENERATED METADATA
 ---
 
 # Prompt a model connected to the Terraform MCP server 

--- a/content/terraform-mcp-server/v0.3.x/docs/mcp-server/reference.mdx
+++ b/content/terraform-mcp-server/v0.3.x/docs/mcp-server/reference.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform MCP server reference
 description: Learn about the configuration options and tools available for the Terraform MCP server.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-10-03T12:52:08-07:00
+last_modified: 2025-10-03T12:52:08-07:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform MCP server reference

--- a/content/terraform-mcp-server/v0.3.x/docs/mcp-server/security.mdx
+++ b/content/terraform-mcp-server/v0.3.x/docs/mcp-server/security.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Security model for Terraform MCP server
 description: Learn about potential security threats to Terraform Model Context Protocol (MCP) server when operating the server locally if you do not take proper precations.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-10-03T12:52:08-07:00
+last_modified: 2025-10-03T12:52:08-07:00
+# END AUTO GENERATED METADATA
 ---
 
 # Security model for Terraform MCP server

--- a/content/terraform-mcp-server/v0.4.x/docs/mcp-server/deploy.mdx
+++ b/content/terraform-mcp-server/v0.4.x/docs/mcp-server/deploy.mdx
@@ -2,6 +2,10 @@
 page_title: Deploy the Terraform model context protocol (MCP) server 
 description: |-
  Learn how to deploy the Terraform MCP server, which helps you write configuration using LLM responses sourced from the Terraform registry.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-01-22T23:00:02-07:00
+last_modified: 2026-01-22T23:00:02-07:00
+# END AUTO GENERATED METADATA
 ---
 
 # Deploy the Terraform MCP server

--- a/content/terraform-mcp-server/v0.4.x/docs/mcp-server/index.mdx
+++ b/content/terraform-mcp-server/v0.4.x/docs/mcp-server/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform MCP server overview
 description: Learn about the Terraform model context protocol (MCP) server and how it can help you write Terraform configuration using AI.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-01-22T23:00:02-07:00
+last_modified: 2026-01-22T23:00:02-07:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform MCP server overview

--- a/content/terraform-mcp-server/v0.4.x/docs/mcp-server/prompt.mdx
+++ b/content/terraform-mcp-server/v0.4.x/docs/mcp-server/prompt.mdx
@@ -2,6 +2,10 @@
 page_title: Prompt an AI model connected to the Terraform MCP server   
 description: |-
  Learn how to prompt your AI model connected to the Terraform MCP server to answer questions about Terraform configuration using code stored in the Terraform registry
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-01-22T23:00:02-07:00
+last_modified: 2026-01-22T23:00:02-07:00
+# END AUTO GENERATED METADATA
 ---
 
 # Prompt a model connected to the Terraform MCP server 

--- a/content/terraform-mcp-server/v0.4.x/docs/mcp-server/reference.mdx
+++ b/content/terraform-mcp-server/v0.4.x/docs/mcp-server/reference.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform MCP server reference
 description: Learn about the configuration options and tools available for the Terraform MCP server.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-01-22T23:00:02-07:00
+last_modified: 2026-01-28T10:45:26-07:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform MCP server reference

--- a/content/terraform-mcp-server/v0.4.x/docs/mcp-server/security.mdx
+++ b/content/terraform-mcp-server/v0.4.x/docs/mcp-server/security.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Security model for Terraform MCP server
 description: Learn about potential security threats to Terraform Model Context Protocol (MCP) server when operating the server locally if you do not take proper precations.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-01-22T23:00:02-07:00
+last_modified: 2026-01-22T23:00:02-07:00
+# END AUTO GENERATED METADATA
 ---
 
 # Security model for Terraform MCP server


### PR DESCRIPTION
### Description

This PR adds date metadata to the terraform-mcp-server documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715

### Testing

Check that terraform-mcp-server docs look normal in the preview: https://unified-docs-frontend-preview-9s6ffljnu-hashicorp.vercel.app/terraform/mcp-server