### PR TITLE
feat: add date metadata for terraform-enterprise part 3

### DIFF
--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,8 +5,8 @@ description: >-
   designate variable values for a no-code module in your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -6,8 +6,8 @@ description: >-
   override policies, and list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -7,8 +7,8 @@ description: >-
   API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/admin-access.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/general.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/resources.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI - Administration - Flexible Deployment Options - Terraform
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backup and Restore - Administration - Flexible Deployment Options - 
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options. 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
@@ -3,8 +3,8 @@ page_title: Access the CLI - Admin CLI - Administration - Flexible Deployment Op
 description: >-
   Learn how to access the command line with Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/admin/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to administer Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
@@ -3,8 +3,8 @@ page_title: Reference Architecture - Flexible Deployments Options - Terraform En
 description: >-
   This pages describes the available reference architectures for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.œå
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to get started deploying Terraform Enterprise on Docker Engine or Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/configuration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Docker - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/index.mdx
@@ -3,8 +3,8 @@ page_title: Overview - Installation - Flexible Deployment Options - Terraform En
 description: >-
   Installation guidance for Terraform Enterprise's flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options - Te
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -3,8 +3,8 @@ page_title: Installation on Kubernetes - Flexible Deployment Options - Terraform
 description: >-
   Learn how to install Terraform Enterprise with Flexible Deployment Options on Kubernetes using Helm.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes - Requirements - Flexible Deployment Options - Terraform 
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Flexible Deployment Options - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
@@ -3,8 +3,8 @@ page_title: Shared Requirements - Installation - Flexible Deployment Options - T
 description: >-
   The pages guide you through the shared requirements for all flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of 
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes Scaling - Scaling - Flexible Deployment Options - Terrafo
 description: >-
   Scaling information for Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
@@ -6,8 +6,8 @@ description: >-
 tfc_only: false
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
@@ -7,8 +7,8 @@ description: >-
   mapping and add more resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
@@ -5,8 +5,8 @@ description: >-
   AWS into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
@@ -5,8 +5,8 @@ description: >-
   Azure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
@@ -5,8 +5,8 @@ description: >-
   Google Cloud Platform into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
@@ -7,8 +7,8 @@ description: >-
   major cloud providers into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
@@ -7,8 +7,8 @@ description: >-
   vSphere into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise and offers two modes of import for Terraform resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration. Prepare modules for no-code provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202307-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202308-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202308-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202308-1 (725) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202309-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202309-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202309-1 (733) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Legacy Deployment (Replicated) - Terraform Enterpri
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Mounted Disk Mode to External Services Mode - Infrast
 description: >-
   Migrating from Mounted Disk Mode to External Services Mode
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/license/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/license/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/index.mdx
@@ -3,8 +3,8 @@ page_title: Legacy Deployment Overview (Replicated) - Terraform Enterprise
 description: >-
   Learn about the history and context of the Terraform Enterprise Replicated deployment option.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/vault.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/monitoring/logging.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/monitoring/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/monitoring/monitoring.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/monitoring/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/docker_engine.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/docker_engine.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   the same workspace.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,8 +5,8 @@ description: >-
   designate variable values for a no-code module in your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -6,8 +6,8 @@ description: >-
   override policies, and list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -7,8 +7,8 @@ description: >-
   projects.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/admin-access.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/general.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/resources.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI - Administration - Flexible Deployment Options - Terraform
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backup and Restore - Administration - Flexible Deployment Options - 
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options. 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
@@ -3,8 +3,8 @@ page_title: Access the CLI - Admin CLI - Administration - Flexible Deployment Op
 description: >-
   Learn how to access the command line with Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/admin/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to administer Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/admin/upgrade.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/admin/upgrade.mdx
@@ -3,8 +3,8 @@ page_title: Upgrade - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to upgrade Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
@@ -3,8 +3,8 @@ page_title: Reference Architecture - Flexible Deployments Options - Terraform En
 description: >-
   This pages describes the available reference architectures for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.œå
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to get started deploying Terraform Enterprise on Docker Engine or Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/configuration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Docker - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/index.mdx
@@ -3,8 +3,8 @@ page_title: Overview - Installation - Flexible Deployment Options - Terraform En
 description: >-
   Installation guidance for Terraform Enterprise's flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options - Te
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -3,8 +3,8 @@ page_title: Installation on Kubernetes - Flexible Deployment Options - Terraform
 description: >-
   Learn how to install Terraform Enterprise with Flexible Deployment Options on Kubernetes using Helm.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes - Requirements - Flexible Deployment Options - Terraform 
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Flexible Deployment Options - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
@@ -3,8 +3,8 @@ page_title: Shared Requirements - Installation - Flexible Deployment Options - T
 description: >-
   The pages guide you through the shared requirements for all flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of 
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes Scaling - Scaling - Flexible Deployment Options - Terrafo
 description: >-
   Scaling information for Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
@@ -6,8 +6,8 @@ description: >-
 tfc_only: false
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
@@ -7,8 +7,8 @@ description: >-
   mapping and add more resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
@@ -5,8 +5,8 @@ description: >-
   AWS into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
@@ -5,8 +5,8 @@ description: >-
   Azure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
@@ -5,8 +5,8 @@ description: >-
   Google Cloud Platform into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
@@ -7,8 +7,8 @@ description: >-
   major cloud providers into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
@@ -7,8 +7,8 @@ description: >-
   vSphere into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise and offers two modes of import for Terraform resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration. Prepare modules for no-code provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202307-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202308-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202308-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202308-1 (725) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202309-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202309-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202309-1 (733) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202310-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202310-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202310-1 (741) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Legacy Deployment (Replicated) - Terraform Enterpri
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Mounted Disk Mode to External Services Mode - Infrast
 description: >-
   Migrating from Mounted Disk Mode to External Services Mode
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/license/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/license/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/index.mdx
@@ -3,8 +3,8 @@ page_title: Legacy Deployment Overview (Replicated) - Terraform Enterprise
 description: >-
   Learn about the history and context of the Terraform Enterprise Replicated deployment option.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/vault.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/monitoring/logging.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/monitoring/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/monitoring/monitoring.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/monitoring/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/docker_engine.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/docker_engine.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   the same workspace.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/deletion.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/deletion.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/opa-versions.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/opa-versions.mdx
@@ -3,8 +3,8 @@ page_title: OPA Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/opa-versions` endpoint to manage available Open Policy Agent (OPA) versions. Learn how to list, show, create, update, and delete OPA versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/sentinel-versions.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/sentinel-versions.mdx
@@ -3,8 +3,8 @@ page_title: Sentinel Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/sentinel-versions` endpoint to manage available Sentinel versions. Learn how to list, show, create, update, and delete Sentinel versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,8 +5,8 @@ description: >-
   designate variable values for a no-code module in your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform run. List, show and override policy checks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/policy-evaluations.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/policy-evaluations.mdx
@@ -6,8 +6,8 @@ description: >-
   list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -7,8 +7,8 @@ description: >-
   projects.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/private-registry/tests.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/private-registry/tests.mdx
@@ -5,8 +5,8 @@ description: >-
   cancel tests using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/admin-access.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/general.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/resources.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI - Administration - Flexible Deployment Options - Terraform
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backup and Restore - Administration - Flexible Deployment Options - 
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options. 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
@@ -3,8 +3,8 @@ page_title: Access the CLI - Admin CLI - Administration - Flexible Deployment Op
 description: >-
   Learn how to access the command line with Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/admin/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to administer Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/admin/upgrade.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/admin/upgrade.mdx
@@ -3,8 +3,8 @@ page_title: Upgrade - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to upgrade Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
@@ -3,8 +3,8 @@ page_title: Reference Architecture - Flexible Deployments Options - Terraform En
 description: >-
   This pages describes the available reference architectures for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.œå
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to get started deploying Terraform Enterprise on Docker Engine or Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/configuration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Docker - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/index.mdx
@@ -3,8 +3,8 @@ page_title: Overview - Installation - Flexible Deployment Options - Terraform En
 description: >-
   Installation guidance for Terraform Enterprise's flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options - Te
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -3,8 +3,8 @@ page_title: Installation on Kubernetes - Flexible Deployment Options - Terraform
 description: >-
   Learn how to install Terraform Enterprise with Flexible Deployment Options on Kubernetes using Helm.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes - Requirements - Flexible Deployment Options - Terraform 
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Flexible Deployment Options - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
@@ -3,8 +3,8 @@ page_title: Shared Requirements - Installation - Flexible Deployment Options - T
 description: >-
   The pages guide you through the shared requirements for all flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of 
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes Scaling - Scaling - Flexible Deployment Options - Terrafo
 description: >-
   Scaling information for Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
@@ -6,8 +6,8 @@ description: >-
 tfc_only: false
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
@@ -7,8 +7,8 @@ description: >-
   mapping and add more resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
@@ -5,8 +5,8 @@ description: >-
   AWS into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
@@ -5,8 +5,8 @@ description: >-
   Azure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
@@ -5,8 +5,8 @@ description: >-
   Google Cloud Platform into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
@@ -7,8 +7,8 @@ description: >-
   major cloud providers into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
@@ -7,8 +7,8 @@ description: >-
   vSphere into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise and offers two modes of import for Terraform resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration. Prepare modules for no-code provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/registry/airgapped-providers.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/registry/airgapped-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Host a version of an official HashiCorp Terraform provider in your
   airgapped Terraform Enterprise private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202307-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202308-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202308-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202308-1 (725) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202309-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202309-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202309-1 (733) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202310-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202310-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202310-1 (741) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202311-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202311-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202311-1 (742) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Legacy Deployment (Replicated) - Terraform Enterpri
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Mounted Disk Mode to External Services Mode - Infrast
 description: >-
   Migrating from Mounted Disk Mode to External Services Mode
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/license/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/license/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/index.mdx
@@ -3,8 +3,8 @@ page_title: Legacy Deployment Overview (Replicated) - Terraform Enterprise
 description: >-
   Learn about the history and context of the Terraform Enterprise Replicated deployment option.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/vault.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/monitoring/logging.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/monitoring/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/monitoring/monitoring.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/monitoring/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/docker_engine.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/docker_engine.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   the same workspace.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/deletion.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/deletion.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/opa-versions.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/opa-versions.mdx
@@ -3,8 +3,8 @@ page_title: OPA Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/opa-versions` endpoint to manage available Open Policy Agent (OPA) versions. Learn how to list, show, create, update, and delete OPA versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/sentinel-versions.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/sentinel-versions.mdx
@@ -3,8 +3,8 @@ page_title: Sentinel Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/sentinel-versions` endpoint to manage available Sentinel versions. Learn how to list, show, create, update, and delete Sentinel versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,8 +5,8 @@ description: >-
   designate variable values for a no-code module in your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform run. List, show and override policy checks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/policy-evaluations.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/policy-evaluations.mdx
@@ -6,8 +6,8 @@ description: >-
   list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -7,8 +7,8 @@ description: >-
   projects.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/private-registry/tests.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/private-registry/tests.mdx
@@ -5,8 +5,8 @@ description: >-
   cancel tests using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/admin-access.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/general.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/resources.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI - Administration - Flexible Deployment Options - Terraform
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backup and Restore - Administration - Flexible Deployment Options - 
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options. 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
@@ -3,8 +3,8 @@ page_title: Access the CLI - Admin CLI - Administration - Flexible Deployment Op
 description: >-
   Learn how to access the command line with Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/admin/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to administer Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/admin/upgrade.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/admin/upgrade.mdx
@@ -3,8 +3,8 @@ page_title: Upgrade - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to upgrade Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
@@ -3,8 +3,8 @@ page_title: Reference Architecture - Flexible Deployments Options - Terraform En
 description: >-
   This pages describes the available reference architectures for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.œå
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to get started deploying Terraform Enterprise on Docker Engine or Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/configuration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/custom-image.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/custom-image.mdx
@@ -3,8 +3,8 @@ page_title: Custom Worker Image - Install and Config - Terraform Enterprise
 description: >-
   Use a custom image to add custom tools or logic to your Terraform Enterprise run enviornment.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Docker - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/index.mdx
@@ -3,8 +3,8 @@ page_title: Overview - Installation - Flexible Deployment Options - Terraform En
 description: >-
   Installation guidance for Terraform Enterprise's flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options - Te
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -3,8 +3,8 @@ page_title: Installation on Kubernetes - Flexible Deployment Options - Terraform
 description: >-
   Learn how to install Terraform Enterprise with Flexible Deployment Options on Kubernetes using Helm.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes - Requirements - Flexible Deployment Options - Terraform 
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Flexible Deployment Options - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Podman - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
@@ -3,8 +3,8 @@ page_title: Shared Requirements - Installation - Flexible Deployment Options - T
 description: >-
   The pages guide you through the shared requirements for all flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of 
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes Scaling - Scaling - Flexible Deployment Options - Terrafo
 description: >-
   Scaling information for Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/kubernetes/api-reference.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/kubernetes/api-reference.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Cloud Operator for Kubernetes API reference
 description: API reference for the Terraform Cloud Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/kubernetes/index.mdx
@@ -5,8 +5,8 @@ description: >-
   from the Kubernetes control plane.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
@@ -5,8 +5,8 @@ description: >-
   2.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/kubernetes/setup.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/kubernetes/setup.mdx
@@ -3,8 +3,8 @@ page_title: Set up the Terraform Cloud Operator for Kubernetes
 description: Install and configure the Terraform Cloud Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
@@ -7,8 +7,8 @@ description: >-
   mapping and add more resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
@@ -5,8 +5,8 @@ description: >-
   AWS into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
@@ -5,8 +5,8 @@ description: >-
   Azure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
@@ -5,8 +5,8 @@ description: >-
   Google Cloud Platform into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
@@ -7,8 +7,8 @@ description: >-
   major cloud providers into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
@@ -7,8 +7,8 @@ description: >-
   vSphere into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise and offers two modes of import for Terraform resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration. Prepare modules for no-code provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/registry/airgapped-providers.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/registry/airgapped-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Host a version of an official HashiCorp Terraform provider in your
   airgapped Terraform Enterprise private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-10-30T14:40:45-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202307-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202308-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202308-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202308-1 (725) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202309-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202309-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202309-1 (733) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202310-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202310-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202310-1 (741) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202311-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202311-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202311-1 (742) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202312-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202312-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202312-1 (745) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Legacy Deployment (Replicated) - Terraform Enterpri
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Mounted Disk Mode to External Services Mode - Infrast
 description: >-
   Migrating from Mounted Disk Mode to External Services Mode
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/license/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/license/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/index.mdx
@@ -3,8 +3,8 @@ page_title: Legacy Deployment Overview (Replicated) - Terraform Enterprise
 description: >-
   Learn about the history and context of the Terraform Enterprise Replicated deployment option.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/vault.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/monitoring/logging.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/monitoring/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/monitoring/monitoring.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/monitoring/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/docker_engine.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/docker_engine.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   the same workspace.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/deletion.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/deletion.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/opa-versions.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/opa-versions.mdx
@@ -3,8 +3,8 @@ page_title: OPA Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/opa-versions` endpoint to manage available Open Policy Agent (OPA) versions. Learn how to list, show, create, update, and delete OPA versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/sentinel-versions.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/sentinel-versions.mdx
@@ -3,8 +3,8 @@ page_title: Sentinel Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/sentinel-versions` endpoint to manage available Sentinel versions. Learn how to list, show, create, update, and delete Sentinel versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,8 +5,8 @@ description: >-
   designate variable values for a no-code module in your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform run. List, show and override policy checks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/policy-evaluations.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/policy-evaluations.mdx
@@ -6,8 +6,8 @@ description: >-
   list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -7,8 +7,8 @@ description: >-
   projects.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/private-registry/tests.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/private-registry/tests.mdx
@@ -5,8 +5,8 @@ description: >-
   cancel tests using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/admin-access.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/general.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/resources.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI - Administration - Flexible Deployment Options - Terraform
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backup and Restore - Administration - Flexible Deployment Options - 
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options. 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
@@ -3,8 +3,8 @@ page_title: Access the CLI - Admin CLI - Administration - Flexible Deployment Op
 description: >-
   Learn how to access the command line with Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/admin/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to administer Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/admin/upgrade.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/admin/upgrade.mdx
@@ -3,8 +3,8 @@ page_title: Upgrade - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to upgrade Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
@@ -3,8 +3,8 @@ page_title: Reference Architecture - Flexible Deployments Options - Terraform En
 description: >-
   This pages describes the available reference architectures for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.œå
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to get started deploying Terraform Enterprise on Docker Engine or Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/configuration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/custom-image.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/custom-image.mdx
@@ -3,8 +3,8 @@ page_title: Custom Worker Image - Install and Config - Terraform Enterprise
 description: >-
   Use a custom image to add custom tools or logic to your Terraform Enterprise run enviornment.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Docker - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/index.mdx
@@ -3,8 +3,8 @@ page_title: Overview - Installation - Flexible Deployment Options - Terraform En
 description: >-
   Installation guidance for Terraform Enterprise's flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options - Te
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -3,8 +3,8 @@ page_title: Installation on Kubernetes - Flexible Deployment Options - Terraform
 description: >-
   Learn how to install Terraform Enterprise with Flexible Deployment Options on Kubernetes using Helm.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes - Requirements - Flexible Deployment Options - Terraform 
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Flexible Deployment Options - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Podman - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
@@ -3,8 +3,8 @@ page_title: Shared Requirements - Installation - Flexible Deployment Options - T
 description: >-
   The pages guide you through the shared requirements for all flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of 
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes Scaling - Scaling - Flexible Deployment Options - Terrafo
 description: >-
   Scaling information for Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/aws-service-catalog/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/aws-service-catalog/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Service Catalog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/kubernetes/api-reference.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/kubernetes/api-reference.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Operator for Kubernetes API reference
 description: API reference for the Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/kubernetes/index.mdx
@@ -5,8 +5,8 @@ description: >-
   from the Kubernetes control plane.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
@@ -5,8 +5,8 @@ description: >-
   2.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/kubernetes/setup.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/kubernetes/setup.mdx
@@ -3,8 +3,8 @@ page_title: Set up the Terraform Enterprise Operator for Kubernetes
 description: Install and configure the Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
@@ -7,8 +7,8 @@ description: >-
   mapping and add more resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
@@ -5,8 +5,8 @@ description: >-
   AWS into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
@@ -5,8 +5,8 @@ description: >-
   Azure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
@@ -5,8 +5,8 @@ description: >-
   Google Cloud Platform into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
@@ -7,8 +7,8 @@ description: >-
   major cloud providers into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
@@ -7,8 +7,8 @@ description: >-
   vSphere into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise and offers two modes of import for Terraform resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration. Prepare modules for no-code provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/registry/airgapped-providers.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/registry/airgapped-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Host a version of an official HashiCorp Terraform provider in your
   airgapped Terraform Enterprise private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-10-30T14:40:45-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/registry/test.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/registry/test.mdx
@@ -3,8 +3,8 @@ page_title: Testing Private Modules - Private Registry - Terraform Enterprise
 description: Enable automated module testing in the private registry
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202307-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202308-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202308-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202308-1 (725) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202309-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202309-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202309-1 (733) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202310-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202310-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202310-1 (741) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202311-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202311-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202311-1 (742) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202312-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202312-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202312-1 (745) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2024/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2024/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2024 Releases - Terraform Enterprise
 description: The 2024 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2024/v202401-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2024/v202401-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-1 (751) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Legacy Deployment (Replicated) - Terraform Enterpri
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Mounted Disk Mode to External Services Mode - Infrast
 description: >-
   Migrating from Mounted Disk Mode to External Services Mode
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/license/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/license/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/index.mdx
@@ -3,8 +3,8 @@ page_title: Legacy Deployment Overview (Replicated) - Terraform Enterprise
 description: >-
   Learn about the history and context of the Terraform Enterprise Replicated deployment option.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/vault.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/monitoring/logging.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/monitoring/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/monitoring/monitoring.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/monitoring/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/docker_engine.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/docker_engine.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/organizations/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/organizations/index.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
@@ -3,8 +3,8 @@ page_title: VCS Status Checks
 description: Learn how VCS status checks work in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   the same workspace.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/deletion.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/deletion.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/opa-versions.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/opa-versions.mdx
@@ -3,8 +3,8 @@ page_title: OPA Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/opa-versions` endpoint to manage available Open Policy Agent (OPA) versions. Learn how to list, show, create, update, and delete OPA versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/sentinel-versions.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/sentinel-versions.mdx
@@ -3,8 +3,8 @@ page_title: Sentinel Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/sentinel-versions` endpoint to manage available Sentinel versions. Learn how to list, show, create, update, and delete Sentinel versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/data-retention-policies.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/data-retention-policies.mdx
@@ -3,8 +3,8 @@ page_title: Data retention policy API
 description: >-
   Learn how to use the `/data-retention-policy` endpoints to configure how long Terraform stores data. You can call the data retention policy APIs to programmatically configure Terraform Enterprise to automatically delete data for different resources after a specific number of days.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,8 +5,8 @@ description: >-
   designate variable values for a no-code module in your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/policy-checks.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform run. List, show and override policy checks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/policy-evaluations.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/policy-evaluations.mdx
@@ -6,8 +6,8 @@ description: >-
   list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/policy-sets.mdx
@@ -7,8 +7,8 @@ description: >-
   projects.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/private-registry/tests.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/private-registry/tests.mdx
@@ -5,8 +5,8 @@ description: >-
   cancel tests using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/admin-access.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/general.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/resources.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI - Administration - Flexible Deployment Options - Terraform
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backup and Restore - Administration - Flexible Deployment Options - 
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options. 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
@@ -3,8 +3,8 @@ page_title: Access the CLI - Admin CLI - Administration - Flexible Deployment Op
 description: >-
   Learn how to access the command line with Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/admin/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to administer Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/admin/upgrade.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/admin/upgrade.mdx
@@ -3,8 +3,8 @@ page_title: Upgrade - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to upgrade Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
@@ -3,8 +3,8 @@ page_title: Reference Architecture - Flexible Deployments Options - Terraform En
 description: >-
   This pages describes the available reference architectures for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.œå
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to get started deploying Terraform Enterprise on Docker Engine or Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/configuration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/custom-image.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/custom-image.mdx
@@ -3,8 +3,8 @@ page_title: Custom Worker Image - Install and Config - Terraform Enterprise
 description: >-
   Use a custom image to add custom tools or logic to your Terraform Enterprise run enviornment.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Docker - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/index.mdx
@@ -3,8 +3,8 @@ page_title: Overview - Installation - Flexible Deployment Options - Terraform En
 description: >-
   Installation guidance for Terraform Enterprise's flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options - Te
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -3,8 +3,8 @@ page_title: Installation on Kubernetes - Flexible Deployment Options - Terraform
 description: >-
   Learn how to install Terraform Enterprise with Flexible Deployment Options on Kubernetes using Helm.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes - Requirements - Flexible Deployment Options - Terraform 
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Flexible Deployment Options - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Podman - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/requirements/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/requirements/index.mdx
@@ -3,8 +3,8 @@ page_title: Shared Requirements - Installation - Flexible Deployment Options - T
 description: >-
   The pages guide you through the shared requirements for all flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/requirements/network.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of 
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/scaling/docker.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/scaling/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes Scaling - Scaling - Flexible Deployment Options - Terrafo
 description: >-
   Scaling information for Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/flexible-deployments/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/aws-service-catalog/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/aws-service-catalog/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Service Catalog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/kubernetes/api-reference.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/kubernetes/api-reference.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Operator for Kubernetes API reference
 description: API reference for the Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/kubernetes/index.mdx
@@ -5,8 +5,8 @@ description: >-
   from the Kubernetes control plane.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
@@ -5,8 +5,8 @@ description: >-
   2.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/kubernetes/setup.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/kubernetes/setup.mdx
@@ -3,8 +3,8 @@ page_title: Set up the Terraform Enterprise Operator for Kubernetes
 description: Install and configure the Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
@@ -7,8 +7,8 @@ description: >-
   mapping and add more resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
@@ -5,8 +5,8 @@ description: >-
   AWS into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
@@ -5,8 +5,8 @@ description: >-
   Azure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
@@ -5,8 +5,8 @@ description: >-
   Google Cloud Platform into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
@@ -7,8 +7,8 @@ description: >-
   major cloud providers into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
@@ -7,8 +7,8 @@ description: >-
   vSphere into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise and offers two modes of import for Terraform resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration. Prepare modules for no-code provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/registry/airgapped-providers.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/registry/airgapped-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Host a version of an official HashiCorp Terraform provider in your
   airgapped Terraform Enterprise private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-10-30T14:40:45-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/registry/test.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/registry/test.mdx
@@ -3,8 +3,8 @@ page_title: Testing Private Modules - Private Registry - Terraform Enterprise
 description: Enable automated module testing in the private registry
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202307-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202308-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202308-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202308-1 (725) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202309-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202309-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202309-1 (733) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202310-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202310-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202310-1 (741) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202311-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202311-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202311-1 (742) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202312-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202312-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202312-1 (745) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2024/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2024/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2024 Releases - Terraform Enterprise
 description: The 2024 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2024/v202401-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2024/v202401-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-1 (751) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2024/v202401-2.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2024/v202401-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-2 (755) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Legacy Deployment (Replicated) - Terraform Enterpri
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Mounted Disk Mode to External Services Mode - Infrast
 description: >-
   Migrating from Mounted Disk Mode to External Services Mode
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/license/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/license/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/index.mdx
@@ -3,8 +3,8 @@ page_title: Legacy Deployment Overview (Replicated) - Terraform Enterprise
 description: >-
   Learn about the history and context of the Terraform Enterprise Replicated deployment option.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/vault.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/monitoring/logging.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/monitoring/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/monitoring/monitoring.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/monitoring/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/docker_engine.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/docker_engine.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/organizations/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/organizations/index.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
@@ -3,8 +3,8 @@ page_title: VCS Status Checks
 description: Learn how VCS status checks work in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   the same workspace.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/deletion.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/deletion.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/opa-versions.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/opa-versions.mdx
@@ -3,8 +3,8 @@ page_title: OPA Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/opa-versions` endpoint to manage available Open Policy Agent (OPA) versions. Learn how to list, show, create, update, and delete OPA versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/sentinel-versions.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/sentinel-versions.mdx
@@ -3,8 +3,8 @@ page_title: Sentinel Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/sentinel-versions` endpoint to manage available Sentinel versions. Learn how to list, show, create, update, and delete Sentinel versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/data-retention-policies.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/data-retention-policies.mdx
@@ -3,8 +3,8 @@ page_title: Data retention policy API
 description: >-
   Learn how to use the `/data-retention-policy` endpoints to configure how long Terraform stores data. You can call the data retention policy APIs to programmatically configure Terraform Enterprise to automatically delete data for different resources after a specific number of days.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,8 +5,8 @@ description: >-
   designate variable values for a no-code module in your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform run. List, show and override policy checks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/policy-evaluations.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/policy-evaluations.mdx
@@ -6,8 +6,8 @@ description: >-
   list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -7,8 +7,8 @@ description: >-
   projects.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/private-registry/tests.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/private-registry/tests.mdx
@@ -5,8 +5,8 @@ description: >-
   cancel tests using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/admin-access.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/general.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/resources.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI - Administration - Flexible Deployment Options - Terraform
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backup and Restore - Administration - Flexible Deployment Options - 
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options. 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
@@ -3,8 +3,8 @@ page_title: Access the CLI - Admin CLI - Administration - Flexible Deployment Op
 description: >-
   Learn how to access the command line with Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/admin/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to administer Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/admin/license.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/admin/license.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/admin/upgrade.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/admin/upgrade.mdx
@@ -3,8 +3,8 @@ page_title: Upgrade - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to upgrade Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
@@ -3,8 +3,8 @@ page_title: Reference Architecture - Flexible Deployments Options - Terraform En
 description: >-
   This pages describes the available reference architectures for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.œå
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to get started deploying Terraform Enterprise on Docker Engine or Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/configuration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/custom-image.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/custom-image.mdx
@@ -3,8 +3,8 @@ page_title: Custom Worker Image - Install and Config - Terraform Enterprise
 description: >-
   Use a custom image to add custom tools or logic to your Terraform Enterprise run enviornment.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Docker - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/index.mdx
@@ -3,8 +3,8 @@ page_title: Overview - Installation - Flexible Deployment Options - Terraform En
 description: >-
   Installation guidance for Terraform Enterprise's flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options - Te
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -3,8 +3,8 @@ page_title: Installation on Kubernetes - Flexible Deployment Options - Terraform
 description: >-
   Learn how to install Terraform Enterprise with Flexible Deployment Options on Kubernetes using Helm.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes - Requirements - Flexible Deployment Options - Terraform 
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Flexible Deployment Options - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Podman - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
@@ -3,8 +3,8 @@ page_title: Shared Requirements - Installation - Flexible Deployment Options - T
 description: >-
   The pages guide you through the shared requirements for all flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of 
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes Scaling - Scaling - Flexible Deployment Options - Terrafo
 description: >-
   Scaling information for Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/aws-service-catalog/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/aws-service-catalog/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Service Catalog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/kubernetes/api-reference.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/kubernetes/api-reference.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Operator for Kubernetes API reference
 description: API reference for the Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/kubernetes/index.mdx
@@ -5,8 +5,8 @@ description: >-
   from the Kubernetes control plane.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
@@ -5,8 +5,8 @@ description: >-
   2.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/kubernetes/setup.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/kubernetes/setup.mdx
@@ -3,8 +3,8 @@ page_title: Set up the Terraform Enterprise Operator for Kubernetes
 description: Install and configure the Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
@@ -7,8 +7,8 @@ description: >-
   mapping and add more resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
@@ -5,8 +5,8 @@ description: >-
   AWS into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
@@ -5,8 +5,8 @@ description: >-
   Azure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
@@ -5,8 +5,8 @@ description: >-
   Google Cloud Platform into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
@@ -7,8 +7,8 @@ description: >-
   major cloud providers into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
@@ -7,8 +7,8 @@ description: >-
   vSphere into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise and offers two modes of import for Terraform resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration. Prepare modules for no-code provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/registry/airgapped-providers.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/registry/airgapped-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Host a version of an official HashiCorp Terraform provider in your
   airgapped Terraform Enterprise private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-10-30T14:40:45-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/registry/test.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/registry/test.mdx
@@ -3,8 +3,8 @@ page_title: Testing Private Modules - Private Registry - Terraform Enterprise
 description: Enable automated module testing in the private registry
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202307-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202308-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202308-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202308-1 (725) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202309-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202309-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202309-1 (733) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202310-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202310-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202310-1 (741) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202311-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202311-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202311-1 (742) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202312-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202312-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202312-1 (745) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2024/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2024/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2024 Releases - Terraform Enterprise
 description: The 2024 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2024/v202401-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2024/v202401-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-1 (751) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2024/v202401-2.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2024/v202401-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-2 (755) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2024/v202402-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2024/v202402-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202402-1 (759) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Legacy Deployment (Replicated) - Terraform Enterpri
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Mounted Disk Mode to External Services Mode - Infrast
 description: >-
   Migrating from Mounted Disk Mode to External Services Mode
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/license/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/license/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/index.mdx
@@ -3,8 +3,8 @@ page_title: Legacy Deployment Overview (Replicated) - Terraform Enterprise
 description: >-
   Learn about the history and context of the Terraform Enterprise Replicated deployment option.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/vault.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/monitoring/logging.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/monitoring/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/monitoring/monitoring.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/monitoring/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/docker_engine.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/docker_engine.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/organizations/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/organizations/index.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
@@ -3,8 +3,8 @@ page_title: VCS Status Checks
 description: Learn how VCS status checks work in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   the same workspace.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/deletion.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/deletion.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/opa-versions.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/opa-versions.mdx
@@ -3,8 +3,8 @@ page_title: OPA Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/opa-versions` endpoint to manage available Open Policy Agent (OPA) versions. Learn how to list, show, create, update, and delete OPA versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/sentinel-versions.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/sentinel-versions.mdx
@@ -3,8 +3,8 @@ page_title: Sentinel Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/sentinel-versions` endpoint to manage available Sentinel versions. Learn how to list, show, create, update, and delete Sentinel versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/data-retention-policies.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/data-retention-policies.mdx
@@ -3,8 +3,8 @@ page_title: Data retention policy API
 description: >-
   Learn how to use the `/data-retention-policy` endpoints to configure how long Terraform stores data. You can call the data retention policy APIs to programmatically configure Terraform Enterprise to automatically delete data for different resources after a specific number of days.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,8 +5,8 @@ description: >-
   designate variable values for a no-code module in your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/policy-checks.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform run. List, show and override policy checks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/policy-evaluations.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/policy-evaluations.mdx
@@ -6,8 +6,8 @@ description: >-
   list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/policy-sets.mdx
@@ -7,8 +7,8 @@ description: >-
   projects.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/private-registry/tests.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/private-registry/tests.mdx
@@ -5,8 +5,8 @@ description: >-
   cancel tests using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/admin-access.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   HCP Terraform.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/general.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/resources.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI - Administration - Flexible Deployment Options - Terraform
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backup and Restore - Administration - Flexible Deployment Options - 
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options. 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
@@ -3,8 +3,8 @@ page_title: Access the CLI - Admin CLI - Administration - Flexible Deployment Op
 description: >-
   Learn how to access the command line with Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/admin/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to administer Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/admin/license.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/admin/license.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/admin/upgrade.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/admin/upgrade.mdx
@@ -3,8 +3,8 @@ page_title: Upgrade - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to upgrade Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
@@ -3,8 +3,8 @@ page_title: Reference Architecture - Flexible Deployments Options - Terraform En
 description: >-
   This pages describes the available reference architectures for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.œå
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to get started deploying Terraform Enterprise on Docker Engine or Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/configuration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/custom-image.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/custom-image.mdx
@@ -3,8 +3,8 @@ page_title: Custom Worker Image - Install and Config - Terraform Enterprise
 description: >-
   Use a custom image to add custom tools or logic to your Terraform Enterprise run enviornment.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Docker - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/index.mdx
@@ -3,8 +3,8 @@ page_title: Overview - Installation - Flexible Deployment Options - Terraform En
 description: >-
   Installation guidance for Terraform Enterprise's flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options - Te
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -3,8 +3,8 @@ page_title: Installation on Kubernetes - Flexible Deployment Options - Terraform
 description: >-
   Learn how to install Terraform Enterprise with Flexible Deployment Options on Kubernetes using Helm.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes - Requirements - Flexible Deployment Options - Terraform 
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Flexible Deployment Options - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Podman - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/requirements/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/requirements/index.mdx
@@ -3,8 +3,8 @@ page_title: Shared Requirements - Installation - Flexible Deployment Options - T
 description: >-
   The pages guide you through the shared requirements for all flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/requirements/network.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of 
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/scaling/docker.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/scaling/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes Scaling - Scaling - Flexible Deployment Options - Terrafo
 description: >-
   Scaling information for Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/flexible-deployments/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of HCP Terraform with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/aws-service-catalog/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/aws-service-catalog/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Service Catalog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/kubernetes/api-reference.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/kubernetes/api-reference.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Operator for Kubernetes API reference
 description: API reference for the Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/kubernetes/index.mdx
@@ -5,8 +5,8 @@ description: >-
   from the Kubernetes control plane.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
@@ -5,8 +5,8 @@ description: >-
   2.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/kubernetes/setup.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/kubernetes/setup.mdx
@@ -3,8 +3,8 @@ page_title: Set up the Terraform Enterprise Operator for Kubernetes
 description: Install and configure the Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the HCP Terraform run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
@@ -7,8 +7,8 @@ description: >-
   mapping and add more resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
@@ -5,8 +5,8 @@ description: >-
   AWS into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
@@ -5,8 +5,8 @@ description: >-
   Azure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
@@ -5,8 +5,8 @@ description: >-
   Google Cloud Platform into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
@@ -7,8 +7,8 @@ description: >-
   major cloud providers into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
@@ -7,8 +7,8 @@ description: >-
   vSphere into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise and offers two modes of import for Terraform resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration. Prepare modules for no-code provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/registry/airgapped-providers.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/registry/airgapped-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Host a version of an official HashiCorp Terraform provider in your
   airgapped Terraform Enterprise private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-10-30T14:40:45-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/registry/test.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/registry/test.mdx
@@ -3,8 +3,8 @@ page_title: Testing Private Modules - Private Registry - Terraform Enterprise
 description: Enable automated module testing in the private registry
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202307-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202308-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202308-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202308-1 (725) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202309-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202309-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202309-1 (733) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202310-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202310-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202310-1 (741) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202311-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202311-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202311-1 (742) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202312-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202312-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202312-1 (745) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2024/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2024/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2024 Releases - Terraform Enterprise
 description: The 2024 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2024/v202401-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2024/v202401-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-1 (751) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2024/v202401-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2024/v202401-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-2 (755) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2024/v202402-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2024/v202402-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202402-1 (759) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2024/v202402-2.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2024/v202402-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202402-2 (760) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Legacy Deployment (Replicated) - Terraform Enterpri
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch Terraform Enterprise instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Mounted Disk Mode to External Services Mode - Infrast
 description: >-
   Migrating from Mounted Disk Mode to External Services Mode
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/license/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/license/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/index.mdx
@@ -3,8 +3,8 @@ page_title: Legacy Deployment Overview (Replicated) - Terraform Enterprise
 description: >-
   Learn about the history and context of the Terraform Enterprise Replicated deployment option.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/vault.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/monitoring/logging.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/monitoring/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/monitoring/monitoring.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/monitoring/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/docker_engine.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/docker_engine.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/organizations/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/organizations/index.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
@@ -3,8 +3,8 @@ page_title: VCS Status Checks
 description: Learn how VCS status checks work in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   the same workspace.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/deletion.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/deletion.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/opa-versions.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/opa-versions.mdx
@@ -3,8 +3,8 @@ page_title: OPA Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/opa-versions` endpoint to manage available Open Policy Agent (OPA) versions. Learn how to list, show, create, update, and delete OPA versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/sentinel-versions.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/sentinel-versions.mdx
@@ -3,8 +3,8 @@ page_title: Sentinel Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/sentinel-versions` endpoint to manage available Sentinel versions. Learn how to list, show, create, update, and delete Sentinel versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/data-retention-policies.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/data-retention-policies.mdx
@@ -3,8 +3,8 @@ page_title: Data retention policy API
 description: >-
   Learn how to use the `/data-retention-policy` endpoints to configure how long Terraform stores data. You can call the data retention policy APIs to programmatically configure Terraform Enterprise to automatically delete data for different resources after a specific number of days.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,8 +5,8 @@ description: >-
   designate variable values for a no-code module in your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API. Attach and detach OAuth clients to projects.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform run. List, show and override policy checks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/policy-evaluations.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/policy-evaluations.mdx
@@ -6,8 +6,8 @@ description: >-
   list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -7,8 +7,8 @@ description: >-
   projects.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/private-registry/tests.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/private-registry/tests.mdx
@@ -5,8 +5,8 @@ description: >-
   cancel tests using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/admin-access.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   HCP Terraform.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/general.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/resources.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI - Administration - Flexible Deployment Options - Terraform
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backup and Restore - Administration - Flexible Deployment Options - 
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options. 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
@@ -3,8 +3,8 @@ page_title: Access the CLI - Admin CLI - Administration - Flexible Deployment Op
 description: >-
   Learn how to access the command line with Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/admin/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to administer Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/admin/license.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/admin/license.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/admin/upgrade.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/admin/upgrade.mdx
@@ -3,8 +3,8 @@ page_title: Upgrade - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to upgrade Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
@@ -3,8 +3,8 @@ page_title: Reference Architecture - Flexible Deployments Options - Terraform En
 description: >-
   This pages describes the available reference architectures for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.œå
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to get started deploying Terraform Enterprise on Docker Engine or Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/configuration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/custom-image.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/custom-image.mdx
@@ -3,8 +3,8 @@ page_title: Custom Worker Image - Install and Config - Terraform Enterprise
 description: >-
   Use a custom image to add custom tools or logic to your Terraform Enterprise run enviornment.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Docker - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/index.mdx
@@ -3,8 +3,8 @@ page_title: Overview - Installation - Flexible Deployment Options - Terraform En
 description: >-
   Installation guidance for Terraform Enterprise's flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options - Te
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -3,8 +3,8 @@ page_title: Installation on Kubernetes - Flexible Deployment Options - Terraform
 description: >-
   Learn how to install Terraform Enterprise with Flexible Deployment Options on Kubernetes using Helm.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes - Requirements - Flexible Deployment Options - Terraform 
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Flexible Deployment Options - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Podman - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/requirements/index.mdx
@@ -3,8 +3,8 @@ page_title: Shared Requirements - Installation - Flexible Deployment Options - T
 description: >-
   The pages guide you through the shared requirements for all flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of 
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/scaling/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes Scaling - Scaling - Flexible Deployment Options - Terrafo
 description: >-
   Scaling information for Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/flexible-deployments/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of HCP Terraform with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/aws-service-catalog/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/aws-service-catalog/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Service Catalog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/kubernetes/annotations-and-labels.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/kubernetes/annotations-and-labels.mdx
@@ -5,8 +5,8 @@ description: >-
   Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/kubernetes/api-reference.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/kubernetes/api-reference.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Operator for Kubernetes API reference
 description: API reference for the Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/kubernetes/index.mdx
@@ -5,8 +5,8 @@ description: >-
   from the Kubernetes control plane.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
@@ -5,8 +5,8 @@ description: >-
   2.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/kubernetes/setup.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/kubernetes/setup.mdx
@@ -3,8 +3,8 @@ page_title: Set up the Terraform Enterprise Operator for Kubernetes
 description: Install and configure the Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the HCP Terraform run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
@@ -7,8 +7,8 @@ description: >-
   mapping and add more resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
@@ -5,8 +5,8 @@ description: >-
   AWS into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
@@ -5,8 +5,8 @@ description: >-
   Azure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
@@ -5,8 +5,8 @@ description: >-
   Google Cloud Platform into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
@@ -7,8 +7,8 @@ description: >-
   major cloud providers into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
@@ -7,8 +7,8 @@ description: >-
   vSphere into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise and offers two modes of import for Terraform resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration. Prepare modules for no-code provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/projects/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/projects/index.mdx
@@ -5,8 +5,8 @@ description: >-
   across your infrastructure. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/projects/managing.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/projects/managing.mdx
@@ -5,8 +5,8 @@ description: |-
   across your infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/registry/airgapped-providers.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/registry/airgapped-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Host a version of an official HashiCorp Terraform provider in your
   airgapped Terraform Enterprise private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-10-30T14:40:45-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/registry/test.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/registry/test.mdx
@@ -3,8 +3,8 @@ page_title: Testing Private Modules - Private Registry - Terraform Enterprise
 description: Enable automated module testing in the private registry
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202307-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202308-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202308-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202308-1 (725) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202309-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202309-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202309-1 (733) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202310-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202310-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202310-1 (741) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202311-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202311-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202311-1 (742) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202312-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202312-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202312-1 (745) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2024 Releases - Terraform Enterprise
 description: The 2024 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/v202401-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/v202401-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-1 (751) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/v202401-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/v202401-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-2 (755) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/v202402-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/v202402-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202402-1 (759) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/v202402-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/v202402-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202402-2 (760) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/v202404-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/v202404-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202404-1 (763) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/v202404-2.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2024/v202404-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202404-2 (764) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Legacy Deployment (Replicated) - Terraform Enterpri
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch Terraform Enterprise instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Mounted Disk Mode to External Services Mode - Infrast
 description: >-
   Migrating from Mounted Disk Mode to External Services Mode
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/license/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/license/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/index.mdx
@@ -3,8 +3,8 @@ page_title: Legacy Deployment Overview (Replicated) - Terraform Enterprise
 description: >-
   Learn about the history and context of the Terraform Enterprise Replicated deployment option.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/vault.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/monitoring/logging.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/monitoring/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/monitoring/monitoring.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/monitoring/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/docker_engine.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/docker_engine.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/organizations/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/organizations/index.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
@@ -3,8 +3,8 @@ page_title: VCS Status Checks
 description: Learn how VCS status checks work in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Data Center - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-08-28T09:11:58-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   the same workspace.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/deletion.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/deletion.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/opa-versions.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/opa-versions.mdx
@@ -3,8 +3,8 @@ page_title: OPA Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/opa-versions` endpoint to manage available Open Policy Agent (OPA) versions. Learn how to list, show, create, update, and delete OPA versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/sentinel-versions.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/sentinel-versions.mdx
@@ -3,8 +3,8 @@ page_title: Sentinel Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/sentinel-versions` endpoint to manage available Sentinel versions. Learn how to list, show, create, update, and delete Sentinel versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/data-retention-policies.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/data-retention-policies.mdx
@@ -3,8 +3,8 @@ page_title: Data retention policy API
 description: >-
   Learn how to use the `/data-retention-policy` endpoints to configure how long Terraform stores data. You can call the data retention policy APIs to programmatically configure Terraform Enterprise to automatically delete data for different resources after a specific number of days.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,8 +5,8 @@ description: >-
   designate variable values for a no-code module in your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API. Attach and detach OAuth clients to projects.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/policy-checks.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform run. List, show and override policy checks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/policy-evaluations.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/policy-evaluations.mdx
@@ -6,8 +6,8 @@ description: >-
   list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/policy-sets.mdx
@@ -7,8 +7,8 @@ description: >-
   projects.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/private-registry/tests.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/private-registry/tests.mdx
@@ -5,8 +5,8 @@ description: >-
   cancel tests using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/admin-access.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   HCP Terraform.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/general.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable HCP Terraform agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/resources.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/admin/admin-cli/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI - Administration - Flexible Deployment Options - Terraform
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/admin/admin-cli/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backup and Restore - Administration - Flexible Deployment Options - 
 description: >-
   All the documentation in this space relates to the general release of Terraform Enterprise Flexible Deployment Options. 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/admin/admin-cli/cli-access.mdx
@@ -3,8 +3,8 @@ page_title: Access the CLI - Admin CLI - Administration - Flexible Deployment Op
 description: >-
   Learn how to access the command line with Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/admin/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to administer Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/admin/license.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/admin/license.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/admin/upgrade.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/admin/upgrade.mdx
@@ -3,8 +3,8 @@ page_title: Upgrade - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to upgrade Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/architecture/reference/index.mdx
@@ -3,8 +3,8 @@ page_title: Reference Architecture - Flexible Deployments Options - Terraform En
 description: >-
   This pages describes the available reference architectures for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/architecture/system/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.œå
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/architecture/system/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to get started deploying Terraform Enterprise on Docker Engine or Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/configuration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/custom-image.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/custom-image.mdx
@@ -3,8 +3,8 @@ page_title: Custom Worker Image - Install and Config - Terraform Enterprise
 description: >-
   Use a custom image to add custom tools or logic to your Terraform Enterprise run enviornment.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/docker/install.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/docker/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/docker/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Docker - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/index.mdx
@@ -3,8 +3,8 @@ page_title: Overview - Installation - Flexible Deployment Options - Terraform En
 description: >-
   Installation guidance for Terraform Enterprise's flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options - Te
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/kubernetes/install.mdx
@@ -3,8 +3,8 @@ page_title: Installation on Kubernetes - Flexible Deployment Options - Terraform
 description: >-
   Learn how to install Terraform Enterprise with Flexible Deployment Options on Kubernetes using Helm.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/kubernetes/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes - Requirements - Flexible Deployment Options - Terraform 
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Flexible Deployment Options - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/podman/install.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/podman/install.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexible Deployment Options
   with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/podman/requirements.mdx
@@ -3,8 +3,8 @@ page_title: Podman - Requirements - Flexible Deployment Options - Terraform Ente
 description: >-
   Requirements for installing Terraform Enterprise Flexible Deployment Options with Podman.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/requirements/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/requirements/index.mdx
@@ -3,8 +3,8 @@ page_title: Shared Requirements - Installation - Flexible Deployment Options - T
 description: >-
   The pages guide you through the shared requirements for all flexible deployment options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/requirements/network.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of 
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/install/requirements/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/scaling/docker.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/scaling/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/scaling/kubernetes.mdx
@@ -3,8 +3,8 @@ page_title: Kubernetes Scaling - Scaling - Flexible Deployment Options - Terrafo
 description: >-
   Scaling information for Terraform Enterprise Flexible Deployment Options on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/flexible-deployments/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of HCP Terraform with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/aws-service-catalog/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/aws-service-catalog/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Catalog.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/kubernetes/annotations-and-labels.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/kubernetes/annotations-and-labels.mdx
@@ -5,8 +5,8 @@ description: >-
   for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/kubernetes/api-reference.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/kubernetes/api-reference.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Operator for Kubernetes API reference
 description: API reference for the Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/kubernetes/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/kubernetes/index.mdx
@@ -5,8 +5,8 @@ description: >-
   infrastructure directly from the Kubernetes control plane.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Kubernetes Operator v2 Migration Guide
 description: Upgrade the Terraform Kubernetes Operator from version 1 to version 2.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/kubernetes/setup.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/kubernetes/setup.mdx
@@ -3,8 +3,8 @@ page_title: Set up the Terraform Enterprise Operator for Kubernetes
 description: Install and configure the Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/run-tasks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Run tasks allow Terraform Enterprise to execute tasks in external systems at specific points in the Terraform Enterprise run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
@@ -3,8 +3,8 @@ page_title: Administrator Guide - ServiceNow Service Catalog Integration - Terra
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -3,8 +3,8 @@ page_title: Developer Reference - ServiceNow Service Catalog Integration - Terra
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
@@ -5,8 +5,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
@@ -5,8 +5,8 @@ description: |-
   provision infrastructure using ServiceNow and HCP Terraform.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
@@ -7,8 +7,8 @@ description: >-
   mapping and add more resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
@@ -5,8 +5,8 @@ description: >-
   AWS into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
@@ -5,8 +5,8 @@ description: >-
   Azure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
@@ -5,8 +5,8 @@ description: >-
   Google Cloud Platform into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
@@ -7,8 +7,8 @@ description: >-
   major cloud providers into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
@@ -7,8 +7,8 @@ description: >-
   vSphere into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow Service Graph Connector for Terraform integrates with Terraform Enterprise and offers two modes of import for Terraform resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration. Prepare modules for no-code provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/projects/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/projects/index.mdx
@@ -5,8 +5,8 @@ description: >-
   across your infrastructure. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/projects/managing.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/projects/managing.mdx
@@ -5,8 +5,8 @@ description: |-
   across your infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/registry/airgapped-providers.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/registry/airgapped-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Host a version of an official HashiCorp Terraform provider in your
   airgapped Terraform Enterprise private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-10-30T14:40:45-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/registry/test.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/registry/test.mdx
@@ -3,8 +3,8 @@ page_title: Testing Private Modules - Private Registry - Terraform Enterprise
 description: Enable automated module testing in the private registry
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202307-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202308-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202308-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202308-1 (725) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202309-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202309-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202309-1 (733) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202310-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202310-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202310-1 (741) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202311-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202311-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202311-1 (742) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202312-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202312-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202312-1 (745) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2024 Releases - Terraform Enterprise
 description: The 2024 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/v202401-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/v202401-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-1 (751) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/v202401-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/v202401-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-2 (755) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/v202402-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/v202402-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202402-1 (759) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/v202402-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/v202402-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202402-2 (760) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/v202404-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/v202404-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202404-1 (763) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/v202404-2.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2024/v202404-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202404-2 (764) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/index.mdx
@@ -3,8 +3,8 @@ page_title: Administration - Legacy Deployment (Replicated) - Terraform Enterpri
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch Terraform Enterprise instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/mounted-to-external-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Mounted Disk Mode to External Services Mode - Infrast
 description: >-
   Migrating from Mounted Disk Mode to External Services Mode
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/license/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/license/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/license/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/license/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/architecture/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/index.mdx
@@ -3,8 +3,8 @@ page_title: Legacy Deployment Overview (Replicated) - Terraform Enterprise
 description: >-
   Learn about the history and context of the Terraform Enterprise Replicated deployment option.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/operation-modes.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/operation-modes.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/vault.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/monitoring/logging.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/monitoring/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/monitoring/monitoring.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/monitoring/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-12-16T09:03:10-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/docker_engine.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/docker_engine.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/organizations/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/organizations/index.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
@@ -3,8 +3,8 @@ page_title: VCS Status Checks
 description: Learn how VCS status checks work in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Data Center - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-08-28T09:11:58-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   the same workspace.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/deletion.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/deletion.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 


### PR DESCRIPTION
### Description

This PR adds date metadata to the third part the terraform-enterprise documentation. Terraform-enterprise has a lot of files so this needed to be split so the build does not fail. This PR covers versions v202309-1 through v202404-2. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715. Older docs versions have been updated with default dates for the versions specified in [this spreadsheet](https://docs.google.com/spreadsheets/d/16FpDhKA4ZBOVtxHWw2ebMjS56mdSask1FBCVecn9QnQ/edit?gid=0#gid=0)

NOTE: The run link checker action is expected to fail for this PR since there are so many files changed. This action is not blocking merge and can be ignored.

### Testing

Check that terraform-enterprise docs look normal in the preview for versions v202309-1 through v202404-2: https://unified-docs-frontend-preview-gv3pfp80a-hashicorp.vercel.app/terraform/enterprise/v202404-2