### PR TITLE
feat: add date metadata for terraform-enterprise docs part 4

### DIFF
--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/registry-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Registry Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/_template.mdx
@@ -1,8 +1,8 @@
 ---
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/account.mdx
@@ -2,8 +2,8 @@
 page_title: Account - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/agents.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/applies.mdx
@@ -2,8 +2,8 @@
 page_title: Applies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/audit-trails.mdx
@@ -2,8 +2,8 @@
 page_title: Audit Trails - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/changelog.mdx
@@ -3,8 +3,8 @@ page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/comments.mdx
@@ -2,8 +2,8 @@
 page_title: Comments - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -2,8 +2,8 @@
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -2,8 +2,8 @@
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   includes authentication, features, and formatting.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/invoices.mdx
@@ -2,8 +2,8 @@
 page_title: Invoices - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -2,8 +2,8 @@
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tags - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/organizations.mdx
@@ -2,8 +2,8 @@
 page_title: Organizations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -2,8 +2,8 @@
 page_title: Plan Exports - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/plans.mdx
@@ -2,8 +2,8 @@
 page_title: Plans - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/policies.mdx
@@ -2,8 +2,8 @@
 page_title: Policies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Checks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   GPG keys with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -2,8 +2,8 @@
 page_title: Modules - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete public providers with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -2,8 +2,8 @@
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/run.mdx
@@ -2,8 +2,8 @@
 page_title: Runs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -2,8 +2,8 @@
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -2,8 +2,8 @@
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/state-versions.mdx
@@ -2,8 +2,8 @@
 page_title: State Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/team-access.mdx
@@ -2,8 +2,8 @@
 page_title: Team Access - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/team-members.mdx
@@ -2,8 +2,8 @@
 page_title: Team Membership - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Team Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/teams.mdx
@@ -2,8 +2,8 @@
 page_title: Teams - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: User Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/users.mdx
@@ -2,8 +2,8 @@
 page_title: Users - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete variable sets with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/variables.mdx
@@ -2,8 +2,8 @@
 page_title: Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Events - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/workspaces.mdx
@@ -2,8 +2,8 @@
 page_title: Workspaces - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/cost-estimation/aws.mdx
@@ -2,8 +2,8 @@
 page_title: AWS - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/cost-estimation/azure.mdx
@@ -2,8 +2,8 @@
 page_title: Azure - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -2,8 +2,8 @@
 page_title: GCP - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/enforce.mdx
@@ -5,8 +5,8 @@ description: >-
   different types of policy checks fail.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/examples.mdx
@@ -5,8 +5,8 @@ description: >-
   within Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   decisions. Learn how you can use Sentinel with Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/manage-policies.mdx
@@ -5,8 +5,8 @@ description: >-
   and manage versioned policy sets.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/github.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   and better workflows in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -2,8 +2,8 @@
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/naming.mdx
@@ -5,8 +5,8 @@ description: >-
   recommendations for consistent, informative names.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/access.mdx
@@ -2,8 +2,8 @@
 page_title: Managing Access - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -2,8 +2,8 @@
 page_title: Notifications - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/registry-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Registry Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/_template.mdx
@@ -1,8 +1,8 @@
 ---
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/account.mdx
@@ -2,8 +2,8 @@
 page_title: Account - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/agent-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/agents.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/applies.mdx
@@ -2,8 +2,8 @@
 page_title: Applies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/audit-trails.mdx
@@ -2,8 +2,8 @@
 page_title: Audit Trails - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/changelog.mdx
@@ -3,8 +3,8 @@ page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/comments.mdx
@@ -2,8 +2,8 @@
 page_title: Comments - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/configuration-versions.mdx
@@ -2,8 +2,8 @@
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/cost-estimates.mdx
@@ -2,8 +2,8 @@
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   includes authentication, features, and formatting.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/invoices.mdx
@@ -2,8 +2,8 @@
 page_title: Invoices - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/notification-configurations.mdx
@@ -2,8 +2,8 @@
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/oauth-clients.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/organization-memberships.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/organization-tags.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tags - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/organization-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/organizations.mdx
@@ -2,8 +2,8 @@
 page_title: Organizations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/plan-exports.mdx
@@ -2,8 +2,8 @@
 page_title: Plan Exports - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/plans.mdx
@@ -2,8 +2,8 @@
 page_title: Plans - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/policies.mdx
@@ -2,8 +2,8 @@
 page_title: Policies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/policy-checks.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Checks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/policy-set-params.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/policy-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   GPG keys with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -2,8 +2,8 @@
 page_title: Modules - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete public providers with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -2,8 +2,8 @@
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/run.mdx
@@ -2,8 +2,8 @@
 page_title: Runs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/stability-policy.mdx
@@ -2,8 +2,8 @@
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -2,8 +2,8 @@
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/state-versions.mdx
@@ -2,8 +2,8 @@
 page_title: State Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/team-access.mdx
@@ -2,8 +2,8 @@
 page_title: Team Access - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/team-members.mdx
@@ -2,8 +2,8 @@
 page_title: Team Membership - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/team-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Team Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/teams.mdx
@@ -2,8 +2,8 @@
 page_title: Teams - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/user-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: User Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/users.mdx
@@ -2,8 +2,8 @@
 page_title: Users - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/variable-sets.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete variable sets with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/variables.mdx
@@ -2,8 +2,8 @@
 page_title: Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/vcs-events.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Events - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/workspace-resources.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/workspace-variables.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/workspaces.mdx
@@ -2,8 +2,8 @@
 page_title: Workspaces - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/cost-estimation/aws.mdx
@@ -2,8 +2,8 @@
 page_title: AWS - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/cost-estimation/azure.mdx
@@ -2,8 +2,8 @@
 page_title: Azure - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/cost-estimation/gcp.mdx
@@ -2,8 +2,8 @@
 page_title: GCP - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202208-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202208-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202208-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202209-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202209-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202210-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202211-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202212-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2022/v202212-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/enforce.mdx
@@ -5,8 +5,8 @@ description: >-
   different types of policy checks fail.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/examples.mdx
@@ -5,8 +5,8 @@ description: >-
   within Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   decisions. Learn how you can use Sentinel with Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/manage-policies.mdx
@@ -5,8 +5,8 @@ description: >-
   and manage versioned policy sets.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/azure-devops-server.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/azure-devops-services.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/bitbucket-server.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/github-enterprise.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/github.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/gitlab-com.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/gitlab-eece.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   and better workflows in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/vcs/troubleshooting.mdx
@@ -2,8 +2,8 @@
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/naming.mdx
@@ -5,8 +5,8 @@ description: >-
   recommendations for consistent, informative names.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/access.mdx
@@ -2,8 +2,8 @@
 page_title: Managing Access - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/notifications.mdx
@@ -2,8 +2,8 @@
 page_title: Notifications - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/settings/vcs.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/github-app-integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub App Integration - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/registry-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Registry Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/_template.mdx
@@ -1,8 +1,8 @@
 ---
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/account.mdx
@@ -2,8 +2,8 @@
 page_title: Account - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/agents.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/applies.mdx
@@ -2,8 +2,8 @@
 page_title: Applies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/audit-trails.mdx
@@ -2,8 +2,8 @@
 page_title: Audit Trails - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/changelog.mdx
@@ -3,8 +3,8 @@ page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/comments.mdx
@@ -2,8 +2,8 @@
 page_title: Comments - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -2,8 +2,8 @@
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -2,8 +2,8 @@
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   includes authentication, features, and formatting.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/invoices.mdx
@@ -2,8 +2,8 @@
 page_title: Invoices - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -2,8 +2,8 @@
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tags - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/organizations.mdx
@@ -2,8 +2,8 @@
 page_title: Organizations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -2,8 +2,8 @@
 page_title: Plan Exports - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/plans.mdx
@@ -2,8 +2,8 @@
 page_title: Plans - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/policies.mdx
@@ -2,8 +2,8 @@
 page_title: Policies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Checks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   GPG keys with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -2,8 +2,8 @@
 page_title: Modules - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete public providers with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -1,8 +1,8 @@
 ---
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/projects.mdx
@@ -2,8 +2,8 @@
 page_title: Projects - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -2,8 +2,8 @@
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/run.mdx
@@ -2,8 +2,8 @@
 page_title: Runs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -2,8 +2,8 @@
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -2,8 +2,8 @@
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/state-versions.mdx
@@ -2,8 +2,8 @@
 page_title: State Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/team-access.mdx
@@ -2,8 +2,8 @@
 page_title: Team Access - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/team-members.mdx
@@ -2,8 +2,8 @@
 page_title: Team Membership - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Team Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/teams.mdx
@@ -2,8 +2,8 @@
 page_title: Teams - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: User Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/users.mdx
@@ -2,8 +2,8 @@
 page_title: Users - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete variable sets with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/variables.mdx
@@ -2,8 +2,8 @@
 page_title: Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Events - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/workspaces.mdx
@@ -2,8 +2,8 @@
 page_title: Workspaces - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/cost-estimation/aws.mdx
@@ -2,8 +2,8 @@
 page_title: AWS - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/cost-estimation/azure.mdx
@@ -2,8 +2,8 @@
 page_title: Azure - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -2,8 +2,8 @@
 page_title: GCP - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/enforce.mdx
@@ -5,8 +5,8 @@ description: >-
   different types of policy checks fail.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/examples.mdx
@@ -5,8 +5,8 @@ description: >-
   within Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   decisions. Learn how you can use Sentinel with Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/manage-policies.mdx
@@ -5,8 +5,8 @@ description: >-
   and manage versioned policy sets.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/github.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   and better workflows in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -2,8 +2,8 @@
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/access.mdx
@@ -2,8 +2,8 @@
 page_title: Managing Access - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -2,8 +2,8 @@
 page_title: Notifications - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/logging-old.mdx
@@ -3,8 +3,8 @@ page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform 
 description: >-
   Use Terraform Enterprise logs to gain visibility into your installation. Learn how to access and read application and audit logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/audit-trails.mdx
@@ -5,8 +5,8 @@ description: >-
   of an organization's audit events for the past 14 days using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -6,8 +6,8 @@ description: >-
   override policies, and list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   and attach and detach policies from workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/logging-old.mdx
@@ -3,8 +3,8 @@ page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform 
 description: >-
   Use Terraform Enterprise logs to gain visibility into your installation. Learn how to access and read application and audit logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/audit-trails.mdx
@@ -5,8 +5,8 @@ description: >-
   of an organization's audit events for the past 14 days using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -6,8 +6,8 @@ description: >-
   override policies, and list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   and attach and detach policies from workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/logging-old.mdx
@@ -3,8 +3,8 @@ page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform 
 description: >-
   Use Terraform Enterprise logs to gain visibility into your installation. Learn how to access and read application and audit logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/audit-trails.mdx
@@ -5,8 +5,8 @@ description: >-
   of an organization's audit events for the past 14 days using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -6,8 +6,8 @@ description: >-
   override policies, and list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   and attach and detach policies from workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/logging-old.mdx
@@ -3,8 +3,8 @@ page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform 
 description: >-
   Use Terraform Enterprise logs to gain visibility into your installation. Learn how to access and read application and audit logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/audit-trails.mdx
@@ -5,8 +5,8 @@ description: >-
   of an organization's audit events for the past 14 days using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/policy-checks.mdx
@@ -6,8 +6,8 @@ description: >-
   override policies, and list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   and attach and detach policies from workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/data-storage/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/logging-old.mdx
@@ -3,8 +3,8 @@ page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform 
 description: >-
   Use Terraform Enterprise logs to gain visibility into your installation. Learn how to access and read application and audit logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - API Docs - Terraform Cloud
 description: >-
   Use these endpoints to control availability of no-code provisioning and designate variable values for a no-code module in your organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -6,8 +6,8 @@ description: >-
   override policies, and list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   and attach and detach policies from workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/admin-cli.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/backup-restore.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/support.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/support.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to sign up for the private beta release of Terraform Enterprise's Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/configuration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/docker.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexibile Deployment Options (FDO)
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options Beta
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/kubernetes.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/kubernetes.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/migration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/migration.mdx
@@ -4,8 +4,8 @@ description: >-
   How to from Terraform Enterprise Replicated to Terraform Enterprise Flexible
   Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Requirements for installing Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/requirements/kubernetes.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/requirements/kubernetes.mdx
@@ -4,8 +4,8 @@ description: >-
   Requirements for installing Terraform Enterprise Flexibile Deployment Options
   (FDO) on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options Beta - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/scaling.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/scaling.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/requirements/network.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -2,8 +2,8 @@
 page_title: Designing No-Code Ready Modules - No-Code Provisioning - Terraform Cloud
 description: No-code ready modules let users deploy a module's resources without writing configuration. Prepare modules for no-code provisioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -2,8 +2,8 @@
 page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/logging-old.mdx
@@ -3,8 +3,8 @@ page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform 
 description: >-
   Use Terraform Enterprise logs to gain visibility into your installation. Learn how to access and read application and audit logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,8 +5,8 @@ description: >-
   designate variable values for a no-code module in your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -6,8 +6,8 @@ description: >-
   override policies, and list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   and attach and detach policies from workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/admin-cli.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/backup-restore.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/support.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/support.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to sign up for the private beta release of Terraform Enterprise's Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/configuration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/docker.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexibile Deployment Options (FDO)
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options Beta
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/kubernetes.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/kubernetes.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/migration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/migration.mdx
@@ -4,8 +4,8 @@ description: >-
   How to from Terraform Enterprise Replicated to Terraform Enterprise Flexible
   Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Requirements for installing Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/requirements/kubernetes.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/requirements/kubernetes.mdx
@@ -4,8 +4,8 @@ description: >-
   Requirements for installing Terraform Enterprise Flexibile Deployment Options
   (FDO) on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options Beta - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/scaling.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/scaling.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/requirements/network.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration. Prepare modules for no-code provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202307-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/admin-access.mdx
@@ -3,8 +3,8 @@ page_title: Accessing Admin Pages - Application Administration - Terraform Enter
 description: >-
   Use the admin interface for managing general settings, systemwide integration settings, and accounts and resources. Learn how to access the admin section of the Terraform Enterprise UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
@@ -3,8 +3,8 @@ page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/customization.mdx
@@ -3,8 +3,8 @@ page_title: Customization - Application Administration - Terraform Enterprise
 description: >-
   Use customization settings to modify the user interface for your organization's needs. Learn how to change the text shown to users who are new, during login, or when they encounter an expected error.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/general.mdx
@@ -3,8 +3,8 @@ page_title: General Settings - Application Administration - Terraform Enterprise
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, adjust limits and timeouts, enable Terraform Cloud Agents, and control remote state sharing and speculative plans in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/github-app-integration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/github-app-integration.mdx
@@ -3,8 +3,8 @@ page_title: GitHub App Integration - Application Administration - Terraform Ente
 description: >-
   Use GitHub app integration across all organizations of a Terraform Enterprise instance. Learn how to configure and manage GitHub app integration in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/integration.mdx
@@ -3,8 +3,8 @@ page_title: Integrations - Application Administration - Terraform Enterprise
 description: >-
     Use service integrations to send communications and authenticate users. Learn how to configure cost estimate, and SAML, SMTP, and Twilio integrations in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/opa-tool-versions.mdx
@@ -3,8 +3,8 @@ page_title: Managing Open Policy Agent (OPA) Tool Versions - Application Adminis
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Application Administration - Terraform Enterprise
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/resources.mdx
@@ -3,8 +3,8 @@ page_title: Accounts and Resources - Application Administration - Terraform Ente
 description: >-
   Learn how to view, search, and filter accounts or resources, manage users, organizations, workspaces, runs and Terraform versions in the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -3,8 +3,8 @@ page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enter
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch TFE instances using the CLI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -3,8 +3,8 @@ page_title: Automated Recovery - Infrastructure Administration - Terraform Enter
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -3,8 +3,8 @@ page_title: Backups and Restores - Infrastructure Administration - Terraform Ent
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/consolidated-services.mdx
@@ -3,8 +3,8 @@ page_title: Consolidated Services - Infrastructure Administration - Terraform En
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -3,8 +3,8 @@ page_title: Log Forwarding - Infrastructure Administration - Terraform Enterpris
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -3,8 +3,8 @@ page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -3,8 +3,8 @@ page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise can be upgraded when online or airgapped. Learn how to upgrade Terraform Enterprise to a new version.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/worker-to-agent-migration.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/logging-old.mdx
@@ -3,8 +3,8 @@ page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform 
 description: >-
   Use Terraform Enterprise logs to gain visibility into your installation. Learn how to access and read application and audit logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/_template.mdx
@@ -3,8 +3,8 @@ page_title: Something - API Docs - Terraform Enterprise
 description: A meaningful description of this endpoint.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/account.mdx
@@ -5,8 +5,8 @@ description: >-
   update account info, and change the user password with the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/index.mdx
@@ -3,8 +3,8 @@ page_title: Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin` endpoint to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the module sharing endpoint. Learn how to update an organization's module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -3,8 +3,8 @@ page_title: Organizations - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -3,8 +3,8 @@ page_title: Registry Sharing - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -3,8 +3,8 @@ page_title: Runs - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/runs` endpoint to interact with runs. Learn how to list runs, and forcibly cancel runs using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 description: >-
   Use the admin settings endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -3,8 +3,8 @@ page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/users.mdx
@@ -3,8 +3,8 @@ page_title: Users - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -3,8 +3,8 @@ page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 description: >-
   Use the admin `/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   create, and destroy tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/agents.mdx
@@ -5,8 +5,8 @@ description: >-
   and list, show, create, update, and delete agent pools using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/applies.mdx
@@ -5,8 +5,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/changelog.mdx
@@ -4,8 +4,8 @@ page_id: api-changelog
 description: Learn about the changes made to the Terraform Enterprise and Enterprise APIs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/comments.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and create comments using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -6,8 +6,8 @@ description: >-
   using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -5,8 +5,8 @@ description: >-
   estimate by ID using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/github-app-installations.mdx
@@ -6,8 +6,8 @@ description: >-
   installation using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   limiting, and clients.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/invoices.mdx
@@ -5,8 +5,8 @@ description: >-
   previous invoices and get the next invoice using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,8 +5,8 @@ description: >-
   designate variable values for a no-code module in your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -6,8 +6,8 @@ description: >-
   configurations for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -6,8 +6,8 @@ description: >-
   clients using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -6,8 +6,8 @@ description: >-
   HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -5,8 +5,8 @@ description: >-
   list, and delete tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens. Generate and delete organization tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/organizations.mdx
@@ -6,8 +6,8 @@ description: >-
   update, and destroy organizations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -6,8 +6,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/plans.mdx
@@ -5,8 +5,8 @@ description: >-
   the JSON-formatted execution plan using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   create, upload, update, and delete policies using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -6,8 +6,8 @@ description: >-
   override policies, and list policy evaluations using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,8 +5,8 @@ description: >-
   policy checks. List, create, update, and delete parameters using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   and attach and detach policies from workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   providers. List, add, get, update, and delete GPG keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   modules and versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -6,8 +6,8 @@ description: >-
   platforms using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   registry. List, create, get, and delete providers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   show, add, update, and remove team access from a project using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/projects.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete projects using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -5,8 +5,8 @@ description: >-
   show, and override task stages, and show run task results using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -5,8 +5,8 @@ description: >-
   about the run task request and callback formats.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -6,8 +6,8 @@ description: >-
   tasks using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete run triggers using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/run.mdx
@@ -5,8 +5,8 @@ description: >-
   discard, execute, and cancel runs using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   create, update, and delete SSH keys using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -5,8 +5,8 @@ description: >-
   deprecation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -6,8 +6,8 @@ description: >-
   state version outputs for a workspace using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/state-versions.mdx
@@ -5,8 +5,8 @@ description: >-
   create, show, and roll back state versions using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/team-access.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, add, update, and remove team access using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/team-members.mdx
@@ -5,8 +5,8 @@ description: >-
   from a team using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   and delete team API tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   delete teams using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   List, show, create, and destroy user tokens using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/users.mdx
@@ -5,8 +5,8 @@ description: >-
   the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   workspaces using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/variables.mdx
@@ -5,8 +5,8 @@ description: >-
   update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -5,8 +5,8 @@ description: >-
   within your organization using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -5,8 +5,8 @@ description: >-
   List resources using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   List, create, update, and delete variables using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/api-docs/workspaces.mdx
@@ -6,8 +6,8 @@ description: >-
   remote state consumers, and tags using the HTTP API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/cost-estimation/aws.mdx
@@ -3,8 +3,8 @@ page_title: AWS - Cost Estimation - Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/cost-estimation/azure.mdx
@@ -3,8 +3,8 @@ page_title: Azure - Cost Estimation - Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -3,8 +3,8 @@ page_title: GCP - Cost Estimation - Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation..
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource, and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-06-19T16:32:56-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/admin-cli.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/backup-restore.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/support.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/support.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/index.mdx
@@ -3,8 +3,8 @@ page_title: Flexible Deployment Options - Terraform Enterprise
 description: >-
   Learn how to sign up for the private beta release of Terraform Enterprise's Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/configuration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration Reference - Installation - Flexible Deployment Options
 description: >-
   The configuration reference for Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/docker.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform Enterprise Flexibile Deployment Options (FDO)
   on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/initial-admin-user.mdx
@@ -3,8 +3,8 @@ page_title: Initial Admin User - Installation - Flexible Deployment Options Beta
 description: >-
   How to create the initial admin user in Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/kubernetes.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/kubernetes.mdx
@@ -4,8 +4,8 @@ description: >-
   All the documentation in this space relates to the private beta release of Terraform Enterprise Flexible Deployment Options. If you would
   like access to the Beta release, please contact your HashiCorp account team.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Requirements for installing Terraform Enterprise Flexibile Deployment Options
   (FDO) on Docker.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/requirements/kubernetes.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/requirements/kubernetes.mdx
@@ -4,8 +4,8 @@ description: >-
   Requirements for installing Terraform Enterprise Flexibile Deployment Options
   (FDO) on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/requirements/license.mdx
@@ -3,8 +3,8 @@ page_title: License - Flexible Deployment Options Beta - Terraform Enterprise
 description: >-
   Terraform Enterprise with Flexible Deployment Options requires a HashiCorp-issued license.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/scaling.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/scaling.mdx
@@ -4,8 +4,8 @@ description: >-
   Scaling information for Terraform Enterprise Flexibile Deployment Options
   (FDO) on Kubernetes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/logs.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how Terraform Enterprise emits logs and what your options are for
   forwarding those logs to another system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/metrics.mdx
@@ -3,8 +3,8 @@ page_title: Metrics - Monitoring - Flexible Deployment Options - Terraform Enter
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/monitoring/startup-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/replicated-migration.mdx
@@ -3,8 +3,8 @@ page_title: Migrating from Replicated - Installation - Flexible Deployment Optio
 description: >-
   Migrate from Terraform Enterprise Replicated to Terraform Enterprise Flexible Deployment Options.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/requirements/network.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - Monitoring - Flexible Deployment Options - Terrafo
 description: >-
   Guide to troubleshooting Terraform Enterprise installations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/install/automated/active-active.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -3,8 +3,8 @@ page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -3,8 +3,8 @@ page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -3,8 +3,8 @@ page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/install/interactive/config.mdx
@@ -3,8 +3,8 @@ page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/install/interactive/installer.mdx
@@ -3,8 +3,8 @@ page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
@@ -4,8 +4,8 @@ description: >-
   Upgrade the Terraform Cloud Kubernetes Operator from version 1 to version 2.
 tfc_only: false
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-catalog-terraform/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
@@ -7,8 +7,8 @@ description: >-
   mapping and add more resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
@@ -5,8 +5,8 @@ description: >-
   AWS into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
@@ -5,8 +5,8 @@ description: >-
   Azure into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
@@ -5,8 +5,8 @@ description: >-
   Google Cloud Platform into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
@@ -7,8 +7,8 @@ description: >-
   major cloud providers into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
@@ -7,8 +7,8 @@ description: >-
   vSphere into ServiceNow CMDB.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise and offers two modes of import for Terraform resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration. Prepare modules for no-code provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -3,8 +3,8 @@ page_title: No-Code Provisioning - Provisioning No-Code Infrastructure
 description: How to provision infrastructure from a no-code ready module.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Sentinel and OPA to validate plans before Terraform provisions infrastructure.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/manage-policy-sets.mdx
@@ -6,8 +6,8 @@ description: >-
   against the policy set for each run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/opa/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/opa/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/opa/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise. A policy set repository has a configuration file and policy files.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/policy-results.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/policy-results.mdx
@@ -5,8 +5,8 @@ description: >-
   policy results, and how to override failed policies.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/policy-enforcement/sentinel/vcs.mdx
@@ -6,8 +6,8 @@ description: >-
   and module files. 
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202301-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202301-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202303-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202304-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202305-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202305-2.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202306-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202307-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202308-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202308-1.mdx
@@ -3,8 +3,8 @@ page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202308-1 (725) release.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -3,8 +3,8 @@ page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -3,8 +3,8 @@ page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -3,8 +3,8 @@ page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -3,8 +3,8 @@ page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -3,8 +3,8 @@ page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -3,8 +3,8 @@ page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -3,8 +3,8 @@ page_title: ADFS Configuration - Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services as the identify provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -3,8 +3,8 @@ page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -3,8 +3,8 @@ page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/system-overview/index.mdx
@@ -3,8 +3,8 @@ page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -5,8 +5,8 @@ description: >-
   VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -3,8 +3,8 @@ page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 description: Learn how to use Azure DevOps Services (dev.azure.com) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 description: Learn how to use Bitbucket Cloud for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -3,8 +3,8 @@ page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterpr
 description: Learn how to use Bitbucket Server and Data Center for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -5,8 +5,8 @@ description: >-
   features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/github.mdx
@@ -5,8 +5,8 @@ description: >-
   connection with the permissions of an individual GitHub user.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -3,8 +3,8 @@ page_title: GitLab.com - VCS Providers - Terraform Enterprise
 description: Learn how to use GitLab.com for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,8 +5,8 @@ description: >-
   GitLab Community Edition (CE) for VCS features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/index.mdx
@@ -6,8 +6,8 @@ description: >-
   additional features.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -3,8 +3,8 @@ page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 description: Learn how to address common problems in VCS integrations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -5,8 +5,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,8 +6,8 @@ description: >-
   the Vault, AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -7,8 +7,8 @@ description: >-
   Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   the same workspace.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Vault-backed dynamic credentials for the AWS, Azure, and GCP providers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -7,8 +7,8 @@ description: >-
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   applies to safely authenticate to external systems.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/health.mdx
@@ -6,8 +6,8 @@ description: >-
   configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/organize-workspaces-with-projects.mdx
@@ -5,8 +5,8 @@ description: >-
   workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/access.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -5,8 +5,8 @@ description: >-
   other events. Create and enable workspace notifications.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -5,8 +5,8 @@ description: >-
   delete run tasks and associate them with workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -5,8 +5,8 @@ description: >-
   View, create, and manage run triggers.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   private Git repositories. Add and delete keys, and assign keys to workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,8 +5,8 @@ description: >-
   repository that contains Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 


### PR DESCRIPTION
### Description

This PR adds date metadata to the fourth part the terraform-enterprise documentation. Terraform-enterprise has a lot of files so this needed to be split so the build does not fail. This PR covers versions v202301-1 through v202308-1. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715. Older docs versions have been updated with default dates for the versions specified in [this spreadsheet](https://docs.google.com/spreadsheets/d/16FpDhKA4ZBOVtxHWw2ebMjS56mdSask1FBCVecn9QnQ/edit?gid=0#gid=0)

NOTE: The run link checker action is expected to fail for this PR since there are so many files changed. This action is not blocking merge and can be ignored.

### Testing

Check that terraform-enterprise docs look normal in the preview for versions v202301-1 through v202308-1: https://unified-docs-frontend-preview-gljm08h1y-hashicorp.vercel.app/terraform/enterprise/v202308-1