### PR TITLE
feat: add date metadata for terraform-enterprise docs part 5

### DIFF
--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/module-sharing.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/account.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Account - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/agents.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/applies.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Applies - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/audit-trails.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Audit Trails - API Docs - Terraform Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/changelog.mdx
@@ -2,8 +2,8 @@
 page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/comments.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Comments - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/feature-sets.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/feature-sets.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Feature Sets - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Use the API to manage runs, workspaces, policies, and more. This introduction
   includes authentication, features, and formatting.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/invoices.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Invoices - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Tags - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Plan Exports - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/plans.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Plans - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/policies.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policies - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Checks - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Sets - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -4,8 +4,8 @@ description: >-
   GPG signing is required for custom providers. Create, read, update, and delete
   GPG keys with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Modules - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -4,8 +4,8 @@ description: >-
   Create, read, update, and delete provider versions and platforms with the
   Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -4,8 +4,8 @@ description: >-
   You can add public providers to your organization's private registry. Create,
   read, update, and delete public providers with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Triggers - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/run.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SSH Keys - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/state-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: State Versions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/subscriptions.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/subscriptions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Subscriptions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/team-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Access - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/team-members.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Membership - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/teams.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Teams - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: User Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -4,8 +4,8 @@ description: >-
   Variable sets allow you to reuse variables across multiple workspaces. Create,
   read, update, and delete variable sets with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/variables.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Variables - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: VCS Events - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/api-docs/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/cost-estimation/aws.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: AWS - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/cost-estimation/azure.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GCP - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/cost-estimation/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Cloud displays hourly and monthly cost estimates for each resource
   and the total cost and delta of all resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Run tasks allow Terraform Cloud to execute tasks in external systems at
   specific points in the Terraform Cloud run lifecycle.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Developer reference for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Example customizations for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/service-now/index.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow integration enables your users to order Terraform-built
   infrastructure from ServiceNow.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -6,8 +6,8 @@ description: |-
   Configure Service Catalogs and VCS repositories to allow end users to
   provision infrastructure using ServiceNow and Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow integration to enable your users to order Terraform-built
   infrastructure from ServiceNow
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/migrate/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Migrate state to Terraform Cloud to continue managing existing infrastructure
   without de-provisioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/registry/add.mdx
@@ -4,8 +4,8 @@ description: >-
   Add providers and modules from the public Terraform Registry to your
   organization's private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/registry/design.mdx
@@ -4,8 +4,8 @@ description: >-
   The configuration designer lets you outline a configuration with private
   modules and helps you quickly define variables.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/registry/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Use the Terraform Cloud private registry to share Terraform providers and
   modules across your organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/registry/publish-modules.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to prepare private modules for publishing, add them to the registry, and
   release new versions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/registry/publish-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Prepare private providers for publishing, add them to the private registry,
   and release new versions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/registry/using.mdx
@@ -2,8 +2,8 @@
 page_title: Using Providers and Modules - Private Module Registry - Terraform Enterprise
 description: Find available providers and modules and include them in configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/run/api.mdx
@@ -4,8 +4,8 @@ description: >-
   External tools communicate with Terraform Cloud to upload configurations and
   trigger runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/run/cli.mdx
@@ -4,8 +4,8 @@ description: >-
   Trigger runs from your terminal using the Terraform CLI. Learn the required
   configuration for remote CLI runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/run/install-software.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform providers and additional software on Terraform
   Cloud workers, including cloud CLIs or configuration management tools.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/run/manage.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces list current, pending, and historical runs. Learn to view run
   information and lock workspaces to prevent new runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/run/modes-and-options.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the effect of the Destroy and Refresh-Only modes as well as options to
   customize behavior during runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/run/remote-operations.mdx
@@ -4,8 +4,8 @@ description: >-
   Run Terraform remotely through the UI, API, or CLI. Learn how Terraform Cloud
   manages runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/run/run-environment.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about worker virtual machines, network access, concurrency for run
   queueing, state access authentication, and environment variables.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/run/states.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn what happens during each stage of a run: pending, plan, cost estimation,
   policy check, apply, and complete.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/run/ui.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces are associated with a VCS repository branch, and Terraform Cloud
   automatically queues runs when new commits are merged.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/enforce.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn when Terraform Cloud performs policy checks and what happens when
   different types of policy checks fail.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/examples.mdx
@@ -4,8 +4,8 @@ description: >-
   Review policy examples that demonstrate some of the most common use cases
   within Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to use Sentinel policy language to create policies, including
   imports to define rules, useful functions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -2,8 +2,8 @@
 page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfplan.mdx
@@ -6,8 +6,8 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfrun.mdx
@@ -2,8 +2,8 @@
 page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/import/tfstate.mdx
@@ -2,8 +2,8 @@
 page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Sentinel is a policy-as-code framework that enables logic-based policy
   decisions. Learn how you can use Sentinel with Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/json.mdx
@@ -2,8 +2,8 @@
 page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/manage-policies.mdx
@@ -4,8 +4,8 @@ description: >-
   Policies are rules that are enforced on Terraform runs. Learn how to create
   and manage versioned policy sets.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/mock.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to use the UI or API to generate mock Sentinel data and how to use
   that data for testing.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -2,8 +2,8 @@
 page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/system-overview/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up and require two-factor authentication. Also learn how to
   log in with two-factor authentication.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the level of access granted by user, team, and organization API
   tokens.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -4,8 +4,8 @@ description: >-
   Organizations allow teams to collaborate on workspaces. Learn about
   organization membership, organization settings, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the difference between workspace-level and organization-level
   permissions and what permissions you can grant to users.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -4,8 +4,8 @@ description: >-
   Teams are a group of users within an organization. Learn about managing teams,
   team membership, team permissions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -4,8 +4,8 @@ description: >-
   Create an account, edit settings, set up two-factor authentication, create API
   tokens, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/github.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to connect a version control system (VCS) to gain additional features
   and better workflows in Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/configurations.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure. Learn how to provide configuration
   versions for a workspace and organize multiple environments.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/creating.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure into meaningful groups. Learn how to create
   and configure workspaces through the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces enable Terraform Cloud to manage collections of infrastructure
   resources. Learn basics and recommended organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -2,8 +2,8 @@
 page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/naming.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure into meaningful groups. Learn our
   recommendations for consistent, informative names.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Managing Access - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure. Find documentation about workspace
   settings for notifications, permissions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Notifications - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/state.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces have their own separate state data. Learn how state is used and how
   to access state from other workspaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/variables/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Cloud workspace variables let you customize configurations, modify
   Terraform's behavior, and store information like provider credentials.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure Terraform input variables and environment variables and create
   reusable variable sets that apply to multiple workspaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/module-sharing.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/account.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Account - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/agents.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/applies.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Applies - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -4,8 +4,8 @@ description: >-
   Assessment results contain information about continuous validation in
   Terraform Cloud, like drift detection.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/audit-trails.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Audit Trails - API Docs - Terraform Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/changelog.mdx
@@ -2,8 +2,8 @@
 page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/comments.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Comments - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/feature-sets.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/feature-sets.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Feature Sets - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Use the API to manage runs, workspaces, policies, and more. This introduction
   includes authentication, features, and formatting.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/invoices.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Invoices - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Tags - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Plan Exports - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/plans.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Plans - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/policies.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policies - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Checks - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Sets - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -4,8 +4,8 @@ description: >-
   GPG signing is required for custom providers. Create, read, update, and delete
   GPG keys with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Modules - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -4,8 +4,8 @@ description: >-
   Create, read, update, and delete provider versions and platforms with the
   Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -4,8 +4,8 @@ description: >-
   You can add public providers to your organization's private registry. Create,
   read, update, and delete public providers with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Triggers - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/run.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SSH Keys - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/state-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: State Versions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/subscriptions.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/subscriptions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Subscriptions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/team-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Access - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/team-members.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Membership - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/teams.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Teams - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: User Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -4,8 +4,8 @@ description: >-
   Variable sets allow you to reuse variables across multiple workspaces. Create,
   read, update, and delete variable sets with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/variables.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Variables - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: VCS Events - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/api-docs/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/cost-estimation/aws.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: AWS - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/cost-estimation/azure.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GCP - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/cost-estimation/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Cloud displays hourly and monthly cost estimates for each resource
   and the total cost and delta of all resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Run tasks allow Terraform Cloud to execute tasks in external systems at
   specific points in the Terraform Cloud run lifecycle.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Developer reference for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Example customizations for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/service-now/index.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow integration enables your users to order Terraform-built
   infrastructure from ServiceNow.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -6,8 +6,8 @@ description: |-
   Configure Service Catalogs and VCS repositories to allow end users to
   provision infrastructure using ServiceNow and Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow integration to enable your users to order Terraform-built
   infrastructure from ServiceNow
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/migrate/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Migrate state to Terraform Cloud or Terraform Enterprise to continue managing
   existing infrastructure without de-provisioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/registry/add.mdx
@@ -4,8 +4,8 @@ description: >-
   Add providers and modules from the public Terraform Registry to your
   organization's private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/registry/design.mdx
@@ -4,8 +4,8 @@ description: >-
   The configuration designer lets you outline a configuration with private
   modules and helps you quickly define variables.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/registry/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Use the Terraform Cloud private registry to share Terraform providers and
   modules across your organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/registry/publish-modules.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to prepare private modules for publishing, add them to the registry, and
   release new versions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/registry/publish-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Prepare private providers for publishing, add them to the private registry,
   and release new versions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/registry/using.mdx
@@ -2,8 +2,8 @@
 page_title: Using Providers and Modules - Private Module Registry - Terraform Enterprise
 description: Find available providers and modules and include them in configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/run/api.mdx
@@ -4,8 +4,8 @@ description: >-
   External tools communicate with Terraform Cloud to upload configurations and
   trigger runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/run/cli.mdx
@@ -4,8 +4,8 @@ description: >-
   Trigger runs from your terminal using the Terraform CLI. Learn the required
   configuration for remote CLI runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/run/install-software.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform providers and additional software on Terraform
   Cloud workers, including cloud CLIs or configuration management tools.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/run/manage.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces list current, pending, and historical runs. Learn to view run
   information and lock workspaces to prevent new runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/run/modes-and-options.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the effect of the Destroy and Refresh-Only modes as well as options to
   customize behavior during runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/run/remote-operations.mdx
@@ -4,8 +4,8 @@ description: >-
   Run Terraform remotely through the UI, API, or CLI. Learn how Terraform Cloud
   manages runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/run/run-environment.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about worker virtual machines, network access, concurrency for run
   queueing, state access authentication, and environment variables.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/run/states.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn what happens during each stage of a run: pending, plan, cost estimation,
   policy check, apply, and complete.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/run/ui.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces are associated with a VCS repository branch, and Terraform Cloud
   automatically queues runs when new commits are merged.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/enforce.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn when Terraform Cloud performs policy checks and what happens when
   different types of policy checks fail.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/examples.mdx
@@ -4,8 +4,8 @@ description: >-
   Review policy examples that demonstrate some of the most common use cases
   within Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to use Sentinel policy language to create policies, including
   imports to define rules, useful functions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -2,8 +2,8 @@
 page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfplan.mdx
@@ -6,8 +6,8 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfrun.mdx
@@ -2,8 +2,8 @@
 page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/import/tfstate.mdx
@@ -2,8 +2,8 @@
 page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Sentinel is a policy-as-code framework that enables logic-based policy
   decisions. Learn how you can use Sentinel with Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/json.mdx
@@ -2,8 +2,8 @@
 page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/manage-policies.mdx
@@ -4,8 +4,8 @@ description: >-
   Policies are rules that are enforced on Terraform runs. Learn how to create
   and manage versioned policy sets.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/mock.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to use the UI or API to generate mock Sentinel data and how to use
   that data for testing.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -2,8 +2,8 @@
 page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/system-overview/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up and require two-factor authentication. Also learn how to
   log in with two-factor authentication.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the level of access granted by user, team, and organization API
   tokens.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -4,8 +4,8 @@ description: >-
   Organizations allow teams to collaborate on workspaces. Learn about
   organization membership, organization settings, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the difference between workspace-level and organization-level
   permissions and what permissions you can grant to users.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -4,8 +4,8 @@ description: >-
   Teams are a group of users within an organization. Learn about managing teams,
   team membership, team permissions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -4,8 +4,8 @@ description: >-
   Create an account, edit settings, set up two-factor authentication, create API
   tokens, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/github.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to connect a version control system (VCS) to gain additional features
   and better workflows in Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/configurations.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure. Learn how to provide configuration
   versions for a workspace and organize multiple environments.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/creating.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure into meaningful groups. Learn how to create
   and configure workspaces through the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces enable Terraform Cloud to manage collections of infrastructure
   resources. Learn basics and recommended organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -2,8 +2,8 @@
 page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/naming.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure into meaningful groups. Learn our
   recommendations for consistent, informative names.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Managing Access - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure. Find documentation about workspace
   settings for notifications, permissions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Notifications - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/state.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces have their own separate state data. Learn how state is used and how
   to access state from other workspaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/variables/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Cloud workspace variables let you customize configurations, modify
   Terraform's behavior, and store information like provider credentials.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure Terraform input variables and environment variables and create
   reusable variable sets that apply to multiple workspaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/module-sharing.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/account.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Account - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/agent-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/agents.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/applies.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Applies - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/assessment-results.mdx
@@ -4,8 +4,8 @@ description: >-
   Assessment results contain information about continuous validation in
   Terraform Cloud, like drift detection.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/audit-trails.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Audit Trails - API Docs - Terraform Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/changelog.mdx
@@ -2,8 +2,8 @@
 page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/comments.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Comments - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/configuration-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/cost-estimates.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/feature-sets.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/feature-sets.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Feature Sets - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Use the API to manage runs, workspaces, policies, and more. This introduction
   includes authentication, features, and formatting.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/invoices.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Invoices - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/notification-configurations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/oauth-clients.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/organization-memberships.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/organization-tags.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Tags - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/organization-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/plan-exports.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Plan Exports - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/plans.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Plans - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/policies.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policies - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/policy-checks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Checks - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/policy-set-params.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/policy-sets.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Sets - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -4,8 +4,8 @@ description: >-
   GPG signing is required for custom providers. Create, read, update, and delete
   GPG keys with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Modules - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -4,8 +4,8 @@ description: >-
   Create, read, update, and delete provider versions and platforms with the
   Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -4,8 +4,8 @@ description: >-
   You can add public providers to your organization's private registry. Create,
   read, update, and delete public providers with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/run-triggers.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Triggers - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/run.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/ssh-keys.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SSH Keys - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/stability-policy.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/state-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: State Versions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/subscriptions.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/subscriptions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Subscriptions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/team-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Access - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/team-members.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Membership - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/team-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/teams.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Teams - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/user-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: User Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/variable-sets.mdx
@@ -4,8 +4,8 @@ description: >-
   Variable sets allow you to reuse variables across multiple workspaces. Create,
   read, update, and delete variable sets with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/variables.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Variables - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/vcs-events.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: VCS Events - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/workspace-resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/workspace-variables.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/api-docs/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/cost-estimation/aws.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: AWS - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/cost-estimation/azure.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/cost-estimation/gcp.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GCP - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/cost-estimation/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Cloud displays hourly and monthly cost estimates for each resource
   and the total cost and delta of all resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/run-tasks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Run tasks allow Terraform Cloud to execute tasks in external systems at
   specific points in the Terraform Cloud run lifecycle.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Developer reference for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Example customizations for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/service-now/index.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow integration enables your users to order Terraform-built
   infrastructure from ServiceNow.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -6,8 +6,8 @@ description: |-
   Configure Service Catalogs and VCS repositories to allow end users to
   provision infrastructure using ServiceNow and Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow integration to enable your users to order Terraform-built
   infrastructure from ServiceNow
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/migrate/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Migrate state to Terraform Cloud or Terraform Enterprise to continue managing
   existing infrastructure without de-provisioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/registry/add.mdx
@@ -4,8 +4,8 @@ description: >-
   Add providers and modules from the public Terraform Registry to your
   organization's private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/registry/design.mdx
@@ -4,8 +4,8 @@ description: >-
   The configuration designer lets you outline a configuration with private
   modules and helps you quickly define variables.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/registry/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Use the Terraform Cloud private registry to share Terraform providers and
   modules across your organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/registry/publish-modules.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to prepare private modules for publishing, add them to the registry, and
   release new versions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/registry/publish-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Prepare private providers for publishing, add them to the private registry,
   and release new versions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/registry/using.mdx
@@ -2,8 +2,8 @@
 page_title: Using Providers and Modules - Private Module Registry - Terraform Enterprise
 description: Find available providers and modules and include them in configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/run/api.mdx
@@ -4,8 +4,8 @@ description: >-
   External tools communicate with Terraform Cloud to upload configurations and
   trigger runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/run/cli.mdx
@@ -4,8 +4,8 @@ description: >-
   Trigger runs from your terminal using the Terraform CLI. Learn the required
   configuration for remote CLI runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/run/install-software.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform providers and additional software on Terraform
   Cloud workers, including cloud CLIs or configuration management tools.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/run/manage.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces list current, pending, and historical runs. Learn to view run
   information and lock workspaces to prevent new runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/run/modes-and-options.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the effect of the Destroy and Refresh-Only modes as well as options to
   customize behavior during runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/run/remote-operations.mdx
@@ -4,8 +4,8 @@ description: >-
   Run Terraform remotely through the UI, API, or CLI. Learn how Terraform Cloud
   manages runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/run/run-environment.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about worker virtual machines, network access, concurrency for run
   queueing, state access authentication, and environment variables.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/run/states.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn what happens during each stage of a run: pending, plan, cost estimation,
   policy check, apply, and complete.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/run/ui.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces are associated with a VCS repository branch, and Terraform Cloud
   automatically queues runs when new commits are merged.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/enforce.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn when Terraform Cloud performs policy checks and what happens when
   different types of policy checks fail.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/examples.mdx
@@ -4,8 +4,8 @@ description: >-
   Review policy examples that demonstrate some of the most common use cases
   within Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to use Sentinel policy language to create policies, including
   imports to define rules, useful functions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -2,8 +2,8 @@
 page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfplan.mdx
@@ -6,8 +6,8 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfrun.mdx
@@ -2,8 +2,8 @@
 page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/import/tfstate.mdx
@@ -2,8 +2,8 @@
 page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Sentinel is a policy-as-code framework that enables logic-based policy
   decisions. Learn how you can use Sentinel with Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/json.mdx
@@ -2,8 +2,8 @@
 page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/manage-policies.mdx
@@ -4,8 +4,8 @@ description: >-
   Policies are rules that are enforced on Terraform runs. Learn how to create
   and manage versioned policy sets.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/mock.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to use the UI or API to generate mock Sentinel data and how to use
   that data for testing.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -2,8 +2,8 @@
 page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/system-overview/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up and require two-factor authentication. Also learn how to
   log in with two-factor authentication.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the level of access granted by user, team, and organization API
   tokens.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -4,8 +4,8 @@ description: >-
   Organizations allow teams to collaborate on workspaces. Learn about
   organization membership, organization settings, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the difference between workspace-level and organization-level
   permissions and what permissions you can grant to users.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/users-teams-organizations/teams.mdx
@@ -4,8 +4,8 @@ description: >-
   Teams are a group of users within an organization. Learn about managing teams,
   team membership, team permissions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/users-teams-organizations/users.mdx
@@ -4,8 +4,8 @@ description: >-
   Create an account, edit settings, set up two-factor authentication, create API
   tokens, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/azure-devops-server.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/azure-devops-services.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/bitbucket-server.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/github-enterprise.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/github.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/gitlab-com.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/gitlab-eece.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to connect a version control system (VCS) to gain additional features
   and better workflows in Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/vcs/troubleshooting.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/configurations.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure. Learn how to provide configuration
   versions for a workspace and organize multiple environments.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/creating.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure into meaningful groups. Learn how to create
   and configure workspaces through the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces enable Terraform Cloud to manage collections of infrastructure
   resources. Learn basics and recommended organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/json-filtering.mdx
@@ -2,8 +2,8 @@
 page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/naming.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure into meaningful groups. Learn our
   recommendations for consistent, informative names.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Managing Access - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure. Find documentation about workspace
   settings for notifications, permissions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/notifications.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Notifications - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/settings/vcs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/state.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces have their own separate state data. Learn how state is used and how
   to access state from other workspaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/variables/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Cloud workspace variables let you customize configurations, modify
   Terraform's behavior, and store information like provider credentials.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure Terraform input variables and environment variables and create
   reusable variable sets that apply to multiple workspaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/module-sharing.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/account.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Account - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/agents.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/applies.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Applies - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/assessment-results.mdx
@@ -4,8 +4,8 @@ description: >-
   Assessment results contain information about continuous validation in
   Terraform Cloud, like drift detection.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/audit-trails.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Audit Trails - API Docs - Terraform Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/changelog.mdx
@@ -2,8 +2,8 @@
 page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/comments.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Comments - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/feature-sets.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/feature-sets.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Feature Sets - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Use the API to manage runs, workspaces, policies, and more. This introduction
   includes authentication, features, and formatting.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/invoices.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Invoices - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Tags - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Plan Exports - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/plans.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Plans - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/policies.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policies - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Checks - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Sets - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -4,8 +4,8 @@ description: >-
   GPG signing is required for custom providers. Create, read, update, and delete
   GPG keys with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Modules - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -4,8 +4,8 @@ description: >-
   Create, read, update, and delete provider versions and platforms with the
   Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -4,8 +4,8 @@ description: >-
   You can add public providers to your organization's private registry. Create,
   read, update, and delete public providers with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Triggers - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/run.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SSH Keys - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/state-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: State Versions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/subscriptions.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/subscriptions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Subscriptions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/team-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Access - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/team-members.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Membership - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/teams.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Teams - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: User Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -4,8 +4,8 @@ description: >-
   Variable sets allow you to reuse variables across multiple workspaces. Create,
   read, update, and delete variable sets with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/variables.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Variables - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: VCS Events - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/api-docs/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/cost-estimation/aws.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: AWS - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/cost-estimation/azure.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GCP - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/cost-estimation/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Cloud displays hourly and monthly cost estimates for each resource
   and the total cost and delta of all resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Run tasks allow Terraform Cloud to execute tasks in external systems at
   specific points in the Terraform Cloud run lifecycle.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Developer reference for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Example customizations for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/service-now/index.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow integration enables your users to order Terraform-built
   infrastructure from ServiceNow.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -6,8 +6,8 @@ description: |-
   Configure Service Catalogs and VCS repositories to allow end users to
   provision infrastructure using ServiceNow and Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow integration to enable your users to order Terraform-built
   infrastructure from ServiceNow
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/migrate/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Migrate state to Terraform Cloud or Terraform Enterprise to continue managing
   existing infrastructure without de-provisioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/registry/add.mdx
@@ -4,8 +4,8 @@ description: >-
   Add providers and modules from the public Terraform Registry to your
   organization's private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/registry/design.mdx
@@ -4,8 +4,8 @@ description: >-
   The configuration designer lets you outline a configuration with private
   modules and helps you quickly define variables.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/registry/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Use the Terraform Cloud private registry to share Terraform providers and
   modules across your organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/registry/publish-modules.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to prepare private modules for publishing, add them to the registry, and
   release new versions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/registry/publish-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Prepare private providers for publishing, add them to the private registry,
   and release new versions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/registry/using.mdx
@@ -2,8 +2,8 @@
 page_title: Using Providers and Modules - Private Module Registry - Terraform Enterprise
 description: Find available providers and modules and include them in configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/run/api.mdx
@@ -4,8 +4,8 @@ description: >-
   External tools communicate with Terraform Cloud to upload configurations and
   trigger runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/run/cli.mdx
@@ -4,8 +4,8 @@ description: >-
   Trigger runs from your terminal using the Terraform CLI. Learn the required
   configuration for remote CLI runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/run/install-software.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform providers and additional software on Terraform
   Cloud workers, including cloud CLIs or configuration management tools.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/run/manage.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces list current, pending, and historical runs. View run information
   and lock workspaces to prevent new runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/run/modes-and-options.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the effect of the Destroy and Refresh-Only modes as well as options to
   customize behavior during runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/run/remote-operations.mdx
@@ -4,8 +4,8 @@ description: >-
   Run Terraform remotely through the UI, API, or CLI. Learn how Terraform Cloud
   manages runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/run/run-environment.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about worker virtual machines, network access, concurrency for run
   queueing, state access authentication, and environment variables.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/run/states.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn what happens during each stage of a run: pending, plan, cost estimation,
   policy check, apply, and complete.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/run/ui.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces are associated with a VCS repository branch, and Terraform Cloud
   automatically queues runs when new commits are merged.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/enforce.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn when Terraform Cloud performs policy checks and what happens when
   different types of policy checks fail.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/examples.mdx
@@ -4,8 +4,8 @@ description: >-
   Review policy examples that demonstrate some of the most common use cases
   within Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to use Sentinel policy language to create policies, including
   imports to define rules, useful functions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -2,8 +2,8 @@
 page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfplan.mdx
@@ -6,8 +6,8 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfrun.mdx
@@ -2,8 +2,8 @@
 page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/import/tfstate.mdx
@@ -2,8 +2,8 @@
 page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Sentinel is a policy-as-code framework that enables logic-based policy
   decisions. Learn how you can use Sentinel with Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/json.mdx
@@ -2,8 +2,8 @@
 page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/manage-policies.mdx
@@ -4,8 +4,8 @@ description: >-
   Policies are rules that are enforced on Terraform runs. Learn how to create
   and manage versioned policy sets.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/mock.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to use the UI or API to generate mock Sentinel data and how to use
   that data for testing.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -2,8 +2,8 @@
 page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/system-overview/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up and require two-factor authentication. Also learn how to
   log in with two-factor authentication.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the level of access granted by user, team, and organization API
   tokens.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -4,8 +4,8 @@ description: >-
   Organizations allow teams to collaborate on workspaces. Learn about
   organization membership, organization settings, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the difference between workspace-level and organization-level
   permissions and what permissions you can grant to users.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -4,8 +4,8 @@ description: >-
   Teams are a group of users within an organization. Learn about managing teams,
   team membership, team permissions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -4,8 +4,8 @@ description: >-
   Create an account, edit settings, set up two-factor authentication, create API
   tokens, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/github.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to connect a version control system (VCS) to gain additional features
   and better workflows in Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/configurations.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure. Learn how to provide configuration
   versions for a workspace and organize multiple environments.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/creating.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure into meaningful groups. Learn how to create
   and configure workspaces through the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces enable Terraform Cloud to manage collections of infrastructure
   resources. Learn basics and recommended organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -2,8 +2,8 @@
 page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/naming.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure into meaningful groups. Learn our
   recommendations for consistent, informative names.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Managing Access - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure. Find documentation about workspace
   settings for notifications, permissions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Notifications - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/state.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces have their own separate state data. Learn how state is used and how
   to access state from other workspaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/variables/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Cloud workspace variables let you customize configurations, modify
   Terraform's behavior, and store information like provider credentials.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure Terraform input variables and environment variables and create
   reusable variable sets that apply to multiple workspaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/module-sharing.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/account.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Account - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/agent-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/agents.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/applies.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Applies - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/assessment-results.mdx
@@ -4,8 +4,8 @@ description: >-
   Assessment results contain information about continuous validation in
   Terraform Cloud, like drift detection.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/audit-trails.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Audit Trails - API Docs - Terraform Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/changelog.mdx
@@ -2,8 +2,8 @@
 page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/comments.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Comments - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/configuration-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/cost-estimates.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/feature-sets.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/feature-sets.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Feature Sets - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Use the API to manage runs, workspaces, policies, and more. This introduction
   includes authentication, features, and formatting.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/invoices.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Invoices - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/notification-configurations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/oauth-clients.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/organization-memberships.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/organization-tags.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Tags - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/organization-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/plan-exports.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Plan Exports - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/plans.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Plans - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/policies.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policies - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/policy-checks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Checks - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/policy-set-params.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/policy-sets.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Sets - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -4,8 +4,8 @@ description: >-
   GPG signing is required for custom providers. Create, read, update, and delete
   GPG keys with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Modules - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -4,8 +4,8 @@ description: >-
   Create, read, update, and delete provider versions and platforms with the
   Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -4,8 +4,8 @@ description: >-
   You can add public providers to your organization's private registry. Create,
   read, update, and delete public providers with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/run-triggers.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Triggers - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/run.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/ssh-keys.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SSH Keys - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/stability-policy.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/state-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: State Versions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/subscriptions.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/subscriptions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Subscriptions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/team-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Access - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/team-members.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Membership - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/team-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/teams.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Teams - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/user-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: User Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/variable-sets.mdx
@@ -4,8 +4,8 @@ description: >-
   Variable sets allow you to reuse variables across multiple workspaces. Create,
   read, update, and delete variable sets with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/variables.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Variables - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/vcs-events.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: VCS Events - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/workspace-resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/workspace-variables.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/api-docs/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/cost-estimation/aws.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: AWS - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/cost-estimation/azure.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/cost-estimation/gcp.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GCP - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/cost-estimation/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Cloud displays hourly and monthly cost estimates for each resource
   and the total cost and delta of all resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/run-tasks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Run tasks allow Terraform Cloud to execute tasks in external systems at
   specific points in the Terraform Cloud run lifecycle.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Developer reference for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Example customizations for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/service-now/index.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow integration enables your users to order Terraform-built
   infrastructure from ServiceNow.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -6,8 +6,8 @@ description: |-
   Configure Service Catalogs and VCS repositories to allow end users to
   provision infrastructure using ServiceNow and Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow integration to enable your users to order Terraform-built
   infrastructure from ServiceNow
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/migrate/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Migrate state to Terraform Cloud or Terraform Enterprise to continue managing
   existing infrastructure without de-provisioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/registry/add.mdx
@@ -4,8 +4,8 @@ description: >-
   Add providers and modules from the public Terraform Registry to your
   organization's private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/registry/design.mdx
@@ -4,8 +4,8 @@ description: >-
   The configuration designer lets you outline a configuration with private
   modules and helps you quickly define variables.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/registry/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Use the Terraform Cloud private registry to share Terraform providers and
   modules across your organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/registry/publish-modules.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to prepare private modules for publishing, add them to the registry, and
   release new versions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/registry/publish-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Prepare private providers for publishing, add them to the private registry,
   and release new versions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/registry/using.mdx
@@ -2,8 +2,8 @@
 page_title: Using Providers and Modules - Private Module Registry - Terraform Enterprise
 description: Find available providers and modules and include them in configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202208-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202208-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2022/v202208-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/run/api.mdx
@@ -4,8 +4,8 @@ description: >-
   External tools communicate with Terraform Cloud to upload configurations and
   trigger runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/run/cli.mdx
@@ -4,8 +4,8 @@ description: >-
   Trigger runs from your terminal using the Terraform CLI. Learn the required
   configuration for remote CLI runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/run/install-software.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform providers and additional software on Terraform
   Cloud workers, including cloud CLIs or configuration management tools.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/run/manage.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces list current, pending, and historical runs. View run information
   and lock workspaces to prevent new runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/run/modes-and-options.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the effect of the Destroy and Refresh-Only modes as well as options to
   customize behavior during runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/run/remote-operations.mdx
@@ -4,8 +4,8 @@ description: >-
   Run Terraform remotely through the UI, API, or CLI. Learn how Terraform Cloud
   manages runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/run/run-environment.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about worker virtual machines, network access, concurrency for run
   queueing, state access authentication, and environment variables.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/run/states.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn what happens during each stage of a run: pending, plan, cost estimation,
   policy check, apply, and complete.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/run/ui.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces are associated with a VCS repository branch, and Terraform Cloud
   automatically queues runs when new commits are merged.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/enforce.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn when Terraform Cloud performs policy checks and what happens when
   different types of policy checks fail.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/examples.mdx
@@ -4,8 +4,8 @@ description: >-
   Review policy examples that demonstrate some of the most common use cases
   within Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to use Sentinel policy language to create policies, including
   imports to define rules, useful functions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -2,8 +2,8 @@
 page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfplan.mdx
@@ -6,8 +6,8 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfrun.mdx
@@ -2,8 +2,8 @@
 page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/import/tfstate.mdx
@@ -2,8 +2,8 @@
 page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Sentinel is a policy-as-code framework that enables logic-based policy
   decisions. Learn how you can use Sentinel with Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/json.mdx
@@ -2,8 +2,8 @@
 page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/manage-policies.mdx
@@ -4,8 +4,8 @@ description: >-
   Policies are rules that are enforced on Terraform runs. Learn how to create
   and manage versioned policy sets.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/mock.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to use the UI or API to generate mock Sentinel data and how to use
   that data for testing.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -2,8 +2,8 @@
 page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/system-overview/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up and require two-factor authentication. Also learn how to
   log in with two-factor authentication.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the level of access granted by user, team, and organization API
   tokens.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -4,8 +4,8 @@ description: >-
   Organizations allow teams to collaborate on workspaces. Learn about
   organization membership, organization settings, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the difference between workspace-level and organization-level
   permissions and what permissions you can grant to users.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/users-teams-organizations/teams.mdx
@@ -4,8 +4,8 @@ description: >-
   Teams are a group of users within an organization. Learn about managing teams,
   team membership, team permissions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/users-teams-organizations/users.mdx
@@ -4,8 +4,8 @@ description: >-
   Create an account, edit settings, set up two-factor authentication, create API
   tokens, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/azure-devops-server.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/azure-devops-services.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/bitbucket-server.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/github-enterprise.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/github.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/gitlab-com.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/gitlab-eece.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to connect a version control system (VCS) to gain additional features
   and better workflows in Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/vcs/troubleshooting.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/configurations.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure. Learn how to provide configuration
   versions for a workspace and organize multiple environments.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/creating.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure into meaningful groups. Learn how to create
   and configure workspaces through the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces enable Terraform Cloud to manage collections of infrastructure
   resources. Learn basics and recommended organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/json-filtering.mdx
@@ -2,8 +2,8 @@
 page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/naming.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure into meaningful groups. Learn our
   recommendations for consistent, informative names.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Managing Access - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure. Find documentation about workspace
   settings for notifications, permissions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/notifications.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Notifications - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/settings/vcs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/state.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces have their own separate state data. Learn how state is used and how
   to access state from other workspaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/variables/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Cloud workspace variables let you customize configurations, modify
   Terraform's behavior, and store information like provider credentials.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure Terraform input variables and environment variables and create
   reusable variable sets that apply to multiple workspaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/module-sharing.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/account.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Account - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/agent-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/agents.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/applies.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Applies - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/assessment-results.mdx
@@ -4,8 +4,8 @@ description: >-
   Assessment results contain information about continuous validation in
   Terraform Cloud, like drift detection.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/audit-trails.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Audit Trails - API Docs - Terraform Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/changelog.mdx
@@ -2,8 +2,8 @@
 page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/comments.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Comments - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/configuration-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/cost-estimates.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/feature-sets.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/feature-sets.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Feature Sets - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Use the API to manage runs, workspaces, policies, and more. This introduction
   includes authentication, features, and formatting.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/invoices.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Invoices - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/notification-configurations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/oauth-clients.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/organization-memberships.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/organization-tags.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Tags - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/organization-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/plan-exports.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Plan Exports - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/plans.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Plans - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/policies.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policies - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/policy-checks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Checks - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/policy-set-params.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/policy-sets.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Policy Sets - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -4,8 +4,8 @@ description: >-
   GPG signing is required for custom providers. Create, read, update, and delete
   GPG keys with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Modules - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -4,8 +4,8 @@ description: >-
   Create, read, update, and delete provider versions and platforms with the
   Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -4,8 +4,8 @@ description: >-
   You can add public providers to your organization's private registry. Create,
   read, update, and delete public providers with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/run-triggers.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Triggers - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/run.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/ssh-keys.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SSH Keys - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/stability-policy.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/state-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: State Versions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/subscriptions.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/subscriptions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Subscriptions - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/team-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Access - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/team-members.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Membership - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/team-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Team Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/teams.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Teams - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/user-tokens.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: User Tokens - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/variable-sets.mdx
@@ -4,8 +4,8 @@ description: >-
   Variable sets allow you to reuse variables across multiple workspaces. Create,
   read, update, and delete variable sets with the Terraform Cloud API.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/variables.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Variables - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/vcs-events.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: VCS Events - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/workspace-resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/workspace-variables.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/api-docs/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/cost-estimation/aws.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: AWS - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/cost-estimation/azure.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/cost-estimation/gcp.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GCP - Cost Estimation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/cost-estimation/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Cloud displays hourly and monthly cost estimates for each resource
   and the total cost and delta of all resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/run-tasks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Run tasks allow Terraform Cloud to execute tasks in external systems at
   specific points in the Terraform Cloud run lifecycle.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Developer reference for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Example customizations for the ServiceNow Service Catalog Integration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/service-now/index.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow integration enables your users to order Terraform-built
   infrastructure from ServiceNow.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -6,8 +6,8 @@ description: |-
   Configure Service Catalogs and VCS repositories to allow end users to
   provision infrastructure using ServiceNow and Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -6,8 +6,8 @@ description: >-
   ServiceNow integration to enable your users to order Terraform-built
   infrastructure from ServiceNow
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/migrate/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Migrate state to Terraform Cloud or Terraform Enterprise to continue managing
   existing infrastructure without de-provisioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/registry/add.mdx
@@ -4,8 +4,8 @@ description: >-
   Add providers and modules from the public Terraform Registry to your
   organization's private registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/registry/design.mdx
@@ -4,8 +4,8 @@ description: >-
   The configuration designer lets you outline a configuration with private
   modules and helps you quickly define variables.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/registry/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Use the Terraform Cloud private registry to share Terraform providers and
   modules across your organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/registry/publish-modules.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to prepare private modules for publishing, add them to the registry, and
   release new versions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/registry/publish-providers.mdx
@@ -4,8 +4,8 @@ description: >-
   Prepare private providers for publishing, add them to the private registry,
   and release new versions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/registry/using.mdx
@@ -2,8 +2,8 @@
 page_title: Using Providers and Modules - Private Module Registry - Terraform Enterprise
 description: Find available providers and modules and include them in configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202208-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202208-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2022/v202208-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/run/api.mdx
@@ -4,8 +4,8 @@ description: >-
   External tools communicate with Terraform Cloud to upload configurations and
   trigger runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/run/cli.mdx
@@ -4,8 +4,8 @@ description: >-
   Trigger runs from your terminal using the Terraform CLI. Learn the required
   configuration for remote CLI runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/run/install-software.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to install Terraform providers and additional software on Terraform
   Cloud workers, including cloud CLIs or configuration management tools.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/run/manage.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces list current, pending, and historical runs. View run information
   and lock workspaces to prevent new runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/run/modes-and-options.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the effect of the Destroy and Refresh-Only modes as well as options to
   customize behavior during runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/run/remote-operations.mdx
@@ -4,8 +4,8 @@ description: >-
   Run Terraform remotely through the UI, API, or CLI. Learn how Terraform Cloud
   manages runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/run/run-environment.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about worker virtual machines, network access, concurrency for run
   queueing, state access authentication, and environment variables.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/run/states.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn what happens during each stage of a run: pending, plan, cost estimation,
   policy check, apply, and complete.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/run/ui.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces are associated with a VCS repository branch, and Terraform Cloud
   automatically queues runs when new commits are merged.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/enforce.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn when Terraform Cloud performs policy checks and what happens when
   different types of policy checks fail.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/examples.mdx
@@ -4,8 +4,8 @@ description: >-
   Review policy examples that demonstrate some of the most common use cases
   within Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to use Sentinel policy language to create policies, including
   imports to define rules, useful functions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -2,8 +2,8 @@
 page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfplan.mdx
@@ -6,8 +6,8 @@ description: >-
   apply`. The plan represents the changes that Terraform needs to make to
   infrastructure to reach the desired state represented by the configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfrun.mdx
@@ -2,8 +2,8 @@
 page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -2,8 +2,8 @@
 page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/import/tfstate.mdx
@@ -2,8 +2,8 @@
 page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Sentinel is a policy-as-code framework that enables logic-based policy
   decisions. Learn how you can use Sentinel with Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/json.mdx
@@ -2,8 +2,8 @@
 page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/manage-policies.mdx
@@ -4,8 +4,8 @@ description: >-
   Policies are rules that are enforced on Terraform runs. Learn how to create
   and manage versioned policy sets.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/mock.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to use the UI or API to generate mock Sentinel data and how to use
   that data for testing.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -2,8 +2,8 @@
 page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/system-overview/data-security.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to set up and require two-factor authentication. Also learn how to
   log in with two-factor authentication.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the level of access granted by user, team, and organization API
   tokens.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -4,8 +4,8 @@ description: >-
   Organizations allow teams to collaborate on workspaces. Learn about
   organization membership, organization settings, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the difference between workspace-level and organization-level
   permissions and what permissions you can grant to users.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/users-teams-organizations/teams.mdx
@@ -4,8 +4,8 @@ description: >-
   Teams are a group of users within an organization. Learn about managing teams,
   team membership, team permissions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/users-teams-organizations/users.mdx
@@ -4,8 +4,8 @@ description: >-
   Create an account, edit settings, set up two-factor authentication, create API
   tokens, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/azure-devops-server.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/azure-devops-services.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/bitbucket-server.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/github-enterprise.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/github.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/gitlab-com.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/gitlab-eece.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to connect a version control system (VCS) to gain additional features
   and better workflows in Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/vcs/troubleshooting.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/configurations.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure. Learn how to provide configuration
   versions for a workspace and organize multiple environments.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/creating.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure into meaningful groups. Learn how to create
   and configure workspaces through the UI.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces enable Terraform Cloud to manage collections of infrastructure
   resources. Learn basics and recommended organization.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/json-filtering.mdx
@@ -2,8 +2,8 @@
 page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/naming.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure into meaningful groups. Learn our
   recommendations for consistent, informative names.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Managing Access - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces organize infrastructure. Find documentation about workspace
   settings for notifications, permissions, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/notifications.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Notifications - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/settings/vcs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/state.mdx
@@ -4,8 +4,8 @@ description: >-
   Workspaces have their own separate state data. Learn how state is used and how
   to access state from other workspaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/variables/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Cloud workspace variables let you customize configurations, modify
   Terraform's behavior, and store information like provider credentials.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure Terraform input variables and environment variables and create
   reusable variable sets that apply to multiple workspaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/module-sharing.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/_template.mdx
@@ -1,8 +1,8 @@
 ---
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/account.mdx
@@ -2,8 +2,8 @@
 page_title: Account - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/agents.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/applies.mdx
@@ -2,8 +2,8 @@
 page_title: Applies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/audit-trails.mdx
@@ -2,8 +2,8 @@
 page_title: Audit Trails - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/changelog.mdx
@@ -3,8 +3,8 @@ page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/comments.mdx
@@ -2,8 +2,8 @@
 page_title: Comments - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -2,8 +2,8 @@
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -2,8 +2,8 @@
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/feature-sets.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/feature-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Feature Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   includes authentication, features, and formatting.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/invoices.mdx
@@ -2,8 +2,8 @@
 page_title: Invoices - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -2,8 +2,8 @@
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tags - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/organizations.mdx
@@ -2,8 +2,8 @@
 page_title: Organizations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -2,8 +2,8 @@
 page_title: Plan Exports - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/plans.mdx
@@ -2,8 +2,8 @@
 page_title: Plans - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/policies.mdx
@@ -2,8 +2,8 @@
 page_title: Policies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Checks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   GPG keys with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -2,8 +2,8 @@
 page_title: Modules - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete public providers with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -2,8 +2,8 @@
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/run.mdx
@@ -2,8 +2,8 @@
 page_title: Runs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -2,8 +2,8 @@
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -2,8 +2,8 @@
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/state-versions.mdx
@@ -2,8 +2,8 @@
 page_title: State Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/subscriptions.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/subscriptions.mdx
@@ -2,8 +2,8 @@
 page_title: Subscriptions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/team-access.mdx
@@ -2,8 +2,8 @@
 page_title: Team Access - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/team-members.mdx
@@ -2,8 +2,8 @@
 page_title: Team Membership - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Team Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/teams.mdx
@@ -2,8 +2,8 @@
 page_title: Teams - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: User Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/users.mdx
@@ -2,8 +2,8 @@
 page_title: Users - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete variable sets with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/variables.mdx
@@ -2,8 +2,8 @@
 page_title: Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Events - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/workspaces.mdx
@@ -2,8 +2,8 @@
 page_title: Workspaces - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/cost-estimation/aws.mdx
@@ -2,8 +2,8 @@
 page_title: AWS - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/cost-estimation/azure.mdx
@@ -2,8 +2,8 @@
 page_title: Azure - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -2,8 +2,8 @@
 page_title: GCP - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/enforce.mdx
@@ -5,8 +5,8 @@ description: >-
   different types of policy checks fail.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/examples.mdx
@@ -5,8 +5,8 @@ description: >-
   within Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   decisions. Learn how you can use Sentinel with Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/manage-policies.mdx
@@ -5,8 +5,8 @@ description: >-
   and manage versioned policy sets.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/github.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   and better workflows in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -2,8 +2,8 @@
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/naming.mdx
@@ -5,8 +5,8 @@ description: >-
   recommendations for consistent, informative names.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/access.mdx
@@ -2,8 +2,8 @@
 page_title: Managing Access - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -2,8 +2,8 @@
 page_title: Notifications - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/module-sharing.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/_template.mdx
@@ -1,8 +1,8 @@
 ---
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/account.mdx
@@ -2,8 +2,8 @@
 page_title: Account - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/agent-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/agents.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/applies.mdx
@@ -2,8 +2,8 @@
 page_title: Applies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/audit-trails.mdx
@@ -2,8 +2,8 @@
 page_title: Audit Trails - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/changelog.mdx
@@ -3,8 +3,8 @@ page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/comments.mdx
@@ -2,8 +2,8 @@
 page_title: Comments - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/configuration-versions.mdx
@@ -2,8 +2,8 @@
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/cost-estimates.mdx
@@ -2,8 +2,8 @@
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/feature-sets.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/feature-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Feature Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   includes authentication, features, and formatting.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/invoices.mdx
@@ -2,8 +2,8 @@
 page_title: Invoices - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/notification-configurations.mdx
@@ -2,8 +2,8 @@
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/oauth-clients.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/organization-memberships.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/organization-tags.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tags - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/organization-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/organizations.mdx
@@ -2,8 +2,8 @@
 page_title: Organizations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/plan-exports.mdx
@@ -2,8 +2,8 @@
 page_title: Plan Exports - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/plans.mdx
@@ -2,8 +2,8 @@
 page_title: Plans - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/policies.mdx
@@ -2,8 +2,8 @@
 page_title: Policies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/policy-checks.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Checks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/policy-set-params.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/policy-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   GPG keys with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -2,8 +2,8 @@
 page_title: Modules - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete public providers with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -2,8 +2,8 @@
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/run.mdx
@@ -2,8 +2,8 @@
 page_title: Runs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/stability-policy.mdx
@@ -2,8 +2,8 @@
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -2,8 +2,8 @@
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/state-versions.mdx
@@ -2,8 +2,8 @@
 page_title: State Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/subscriptions.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/subscriptions.mdx
@@ -2,8 +2,8 @@
 page_title: Subscriptions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/team-access.mdx
@@ -2,8 +2,8 @@
 page_title: Team Access - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/team-members.mdx
@@ -2,8 +2,8 @@
 page_title: Team Membership - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/team-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Team Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/teams.mdx
@@ -2,8 +2,8 @@
 page_title: Teams - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/user-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: User Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/users.mdx
@@ -2,8 +2,8 @@
 page_title: Users - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/variable-sets.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete variable sets with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/variables.mdx
@@ -2,8 +2,8 @@
 page_title: Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/vcs-events.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Events - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/workspace-resources.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/workspace-variables.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/workspaces.mdx
@@ -2,8 +2,8 @@
 page_title: Workspaces - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/cost-estimation/aws.mdx
@@ -2,8 +2,8 @@
 page_title: AWS - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/cost-estimation/azure.mdx
@@ -2,8 +2,8 @@
 page_title: Azure - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/cost-estimation/gcp.mdx
@@ -2,8 +2,8 @@
 page_title: GCP - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202208-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202208-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202208-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202209-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2022/v202209-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/enforce.mdx
@@ -5,8 +5,8 @@ description: >-
   different types of policy checks fail.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/examples.mdx
@@ -5,8 +5,8 @@ description: >-
   within Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   decisions. Learn how you can use Sentinel with Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/manage-policies.mdx
@@ -5,8 +5,8 @@ description: >-
   and manage versioned policy sets.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/azure-devops-server.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/azure-devops-services.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/bitbucket-server.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/github-enterprise.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/github.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/gitlab-com.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/gitlab-eece.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   and better workflows in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/vcs/troubleshooting.mdx
@@ -2,8 +2,8 @@
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/naming.mdx
@@ -5,8 +5,8 @@ description: >-
   recommendations for consistent, informative names.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/access.mdx
@@ -2,8 +2,8 @@
 page_title: Managing Access - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/notifications.mdx
@@ -2,8 +2,8 @@
 page_title: Notifications - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/settings/vcs.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/module-sharing.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/_template.mdx
@@ -1,8 +1,8 @@
 ---
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/account.mdx
@@ -2,8 +2,8 @@
 page_title: Account - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/agents.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/applies.mdx
@@ -2,8 +2,8 @@
 page_title: Applies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/audit-trails.mdx
@@ -2,8 +2,8 @@
 page_title: Audit Trails - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/changelog.mdx
@@ -3,8 +3,8 @@ page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/comments.mdx
@@ -2,8 +2,8 @@
 page_title: Comments - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -2,8 +2,8 @@
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -2,8 +2,8 @@
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/feature-sets.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/feature-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Feature Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   includes authentication, features, and formatting.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/invoices.mdx
@@ -2,8 +2,8 @@
 page_title: Invoices - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -2,8 +2,8 @@
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tags - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/organizations.mdx
@@ -2,8 +2,8 @@
 page_title: Organizations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -2,8 +2,8 @@
 page_title: Plan Exports - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/plans.mdx
@@ -2,8 +2,8 @@
 page_title: Plans - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/policies.mdx
@@ -2,8 +2,8 @@
 page_title: Policies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Checks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   GPG keys with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -2,8 +2,8 @@
 page_title: Modules - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete public providers with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -2,8 +2,8 @@
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/run.mdx
@@ -2,8 +2,8 @@
 page_title: Runs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -2,8 +2,8 @@
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -2,8 +2,8 @@
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/state-versions.mdx
@@ -2,8 +2,8 @@
 page_title: State Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/subscriptions.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/subscriptions.mdx
@@ -2,8 +2,8 @@
 page_title: Subscriptions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/team-access.mdx
@@ -2,8 +2,8 @@
 page_title: Team Access - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/team-members.mdx
@@ -2,8 +2,8 @@
 page_title: Team Membership - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Team Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/teams.mdx
@@ -2,8 +2,8 @@
 page_title: Teams - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: User Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/users.mdx
@@ -2,8 +2,8 @@
 page_title: Users - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete variable sets with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/variables.mdx
@@ -2,8 +2,8 @@
 page_title: Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Events - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/workspaces.mdx
@@ -2,8 +2,8 @@
 page_title: Workspaces - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/cost-estimation/aws.mdx
@@ -2,8 +2,8 @@
 page_title: AWS - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/cost-estimation/azure.mdx
@@ -2,8 +2,8 @@
 page_title: Azure - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -2,8 +2,8 @@
 page_title: GCP - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/enforce.mdx
@@ -5,8 +5,8 @@ description: >-
   different types of policy checks fail.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/examples.mdx
@@ -5,8 +5,8 @@ description: >-
   within Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   decisions. Learn how you can use Sentinel with Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/manage-policies.mdx
@@ -5,8 +5,8 @@ description: >-
   and manage versioned policy sets.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/github.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   and better workflows in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -2,8 +2,8 @@
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/naming.mdx
@@ -5,8 +5,8 @@ description: >-
   recommendations for consistent, informative names.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/access.mdx
@@ -2,8 +2,8 @@
 page_title: Managing Access - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -2,8 +2,8 @@
 page_title: Notifications - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/module-sharing.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/_template.mdx
@@ -1,8 +1,8 @@
 ---
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/account.mdx
@@ -2,8 +2,8 @@
 page_title: Account - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/agents.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/applies.mdx
@@ -2,8 +2,8 @@
 page_title: Applies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/audit-trails.mdx
@@ -2,8 +2,8 @@
 page_title: Audit Trails - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/changelog.mdx
@@ -3,8 +3,8 @@ page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/comments.mdx
@@ -2,8 +2,8 @@
 page_title: Comments - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -2,8 +2,8 @@
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -2,8 +2,8 @@
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/feature-sets.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/feature-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Feature Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   includes authentication, features, and formatting.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/invoices.mdx
@@ -2,8 +2,8 @@
 page_title: Invoices - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -2,8 +2,8 @@
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tags - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/organizations.mdx
@@ -2,8 +2,8 @@
 page_title: Organizations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -2,8 +2,8 @@
 page_title: Plan Exports - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/plans.mdx
@@ -2,8 +2,8 @@
 page_title: Plans - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/policies.mdx
@@ -2,8 +2,8 @@
 page_title: Policies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Checks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   GPG keys with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -2,8 +2,8 @@
 page_title: Modules - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete public providers with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -2,8 +2,8 @@
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/run.mdx
@@ -2,8 +2,8 @@
 page_title: Runs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -2,8 +2,8 @@
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -2,8 +2,8 @@
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/state-versions.mdx
@@ -2,8 +2,8 @@
 page_title: State Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/subscriptions.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/subscriptions.mdx
@@ -2,8 +2,8 @@
 page_title: Subscriptions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/team-access.mdx
@@ -2,8 +2,8 @@
 page_title: Team Access - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/team-members.mdx
@@ -2,8 +2,8 @@
 page_title: Team Membership - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Team Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/teams.mdx
@@ -2,8 +2,8 @@
 page_title: Teams - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: User Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/users.mdx
@@ -2,8 +2,8 @@
 page_title: Users - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete variable sets with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/variables.mdx
@@ -2,8 +2,8 @@
 page_title: Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Events - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/workspaces.mdx
@@ -2,8 +2,8 @@
 page_title: Workspaces - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/cost-estimation/aws.mdx
@@ -2,8 +2,8 @@
 page_title: AWS - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/cost-estimation/azure.mdx
@@ -2,8 +2,8 @@
 page_title: Azure - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -2,8 +2,8 @@
 page_title: GCP - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/enforce.mdx
@@ -5,8 +5,8 @@ description: >-
   different types of policy checks fail.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/examples.mdx
@@ -5,8 +5,8 @@ description: >-
   within Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   decisions. Learn how you can use Sentinel with Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/manage-policies.mdx
@@ -5,8 +5,8 @@ description: >-
   and manage versioned policy sets.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/github.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   and better workflows in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -2,8 +2,8 @@
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/naming.mdx
@@ -5,8 +5,8 @@ description: >-
   recommendations for consistent, informative names.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/access.mdx
@@ -2,8 +2,8 @@
 page_title: Managing Access - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -2,8 +2,8 @@
 page_title: Notifications - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/module-sharing.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/_template.mdx
@@ -1,8 +1,8 @@
 ---
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/account.mdx
@@ -2,8 +2,8 @@
 page_title: Account - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/agent-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/agents.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/applies.mdx
@@ -2,8 +2,8 @@
 page_title: Applies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/audit-trails.mdx
@@ -2,8 +2,8 @@
 page_title: Audit Trails - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/changelog.mdx
@@ -3,8 +3,8 @@ page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/comments.mdx
@@ -2,8 +2,8 @@
 page_title: Comments - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/configuration-versions.mdx
@@ -2,8 +2,8 @@
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/cost-estimates.mdx
@@ -2,8 +2,8 @@
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   includes authentication, features, and formatting.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/invoices.mdx
@@ -2,8 +2,8 @@
 page_title: Invoices - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/notification-configurations.mdx
@@ -2,8 +2,8 @@
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/oauth-clients.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/organization-memberships.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/organization-tags.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tags - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/organization-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/organizations.mdx
@@ -2,8 +2,8 @@
 page_title: Organizations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/plan-exports.mdx
@@ -2,8 +2,8 @@
 page_title: Plan Exports - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/plans.mdx
@@ -2,8 +2,8 @@
 page_title: Plans - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/policies.mdx
@@ -2,8 +2,8 @@
 page_title: Policies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/policy-checks.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Checks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/policy-set-params.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/policy-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   GPG keys with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -2,8 +2,8 @@
 page_title: Modules - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete public providers with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -2,8 +2,8 @@
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/run.mdx
@@ -2,8 +2,8 @@
 page_title: Runs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/stability-policy.mdx
@@ -2,8 +2,8 @@
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -2,8 +2,8 @@
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/state-versions.mdx
@@ -2,8 +2,8 @@
 page_title: State Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/team-access.mdx
@@ -2,8 +2,8 @@
 page_title: Team Access - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/team-members.mdx
@@ -2,8 +2,8 @@
 page_title: Team Membership - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/team-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Team Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/teams.mdx
@@ -2,8 +2,8 @@
 page_title: Teams - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/user-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: User Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/users.mdx
@@ -2,8 +2,8 @@
 page_title: Users - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/variable-sets.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete variable sets with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/variables.mdx
@@ -2,8 +2,8 @@
 page_title: Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/vcs-events.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Events - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/workspace-resources.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/workspace-variables.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/workspaces.mdx
@@ -2,8 +2,8 @@
 page_title: Workspaces - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/cost-estimation/aws.mdx
@@ -2,8 +2,8 @@
 page_title: AWS - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/cost-estimation/azure.mdx
@@ -2,8 +2,8 @@
 page_title: Azure - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/cost-estimation/gcp.mdx
@@ -2,8 +2,8 @@
 page_title: GCP - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202208-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202208-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202208-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202209-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202209-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202210-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202211-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202212-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2022/v202212-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/enforce.mdx
@@ -5,8 +5,8 @@ description: >-
   different types of policy checks fail.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/examples.mdx
@@ -5,8 +5,8 @@ description: >-
   within Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   decisions. Learn how you can use Sentinel with Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/manage-policies.mdx
@@ -5,8 +5,8 @@ description: >-
   and manage versioned policy sets.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/azure-devops-server.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/azure-devops-services.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/bitbucket-server.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/github-enterprise.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/github.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/gitlab-com.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/gitlab-eece.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   and better workflows in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/vcs/troubleshooting.mdx
@@ -2,8 +2,8 @@
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/naming.mdx
@@ -5,8 +5,8 @@ description: >-
   recommendations for consistent, informative names.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/access.mdx
@@ -2,8 +2,8 @@
 page_title: Managing Access - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/notifications.mdx
@@ -2,8 +2,8 @@
 page_title: Notifications - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/settings/vcs.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/agents-on-tfe.mdx
@@ -9,8 +9,8 @@ description: >-
   Learn what's different when you use cloud agents in Terraform Enterprise vs.
   Terraform Cloud.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/admin-access.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/admin-access.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accessing Admin Pages - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/customization.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/customization.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Customization - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/general.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/general.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: General Settings - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/integration.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/integration.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Integrations - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/module-sharing.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/resources.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/resources.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Accounts and Resources - Application Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/update-tfe-license.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/application/update-tfe-license.mdx
@@ -3,8 +3,8 @@ page_title: >-
   Updating Terraform Enterprise License - Application Administration - Terraform
   Enterprise 
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/admin-cli.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/automated-recovery.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/backup-restore.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/demo-to-disk-migration.mdx
@@ -4,8 +4,8 @@ page_title: >-
   Enterprise
 description: Learn how to migrate Terraform Enterprise from Demo mode to Mounted Disk mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/logging.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/monitoring.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/upgrades.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/upgrades.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/logging-old.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/logging-old.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/_template.mdx
@@ -1,8 +1,8 @@
 ---
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/account.mdx
@@ -2,8 +2,8 @@
 page_title: Account - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Module Sharing - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/organizations.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Organizations - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/runs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Runs - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/settings.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Enterprise Settings - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Terraform Versions - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/users.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Users - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Workspaces - Admin - API Docs - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/agent-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/agents.mdx
@@ -2,8 +2,8 @@
 page_title: Agent Pools and Agents - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/applies.mdx
@@ -2,8 +2,8 @@
 page_title: Applies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/audit-trails.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/audit-trails.mdx
@@ -2,8 +2,8 @@
 page_title: Audit Trails - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/changelog.mdx
@@ -3,8 +3,8 @@ page_title: API Changelog - API Docs - Terraform Enterprise
 page_id: api-changelog
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/comments.mdx
@@ -2,8 +2,8 @@
 page_title: Comments - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/configuration-versions.mdx
@@ -2,8 +2,8 @@
 page_title: Configuration Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/cost-estimates.mdx
@@ -2,8 +2,8 @@
 page_title: Cost Estimates - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   includes authentication, features, and formatting.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/invoices.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/invoices.mdx
@@ -2,8 +2,8 @@
 page_title: Invoices - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/notification-configurations.mdx
@@ -2,8 +2,8 @@
 page_title: Notification Configurations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/oauth-clients.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Clients - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: OAuth Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/organization-memberships.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Memberships - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/organization-tags.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tags - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/organization-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Organization Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/organizations.mdx
@@ -2,8 +2,8 @@
 page_title: Organizations - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/plan-exports.mdx
@@ -2,8 +2,8 @@
 page_title: Plan Exports - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/plans.mdx
@@ -2,8 +2,8 @@
 page_title: Plans - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/policies.mdx
@@ -2,8 +2,8 @@
 page_title: Policies - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/policy-checks.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Checks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/policy-set-params.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Set Parameters - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/policy-sets.mdx
@@ -2,8 +2,8 @@
 page_title: Policy Sets - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,8 +5,8 @@ description: >-
   GPG keys with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -2,8 +2,8 @@
 page_title: Modules - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -5,8 +5,8 @@ description: >-
   Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete public providers with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -2,8 +2,8 @@
 page_title: Run Task Stages and Results - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks Integration - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/run.mdx
@@ -2,8 +2,8 @@
 page_title: Runs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/stability-policy.mdx
@@ -2,8 +2,8 @@
 page_title: API Stability Policy - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -2,8 +2,8 @@
 page_title: State Version Outputs - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/state-versions.mdx
@@ -2,8 +2,8 @@
 page_title: State Versions - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/team-access.mdx
@@ -2,8 +2,8 @@
 page_title: Team Access - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/team-members.mdx
@@ -2,8 +2,8 @@
 page_title: Team Membership - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/team-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: Team Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/teams.mdx
@@ -2,8 +2,8 @@
 page_title: Teams - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/user-tokens.mdx
@@ -2,8 +2,8 @@
 page_title: User Tokens - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/users.mdx
@@ -2,8 +2,8 @@
 page_title: Users - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/variable-sets.mdx
@@ -5,8 +5,8 @@ description: >-
   read, update, and delete variable sets with the Terraform Enterprise API.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/variables.mdx
@@ -2,8 +2,8 @@
 page_title: Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/vcs-events.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Events - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/workspace-resources.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Resources - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/workspace-variables.mdx
@@ -2,8 +2,8 @@
 page_title: Workspace Variables - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/workspaces.mdx
@@ -2,8 +2,8 @@
 page_title: Workspaces - API Docs - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/cost-estimation/aws.mdx
@@ -2,8 +2,8 @@
 page_title: AWS - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/cost-estimation/azure.mdx
@@ -2,8 +2,8 @@
 page_title: Azure - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/cost-estimation/gcp.mdx
@@ -2,8 +2,8 @@
 page_title: GCP - Cost Estimation - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/cost-estimation/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resource and the total cost and delta of all resources.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise is a self-hosted instance of Terraform Cloud with
   features like audit logging and SAML single sign-on.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/install/automated/active-active.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/install/automated/automating-initial-user.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/install/automated/automating-the-installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/install/automated/encryption-password.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/install/interactive/config.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/install/interactive/config.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Configuration - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/install/interactive/installer.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/install/pre-install-checklist.mdx
@@ -4,8 +4,8 @@ description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/install/uninstall.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/run-tasks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   specific points in the Terraform Cloud run lifecycle.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/service-now/admin-guide.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/service-now/admin-guide.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/service-now/developer-reference.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/service-now/developer-reference.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Developer reference for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/service-now/example-customizations.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/service-now/example-customizations.mdx
@@ -5,8 +5,8 @@ page_title: >-
 description: Example customizations for the ServiceNow Service Catalog Integration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/service-now/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/service-now/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/service-now/service-catalog.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/service-now/service-catalog.mdx
@@ -7,8 +7,8 @@ description: |-
   provision infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/integrations/service-now/service-now-v1/index.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure from ServiceNow
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/migrate/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/migrate/index.mdx
@@ -5,8 +5,8 @@ description: >-
   managing existing infrastructure without de-provisioning.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/operational-modes/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/operational-modes/index.mdx
@@ -2,8 +2,8 @@
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/reference-architecture/aws.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/reference-architecture/azure.mdx
@@ -5,8 +5,8 @@ description: |-
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/reference-architecture/gcp.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/reference-architecture/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/reference-architecture/vmware.mdx
@@ -4,8 +4,8 @@ description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/registry/add.mdx
@@ -5,8 +5,8 @@ description: >-
   organization's private registry.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/registry/design.mdx
@@ -5,8 +5,8 @@ description: >-
   modules and helps you quickly define variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/registry/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modules across your organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/registry/publish-modules.mdx
@@ -5,8 +5,8 @@ description: >-
   release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/registry/publish-providers.mdx
@@ -5,8 +5,8 @@ description: >-
   and release new versions.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/registry/using.mdx
@@ -3,8 +3,8 @@ page_title: Using Providers and Modules - Private Module Registry - Terraform En
 description: Find available providers and modules and include them in configurations.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2018/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2019/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2020/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202101-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202102-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202102-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202103-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202103-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202104-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202105-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202106-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202107-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202108-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202109-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202109-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202110-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202111-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202112-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202112-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/index.mdx
@@ -2,8 +2,8 @@
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202201-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202201-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202202-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202203-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202204-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202204-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202205-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202206-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202207-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202207-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202208-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202208-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202208-3.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202209-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202209-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202210-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202211-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202212-1.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2022/v202212-2.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: Releases - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/index.mdx
@@ -4,8 +4,8 @@ description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/credentials.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/credentials.mdx
@@ -4,8 +4,8 @@ description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/data-storage/minio-setup-guide.mdx
@@ -4,8 +4,8 @@ description: >-
   This document provides an overview for setting up Minio for external object
   storage for HashiCorp Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -4,8 +4,8 @@ description: >-
   Data storage requirements differ based on the operational mode of your
   Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/data-storage/postgres-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/data-storage/vault.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/data-storage/vault.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: External Vault - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/docker.mdx
@@ -4,8 +4,8 @@ description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/hardware.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/hardware.mdx
@@ -2,8 +2,8 @@
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/network.mdx
@@ -4,8 +4,8 @@ description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/os-specific/centos-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/os-specific/rhel-requirements.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/os-specific/supported-os.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/run/api.mdx
@@ -5,8 +5,8 @@ description: >-
   and trigger runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/run/cli.mdx
@@ -5,8 +5,8 @@ description: >-
   configuration for remote CLI runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/run/install-software.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise workers, including cloud CLIs or configuration management tools.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/run/manage.mdx
@@ -5,8 +5,8 @@ description: >-
   and lock workspaces to prevent new runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/run/modes-and-options.mdx
@@ -5,8 +5,8 @@ description: >-
   customize behavior during runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/run/remote-operations.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise manages runs.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/run/run-environment.mdx
@@ -5,8 +5,8 @@ description: >-
   queueing, state access authentication, and environment variables.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/run/states.mdx
@@ -5,8 +5,8 @@ description: >-
   policy check, apply, and complete.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/run/ui.mdx
@@ -5,8 +5,8 @@ description: >-
   Enterprise automatically queues runs when new commits are merged.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/saml/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   When a new user logs in, Terraform Enterprise updates their account with data
   from SAML user attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/saml/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn to set up SAML and configure Terraform Enterprise as the Service
   Provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,8 +3,8 @@ page_title: >-
   SAML Azure Active Directory Identity Provider Configuration - Terraform
   Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: ADFS Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/saml/idp-configuration/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Set up SAML for specific identity providers and review a sample sign-on
   request and response.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML Okta Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: SAML OneLogin Identity Provider Configuration - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/saml/login.mdx
@@ -4,8 +4,8 @@ description: >-
   How to log in when SAML is configured and how admins can change the user API
   token session timeout.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/saml/team-membership.mdx
@@ -2,8 +2,8 @@
 page_title: SAML Team Membership - Terraform Enterprise
 description: Automatically add users to teams based on their SAML assertion.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/saml/troubleshooting.mdx
@@ -4,8 +4,8 @@ description: >-
   How to disable SAML, debug and test SAML, create a non-SSO admin account for
   recovery, common configuration errors, and more.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/enforce.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/enforce.mdx
@@ -5,8 +5,8 @@ description: >-
   different types of policy checks fail.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/examples.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/examples.mdx
@@ -5,8 +5,8 @@ description: >-
   within Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/index.mdx
@@ -5,8 +5,8 @@ description: >-
   imports to define rules, useful functions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfconfig-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfconfig.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfconfig.mdx
@@ -3,8 +3,8 @@ page_title: tfconfig - Imports - Sentinel - Terraform Enterprise
 description: The tfconfig import provides access to a Terraform configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfplan-v2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfplan-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfplan/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfplan/v2 import provides access to a Terraform plan.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfplan.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfplan.mdx
@@ -7,8 +7,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfrun.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfrun.mdx
@@ -3,8 +3,8 @@ page_title: tfrun - Imports - Sentinel - Terraform Enterprise
 description: The `tfrun` import provides access to data associated with a Terraform run.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfstate-v2.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfstate-v2.mdx
@@ -3,8 +3,8 @@ page_title: tfstate/v2 - Imports - Sentinel - Terraform Enterprise
 description: The tfstate/v2 import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfstate.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/import/tfstate.mdx
@@ -3,8 +3,8 @@ page_title: tfstate - Imports - Sentinel - Terraform Enterprise
 description: The tfstate import provides access to a Terraform state.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/index.mdx
@@ -5,8 +5,8 @@ description: >-
   decisions. Learn how you can use Sentinel with Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/json.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/json.mdx
@@ -3,8 +3,8 @@ page_title: Working With JSON Result Data - Sentinel - Terraform Enterprise
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/manage-policies.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/manage-policies.mdx
@@ -5,8 +5,8 @@ description: >-
   and manage versioned policy sets.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/mock.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/mock.mdx
@@ -5,8 +5,8 @@ description: >-
   that data for testing.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/sentinel-tf-012.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/sentinel/sentinel-tf-012.mdx
@@ -3,8 +3,8 @@ page_title: Using Sentinel with Terraform 0.12 - Terraform Enterprise
 description: Read about the changes made to Sentinel in Terraform 0.12.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/support/index.mdx
@@ -2,8 +2,8 @@
 page_title: Support - Terraform Enterprise
 description: Learn to how to run diagnostics and contact HashiCorp support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/system-overview/architecture.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/system-overview/architecture.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the services used to run Terraform Enterprise and understand how
   data flows through the system.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/system-overview/capacity.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/system-overview/data-security.mdx
@@ -5,8 +5,8 @@ description: >-
   and encryption methods we use.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/system-overview/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/system-overview/index.mdx
@@ -1,8 +1,8 @@
 ---
 page_title: System Overview - Terraform Enterprise
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/system-overview/reliability-availability.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/system-overview/security-model.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -5,8 +5,8 @@ description: >-
   log in with two-factor authentication.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/users-teams-organizations/organizations.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/users-teams-organizations/organizations.mdx
@@ -5,8 +5,8 @@ description: >-
   organization membership, organization settings, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/users-teams-organizations/permissions.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/users-teams-organizations/permissions.mdx
@@ -5,8 +5,8 @@ description: >-
   permissions and what permissions you can grant to users.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/users-teams-organizations/teams.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/users-teams-organizations/teams.mdx
@@ -5,8 +5,8 @@ description: >-
   team membership, team permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/users-teams-organizations/users.mdx
@@ -5,8 +5,8 @@ description: >-
   tokens, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/azure-devops-server.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Server - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/azure-devops-services.mdx
@@ -2,8 +2,8 @@
 page_title: Azure DevOps Services - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Cloud - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/bitbucket-server.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/bitbucket-server.mdx
@@ -2,8 +2,8 @@
 page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/github-enterprise.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub Enterprise - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/github.mdx
@@ -2,8 +2,8 @@
 page_title: GitHub.com (OAuth) - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/gitlab-com.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab.com - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/gitlab-eece.mdx
@@ -2,8 +2,8 @@
 page_title: GitLab EE and CE - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   and better workflows in Terraform Enterprise.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/vcs/troubleshooting.mdx
@@ -2,8 +2,8 @@
 page_title: Troubleshooting - VCS Providers - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/configurations.mdx
@@ -5,8 +5,8 @@ description: >-
   versions for a workspace and organize multiple environments.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/creating.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/creating.mdx
@@ -5,8 +5,8 @@ description: >-
   and configure workspaces through the UI.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources. Learn basics and recommended organization.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/json-filtering.mdx
@@ -3,8 +3,8 @@ page_title: JSON Filtering - Terraform Enterprise
 description: Learn how to create custom datasets on pages that display JSON data.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/naming.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/naming.mdx
@@ -5,8 +5,8 @@ description: >-
   recommendations for consistent, informative names.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/access.mdx
@@ -2,8 +2,8 @@
 page_title: Managing Access - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/index.mdx
@@ -5,8 +5,8 @@ description: >-
   settings for notifications, permissions, and more.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/notifications.mdx
@@ -2,8 +2,8 @@
 page_title: Notifications - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -2,8 +2,8 @@
 page_title: Run Tasks - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -2,8 +2,8 @@
 page_title: Run Triggers - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -2,8 +2,8 @@
 page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/settings/vcs.mdx
@@ -2,8 +2,8 @@
 page_title: VCS Connections - Workspaces - Terraform Enterprise
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/state.mdx
@@ -5,8 +5,8 @@ description: >-
   to access state from other workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/variables/index.mdx
@@ -5,8 +5,8 @@ description: >-
   modify Terraform's behavior, and store information like provider credentials.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/workspaces/variables/managing-variables.mdx
@@ -5,8 +5,8 @@ description: >-
   reusable variable sets that apply to multiple workspaces.
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-05-28T07:56:28-04:00
-last_modified: 2025-05-28T07:56:28-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 


### PR DESCRIPTION
### Description

This PR adds date metadata to the fifth part the terraform-enterprise documentation. Terraform-enterprise has a lot of files so this needed to be split so the build does not fail. This PR covers versions v202206-1 through v202212-2. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715. Older docs versions have been updated with default dates for the versions specified in [this spreadsheet](https://docs.google.com/spreadsheets/d/16FpDhKA4ZBOVtxHWw2ebMjS56mdSask1FBCVecn9QnQ/edit?gid=0#gid=0)

NOTE: The run link checker action is expected to fail for this PR since there are so many files changed. This action is not blocking merge and can be ignored.

### Testing

Check that terraform-enterprise docs look normal in the preview for versions v202206-1 through v202212-2: https://unified-docs-frontend-preview-ma5gx31gx-hashicorp.vercel.app/terraform/enterprise/v202212-2