### PR TITLE
HCP Terraform Docs

### DIFF
--- a/content/terraform/v1.12.x/docs/language/modules/configuration.mdx
+++ b/content/terraform/v1.12.x/docs/language/modules/configuration.mdx
@@ -166,7 +166,7 @@ You can also remove a module from your Terraform state without destroying the re
 
 1. Replace the `module` block from your configuration with a `removed` block.
 1. And add the `lifecycle` block to your `removed` block.
-1. Add the `destroy` argument and set it to `false.
+1. Add the `destroy` argument and set it to `false`.
 
 The following example removes the `module.example` resources from the Terraform state without destroying them: 
 

--- a/content/terraform/v1.12.x/docs/language/modules/configuration.mdx
+++ b/content/terraform/v1.12.x/docs/language/modules/configuration.mdx
@@ -165,7 +165,7 @@ Terraform v1.7 or later is required to use the `removed` block. To remove a reso
 You can also remove a module from your Terraform state without destroying the real infrastructure objects it manages:
 
 1. Replace the `module` block from your configuration with a `removed` block.
-1. And add the `lifecycle` block to your `removed` block.
+1. Add the `lifecycle` block to your `removed` block.
 1. Add the `destroy` argument and set it to `false`.
 
 The following example removes the `module.example` resources from the Terraform state without destroying them: 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Added missing \` symbol intended to make the boolean value `false` stand out.
Additionally, removed the unnecessary `and` in step#2, as these are after all, 3 steps that must be done. So the `and` is implicit.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
It makes the docs more consistent.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->
The issue at hand:
<img width="2063" height="999" alt="image" src="https://github.com/user-attachments/assets/fbb1e38f-2e58-48c6-a40f-db535b0af460" />

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated.
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
