### PR TITLE
Remove deprecation notice of vault-ruby

### DIFF
--- a/content/vault/v1.16.x/content/api-docs/libraries.mdx
+++ b/content/vault/v1.16.x/content/api-docs/libraries.mdx
@@ -30,8 +30,6 @@ $ go get github.com/hashicorp/vault/api
 
 ### Ruby
 
-@include 'alerts/deprecated.mdx'
-
 - [Vault Ruby Client](https://github.com/hashicorp/vault-ruby)
 
 ```shell-session

--- a/content/vault/v1.16.x/content/docs/deprecation/index.mdx
+++ b/content/vault/v1.16.x/content/docs/deprecation/index.mdx
@@ -36,8 +36,6 @@ or raise a ticket with your support team.
 
 @include '../../../global/partials/deprecation/ldap-null-bind.mdx'
 
-@include 'deprecation/ruby-client-library.mdx'
-
 @include 'deprecation/active-directory-secrets-engine.mdx'
 
 @include 'deprecation/snowflake-password-auth.mdx'

--- a/content/vault/v1.17.x/content/api-docs/libraries.mdx
+++ b/content/vault/v1.17.x/content/api-docs/libraries.mdx
@@ -30,8 +30,6 @@ $ go get github.com/hashicorp/vault/api
 
 ### Ruby
 
-@include 'alerts/deprecated.mdx'
-
 - [Vault Ruby Client](https://github.com/hashicorp/vault-ruby)
 
 ```shell-session

--- a/content/vault/v1.17.x/content/docs/deprecation/index.mdx
+++ b/content/vault/v1.17.x/content/docs/deprecation/index.mdx
@@ -34,8 +34,6 @@ or raise a ticket with your support team.
   more information on the product support timeline.
 </EnterpriseAlert>
 
-@include 'deprecation/ruby-client-library.mdx'
-
 @include 'deprecation/active-directory-secrets-engine.mdx'
 
 @include 'deprecation/snowflake-password-auth.mdx'

--- a/content/vault/v1.18.x/content/api-docs/libraries.mdx
+++ b/content/vault/v1.18.x/content/api-docs/libraries.mdx
@@ -30,8 +30,6 @@ $ go get github.com/hashicorp/vault/api
 
 ### Ruby
 
-@include 'alerts/deprecated.mdx'
-
 - [Vault Ruby Client](https://github.com/hashicorp/vault-ruby)
 
 ```shell-session

--- a/content/vault/v1.18.x/content/docs/deprecation/index.mdx
+++ b/content/vault/v1.18.x/content/docs/deprecation/index.mdx
@@ -34,8 +34,6 @@ or raise a ticket with your support team.
   more information on the product support timeline.
 </EnterpriseAlert>
 
-@include 'deprecation/ruby-client-library.mdx'
-
 @include 'deprecation/active-directory-secrets-engine.mdx'
 
 @include 'deprecation/snowflake-password-auth.mdx'

--- a/content/vault/v1.19.x/content/api-docs/libraries.mdx
+++ b/content/vault/v1.19.x/content/api-docs/libraries.mdx
@@ -30,8 +30,6 @@ $ go get github.com/hashicorp/vault/api
 
 ### Ruby
 
-@include 'alerts/deprecated.mdx'
-
 - [Vault Ruby Client](https://github.com/hashicorp/vault-ruby)
 
 ```shell-session

--- a/content/vault/v1.19.x/content/docs/updates/deprecation.mdx
+++ b/content/vault/v1.19.x/content/docs/updates/deprecation.mdx
@@ -36,8 +36,6 @@ or raise a ticket with your support team.
 
 @include '../../../global/partials/deprecation/ldap-null-bind.mdx'
 
-@include 'deprecation/ruby-client-library.mdx'
-
 @include 'deprecation/snowflake-password-auth.mdx'
 
 </Tab>

--- a/content/vault/v1.20.x/content/api-docs/libraries.mdx
+++ b/content/vault/v1.20.x/content/api-docs/libraries.mdx
@@ -30,8 +30,6 @@ $ go get github.com/hashicorp/vault/api
 
 ### Ruby
 
-@include 'alerts/deprecated.mdx'
-
 - [Vault Ruby Client](https://github.com/hashicorp/vault-ruby)
 
 ```shell-session

--- a/content/vault/v1.20.x/content/docs/updates/deprecation.mdx
+++ b/content/vault/v1.20.x/content/docs/updates/deprecation.mdx
@@ -36,8 +36,6 @@ or raise a ticket with your support team.
 
 @include '../../../global/partials/deprecation/ldap-null-bind.mdx'
 
-@include 'deprecation/ruby-client-library.mdx'
-
 @include 'deprecation/snowflake-password-auth.mdx'
 
 </Tab>

--- a/content/vault/v1.21.x/content/api-docs/libraries.mdx
+++ b/content/vault/v1.21.x/content/api-docs/libraries.mdx
@@ -30,8 +30,6 @@ $ go get github.com/hashicorp/vault/api
 
 ### Ruby
 
-@include 'alerts/deprecated.mdx'
-
 - [Vault Ruby Client](https://github.com/hashicorp/vault-ruby)
 
 ```shell-session

--- a/content/vault/v1.21.x/content/docs/updates/deprecation.mdx
+++ b/content/vault/v1.21.x/content/docs/updates/deprecation.mdx
@@ -44,9 +44,7 @@ or raise a ticket with your support team.
 
 @include 'deprecation/list-allowed-parameters.mdx'
 
-## Removed 
-
-@include 'deprecation/ruby-client-library.mdx'
+## Removed
 
 @include 'deprecation/aws-field-change.mdx'
 


### PR DESCRIPTION
This client library is maintained by the ILM team at HashiCorp. 