### PR TITLE
Remove redundant  `stacks deployment-run cancel` options callout

### DIFF
--- a/content/terraform/v1.13.x/docs/cli/commands/stacks/deployment-run/cancel.mdx
+++ b/content/terraform/v1.13.x/docs/cli/commands/stacks/deployment-run/cancel.mdx
@@ -10,7 +10,7 @@ UUse the `terraform stacks deployment-run cancel` command to cancel a deployment
 ## Usage
 
 ```shell-session
-$ terraform stacks <global-stacks-flags> deployment-run cancel -deployment-run-id <value> <options>
+$ terraform stacks <global-stacks-flags> deployment-run cancel -deployment-run-id <value>
 ```
 
 ## Description

--- a/content/terraform/v1.14.x/docs/cli/commands/stacks/deployment-run/cancel.mdx
+++ b/content/terraform/v1.14.x/docs/cli/commands/stacks/deployment-run/cancel.mdx
@@ -10,7 +10,7 @@ UUse the `terraform stacks deployment-run cancel` command to cancel a deployment
 ## Usage
 
 ```shell-session
-$ terraform stacks <global-stacks-flags> deployment-run cancel -deployment-run-id <value> <options>
+$ terraform stacks <global-stacks-flags> deployment-run cancel -deployment-run-id <value>
 ```
 
 ## Description

--- a/content/terraform/v1.15.x (alpha)/docs/cli/commands/stacks/deployment-run/cancel.mdx
+++ b/content/terraform/v1.15.x (alpha)/docs/cli/commands/stacks/deployment-run/cancel.mdx
@@ -10,7 +10,7 @@ UUse the `terraform stacks deployment-run cancel` command to cancel a deployment
 ## Usage
 
 ```shell-session
-$ terraform stacks <global-stacks-flags> deployment-run cancel -deployment-run-id <value> <options>
+$ terraform stacks <global-stacks-flags> deployment-run cancel -deployment-run-id <value>
 ```
 
 ## Description


### PR DESCRIPTION
### What

Remove the `<options>` callout for the `terraform stacks deployment-run cancel` command

### Why

It's unneeded/misleading since there is only one options on the command, that's already given in the line.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
