### PR TITLE
feat: update older versions with default date in frontmatter for sentinel

### DIFF
--- a/content/sentinel/v0.13.x/content/sentinel/docs/changelog/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/changelog/index.mdx
@@ -7,8 +7,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/commands/apply.mdx
@@ -7,8 +7,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/commands/config.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/commands/config.mdx
@@ -7,8 +7,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/commands/fmt.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/commands/test.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/concepts/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/concepts/language.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -9,8 +9,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/consul/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/consul/index.mdx
@@ -8,8 +8,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/extending/dev.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/extending/dev.mdx
@@ -8,8 +8,8 @@ description: >-
   to launch the plugin.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Imports allow a Sentinel policy to access external data and add new functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/extending/install.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/extending/install.mdx
@@ -8,8 +8,8 @@ description: >-
   to launch the plugin.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/append.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/delete.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/error.mdx
@@ -7,8 +7,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/keys.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/length.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/print.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/range.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/functions/values.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/guides/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/guides/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: guides-index
 description: TODO Guides
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/decimal.mdx
@@ -7,8 +7,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/http.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/index.mdx
@@ -7,8 +7,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/json.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/runtime.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/strings.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/time.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/types.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/imports/units.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/internals/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/internals/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-internals
 description: Imports allow a Sentinel policy to access external data and add new functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/internals/plugins.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/internals/plugins.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-internals-plugins
 description: Imports allow a Sentinel policy to access external data and add new functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/arithmetic.mdx
@@ -7,8 +7,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/boolexpr.mdx
@@ -7,8 +7,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/conditionals.mdx
@@ -6,8 +6,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/functions.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/imports.mdx
@@ -7,8 +7,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/index.mdx
@@ -9,8 +9,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/lists.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/logging-errors.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/loops.mdx
@@ -7,8 +7,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/maps.mdx
@@ -7,8 +7,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/parameters.mdx
@@ -7,8 +7,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/scope.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/slices.mdx
@@ -7,8 +7,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/spec.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/undefined.mdx
@@ -7,8 +7,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/values.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/language/variables.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/nomad/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/nomad/index.mdx
@@ -8,8 +8,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/terraform/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/vault/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/vault/index.mdx
@@ -8,8 +8,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/basic.mdx
@@ -8,8 +8,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/debugging.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/index.mdx
@@ -9,8 +9,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/rules.mdx
@@ -8,8 +8,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/testing.mdx
@@ -7,8 +7,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/docs/writing/tracing.mdx
@@ -7,8 +7,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/install.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/logic.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/rules.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/intro/what/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/what/index.mdx
@@ -7,8 +7,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.13.x/content/sentinel/intro/why/index.mdx
+++ b/content/sentinel/v0.13.x/content/sentinel/intro/why/index.mdx
@@ -7,8 +7,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/changelog/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/changelog/index.mdx
@@ -7,8 +7,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/commands/apply.mdx
@@ -7,8 +7,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/commands/config.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/commands/config.mdx
@@ -7,8 +7,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/commands/fmt.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/commands/test.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/concepts/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/concepts/language.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -9,8 +9,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/consul/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/consul/index.mdx
@@ -8,8 +8,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/extending/dev.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/extending/dev.mdx
@@ -8,8 +8,8 @@ description: >-
   to launch the plugin.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Imports allow a Sentinel policy to access external data and add new functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/extending/install.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/extending/install.mdx
@@ -8,8 +8,8 @@ description: >-
   to launch the plugin.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/append.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/delete.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/error.mdx
@@ -7,8 +7,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/keys.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/length.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/print.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/range.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/functions/values.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/guides/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/guides/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: guides-index
 description: TODO Guides
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/decimal.mdx
@@ -7,8 +7,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/http.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/index.mdx
@@ -7,8 +7,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/json.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/runtime.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/strings.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/time.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/types.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/imports/units.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/internals/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/internals/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-internals
 description: Imports allow a Sentinel policy to access external data and add new functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/internals/plugins.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/internals/plugins.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-internals-plugins
 description: Imports allow a Sentinel policy to access external data and add new functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/arithmetic.mdx
@@ -7,8 +7,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/boolexpr.mdx
@@ -7,8 +7,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/collection-operations.mdx
@@ -6,8 +6,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/conditionals.mdx
@@ -6,8 +6,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/functions.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/imports.mdx
@@ -7,8 +7,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/index.mdx
@@ -9,8 +9,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/lists.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/logging-errors.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/loops.mdx
@@ -7,8 +7,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/maps.mdx
@@ -7,8 +7,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/parameters.mdx
@@ -7,8 +7,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/scope.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/slices.mdx
@@ -7,8 +7,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/spec.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/undefined.mdx
@@ -7,8 +7,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/values.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/language/variables.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/nomad/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/nomad/index.mdx
@@ -8,8 +8,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/terraform/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/vault/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/vault/index.mdx
@@ -8,8 +8,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/basic.mdx
@@ -8,8 +8,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/debugging.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/index.mdx
@@ -9,8 +9,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/rules.mdx
@@ -8,8 +8,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/testing.mdx
@@ -7,8 +7,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/docs/writing/tracing.mdx
@@ -7,8 +7,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/install.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/logic.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/rules.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/intro/what/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/what/index.mdx
@@ -7,8 +7,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.14.x/content/sentinel/intro/why/index.mdx
+++ b/content/sentinel/v0.14.x/content/sentinel/intro/why/index.mdx
@@ -7,8 +7,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/changelog/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/changelog/index.mdx
@@ -7,8 +7,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/commands/apply.mdx
@@ -7,8 +7,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/commands/config.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/commands/config.mdx
@@ -7,8 +7,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/commands/fmt.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/commands/test.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/concepts/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/concepts/language.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -9,8 +9,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/consul/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/consul/index.mdx
@@ -8,8 +8,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/extending/internals.mdx
@@ -6,8 +6,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/extending/modules.mdx
@@ -7,8 +7,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/extending/plugins.mdx
@@ -8,8 +8,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/append.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/delete.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/error.mdx
@@ -7,8 +7,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/keys.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/length.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/print.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/range.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/functions/values.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/guides/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/guides/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: guides-index
 description: TODO Guides
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/decimal.mdx
@@ -7,8 +7,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/http.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/index.mdx
@@ -7,8 +7,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/json.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/runtime.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/strings.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/time.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/types.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/imports/units.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/arithmetic.mdx
@@ -7,8 +7,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/boolexpr.mdx
@@ -7,8 +7,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/collection-operations.mdx
@@ -6,8 +6,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/conditionals.mdx
@@ -6,8 +6,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/functions.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/imports.mdx
@@ -7,8 +7,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/index.mdx
@@ -9,8 +9,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/lists.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/logging-errors.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/loops.mdx
@@ -7,8 +7,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/maps.mdx
@@ -7,8 +7,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/parameters.mdx
@@ -7,8 +7,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/scope.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/slices.mdx
@@ -7,8 +7,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/spec.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/undefined.mdx
@@ -7,8 +7,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/values.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/language/variables.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/nomad/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/nomad/index.mdx
@@ -8,8 +8,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/terraform/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/terraform/index.mdx
@@ -7,8 +7,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/vault/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/vault/index.mdx
@@ -8,8 +8,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/basic.mdx
@@ -8,8 +8,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/debugging.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/index.mdx
@@ -9,8 +9,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/rules.mdx
@@ -8,8 +8,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/testing.mdx
@@ -7,8 +7,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/docs/writing/tracing.mdx
@@ -7,8 +7,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/install.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/logic.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/rules.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/intro/what/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/what/index.mdx
@@ -7,8 +7,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.15.x/content/sentinel/intro/why/index.mdx
+++ b/content/sentinel/v0.15.x/content/sentinel/intro/why/index.mdx
@@ -7,8 +7,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/changelog.mdx
@@ -7,8 +7,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/commands/apply.mdx
@@ -7,8 +7,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/commands/fmt.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/commands/test.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/concepts/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/concepts/language.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -9,8 +9,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/configuration/index.mdx
@@ -7,8 +7,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -7,8 +7,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/consul.mdx
@@ -8,8 +8,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/extending/internals.mdx
@@ -6,8 +6,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/extending/modules.mdx
@@ -7,8 +7,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/extending/plugins.mdx
@@ -8,8 +8,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/append.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/delete.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/error.mdx
@@ -7,8 +7,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/keys.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/length.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/print.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/range.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/functions/values.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/guides/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/guides/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: guides-index
 description: TODO Guides
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/decimal.mdx
@@ -7,8 +7,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/http.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/index.mdx
@@ -7,8 +7,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/json.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/runtime.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/strings.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/time.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/types.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/units.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/imports/version.mdx
@@ -7,8 +7,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/arithmetic.mdx
@@ -7,8 +7,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/boolexpr.mdx
@@ -7,8 +7,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/collection-operations.mdx
@@ -6,8 +6,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/conditionals.mdx
@@ -6,8 +6,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/functions.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/imports.mdx
@@ -7,8 +7,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/index.mdx
@@ -9,8 +9,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/lists.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/logging-errors.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/loops.mdx
@@ -7,8 +7,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/maps.mdx
@@ -7,8 +7,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/parameters.mdx
@@ -7,8 +7,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/scope.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/slices.mdx
@@ -7,8 +7,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/spec.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/undefined.mdx
@@ -7,8 +7,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/values.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/language/variables.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/nomad.mdx
@@ -8,8 +8,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/terraform.mdx
@@ -7,8 +7,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/vault.mdx
@@ -8,8 +8,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/basic.mdx
@@ -8,8 +8,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/debugging.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/index.mdx
@@ -9,8 +9,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/rules.mdx
@@ -8,8 +8,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/testing.mdx
@@ -7,8 +7,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/docs/writing/tracing.mdx
@@ -7,8 +7,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/install.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/logic.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/rules.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/what.mdx
@@ -7,8 +7,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.16.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.16.x/content/sentinel/intro/why.mdx
@@ -7,8 +7,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/changelog.mdx
@@ -7,8 +7,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/commands/apply.mdx
@@ -7,8 +7,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/commands/fmt.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/commands/test.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/concepts/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/concepts/language.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -9,8 +9,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/configuration/index.mdx
@@ -7,8 +7,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -7,8 +7,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/consul.mdx
@@ -8,8 +8,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/extending/internals.mdx
@@ -6,8 +6,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/extending/modules.mdx
@@ -7,8 +7,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/extending/plugins.mdx
@@ -8,8 +8,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/append.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/delete.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/error.mdx
@@ -7,8 +7,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/keys.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/length.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/print.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/range.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/functions/values.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/guides.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/guides.mdx
@@ -4,8 +4,8 @@ sidebar_current: guides-index
 description: TODO Guides
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/base64.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/decimal.mdx
@@ -7,8 +7,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/http.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/index.mdx
@@ -7,8 +7,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/json.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/runtime.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/strings.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/time.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/types.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/units.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/imports/version.mdx
@@ -7,8 +7,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/arithmetic.mdx
@@ -7,8 +7,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/boolexpr.mdx
@@ -7,8 +7,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/collection-operations.mdx
@@ -6,8 +6,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/conditionals.mdx
@@ -6,8 +6,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/functions.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/imports.mdx
@@ -7,8 +7,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/index.mdx
@@ -9,8 +9,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/lists.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/logging-errors.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/loops.mdx
@@ -7,8 +7,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/maps.mdx
@@ -7,8 +7,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/parameters.mdx
@@ -7,8 +7,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/scope.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/slices.mdx
@@ -7,8 +7,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/spec.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/undefined.mdx
@@ -7,8 +7,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/values.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/language/variables.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/nomad.mdx
@@ -8,8 +8,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/terraform.mdx
@@ -7,8 +7,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/vault.mdx
@@ -8,8 +8,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/basic.mdx
@@ -8,8 +8,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/debugging.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/index.mdx
@@ -9,8 +9,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/rules.mdx
@@ -8,8 +8,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/testing.mdx
@@ -7,8 +7,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/docs/writing/tracing.mdx
@@ -7,8 +7,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/imports.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/install.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/logic.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/rules.mdx
@@ -5,8 +5,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/what.mdx
@@ -7,8 +7,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.17.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.17.x/content/sentinel/intro/why.mdx
@@ -7,8 +7,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/changelog.mdx
@@ -6,8 +6,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/commands/apply.mdx
@@ -6,8 +6,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/commands/test.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/concepts/language.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,8 +8,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/configuration/index.mdx
@@ -6,8 +6,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,8 +6,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/consul.mdx
@@ -7,8 +7,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/extending/internals.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/extending/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,8 +7,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/append.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/delete.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/error.mdx
@@ -6,8 +6,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/keys.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/length.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/print.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/range.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/functions/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/base64.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,8 +6,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/http.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/index.mdx
@@ -6,8 +6,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/json.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/strings.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/time.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/types.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/units.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/imports/version.mdx
@@ -6,8 +6,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,8 +6,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,8 +6,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,8 +5,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,8 +5,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/functions.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/imports.mdx
@@ -6,8 +6,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/index.mdx
@@ -8,8 +8,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/loops.mdx
@@ -6,8 +6,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/maps.mdx
@@ -6,8 +6,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/parameters.mdx
@@ -6,8 +6,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/rules.mdx
@@ -6,8 +6,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/scope.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/slices.mdx
@@ -6,8 +6,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/spec.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/undefined.mdx
@@ -6,8 +6,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/language/variables.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/nomad.mdx
@@ -7,8 +7,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/terraform.mdx
@@ -6,8 +6,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/vault.mdx
@@ -7,8 +7,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/basic.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/testing.mdx
@@ -6,8 +6,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,8 +6,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/what.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.18.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.18.x/content/sentinel/intro/why.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/changelog.mdx
@@ -6,8 +6,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/commands/apply.mdx
@@ -6,8 +6,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/commands/test.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/concepts/language.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,8 +8,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/configuration/index.mdx
@@ -6,8 +6,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/configuration/overrides.mdx
@@ -6,8 +6,8 @@ description: >-
   Override files merge additional settings into existing configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,8 +6,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/consul.mdx
@@ -7,8 +7,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/extending/internals.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/extending/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,8 +7,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/extending/static-imports.mdx
@@ -6,8 +6,8 @@ description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/append.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/delete.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/error.mdx
@@ -6,8 +6,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/keys.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/length.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/print.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/range.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/functions/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/base64.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,8 +6,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/http.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/index.mdx
@@ -6,8 +6,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/json.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/strings.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/time.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/types.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/units.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/imports/version.mdx
@@ -6,8 +6,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,8 +6,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,8 +6,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,8 +5,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,8 +5,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/functions.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/imports.mdx
@@ -6,8 +6,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/index.mdx
@@ -8,8 +8,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/loops.mdx
@@ -6,8 +6,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/maps.mdx
@@ -6,8 +6,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/parameters.mdx
@@ -6,8 +6,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/rules.mdx
@@ -6,8 +6,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/scope.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/slices.mdx
@@ -6,8 +6,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/spec.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/undefined.mdx
@@ -6,8 +6,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/language/variables.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/nomad.mdx
@@ -7,8 +7,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/terraform.mdx
@@ -6,8 +6,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/vault.mdx
@@ -7,8 +7,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/basic.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/testing.mdx
@@ -6,8 +6,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,8 +6,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/what.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.19.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.19.x/content/sentinel/intro/why.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/changelog.mdx
@@ -6,8 +6,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/commands/apply.mdx
@@ -6,8 +6,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/commands/test.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/concepts/language.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,8 +8,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/configuration/index.mdx
@@ -6,8 +6,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/configuration/overrides.mdx
@@ -6,8 +6,8 @@ description: >-
   Override files merge additional settings into existing configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,8 +6,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/consul.mdx
@@ -7,8 +7,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/extending/internals.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/extending/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,8 +7,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/extending/static-imports.mdx
@@ -6,8 +6,8 @@ description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/append.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/delete.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/error.mdx
@@ -6,8 +6,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/keys.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/length.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/print.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/range.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/functions/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/base64.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,8 +6,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/http.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/index.mdx
@@ -6,8 +6,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/json.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/strings.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/time.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/types.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/units.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/imports/version.mdx
@@ -6,8 +6,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,8 +6,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,8 +6,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,8 +5,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,8 +5,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/functions.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/imports.mdx
@@ -6,8 +6,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/index.mdx
@@ -8,8 +8,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/loops.mdx
@@ -6,8 +6,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/maps.mdx
@@ -6,8 +6,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/parameters.mdx
@@ -6,8 +6,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/rules.mdx
@@ -6,8 +6,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/scope.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/slices.mdx
@@ -6,8 +6,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/spec.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/undefined.mdx
@@ -6,8 +6,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/language/variables.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/nomad.mdx
@@ -7,8 +7,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/terraform.mdx
@@ -6,8 +6,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/vault.mdx
@@ -7,8 +7,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/basic.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/testing.mdx
@@ -6,8 +6,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,8 +6,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/what.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.20.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.20.x/content/sentinel/intro/why.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/changelog.mdx
@@ -6,8 +6,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/commands/apply.mdx
@@ -6,8 +6,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/commands/test.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/concepts/language.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,8 +8,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/configuration/index.mdx
@@ -6,8 +6,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/configuration/overrides.mdx
@@ -6,8 +6,8 @@ description: >-
   Override files merge additional settings into existing configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,8 +6,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/consul.mdx
@@ -7,8 +7,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/extending/internals.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/extending/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,8 +7,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/extending/static-imports.mdx
@@ -6,8 +6,8 @@ description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/append.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/delete.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/error.mdx
@@ -6,8 +6,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/keys.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/length.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/print.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/range.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/functions/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/base64.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,8 +6,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/http.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/index.mdx
@@ -6,8 +6,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/json.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/strings.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/time.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/types.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/units.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/imports/version.mdx
@@ -6,8 +6,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,8 +6,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,8 +6,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,8 +5,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,8 +5,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/functions.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/imports.mdx
@@ -6,8 +6,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/index.mdx
@@ -8,8 +8,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/loops.mdx
@@ -6,8 +6,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/maps.mdx
@@ -6,8 +6,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/parameters.mdx
@@ -6,8 +6,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/rules.mdx
@@ -6,8 +6,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/scope.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/slices.mdx
@@ -6,8 +6,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/spec.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/undefined.mdx
@@ -6,8 +6,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/language/variables.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/nomad.mdx
@@ -7,8 +7,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/terraform.mdx
@@ -6,8 +6,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/vault.mdx
@@ -7,8 +7,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/basic.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/testing.mdx
@@ -6,8 +6,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,8 +6,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/what.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.21.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.21.x/content/sentinel/intro/why.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/changelog.mdx
@@ -6,8 +6,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/commands/apply.mdx
@@ -6,8 +6,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/commands/test.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/concepts/language.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,8 +8,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/configuration/index.mdx
@@ -6,8 +6,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/configuration/overrides.mdx
@@ -6,8 +6,8 @@ description: >-
   Override files merge additional settings into existing configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,8 +6,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/consul.mdx
@@ -7,8 +7,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/extending/internals.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/extending/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,8 +7,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/extending/static-imports.mdx
@@ -6,8 +6,8 @@ description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/append.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/delete.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/error.mdx
@@ -6,8 +6,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/keys.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/length.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/print.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/range.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/functions/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/base64.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,8 +6,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/http.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/index.mdx
@@ -6,8 +6,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/json.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/strings.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/time.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/types.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/units.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/imports/version.mdx
@@ -6,8 +6,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,8 +6,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,8 +6,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,8 +5,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,8 +5,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/functions.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/imports.mdx
@@ -6,8 +6,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/index.mdx
@@ -8,8 +8,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/loops.mdx
@@ -6,8 +6,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/maps.mdx
@@ -6,8 +6,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/parameters.mdx
@@ -6,8 +6,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/rules.mdx
@@ -6,8 +6,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/scope.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/slices.mdx
@@ -6,8 +6,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/spec.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/undefined.mdx
@@ -6,8 +6,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/language/variables.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/nomad.mdx
@@ -7,8 +7,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/terraform.mdx
@@ -6,8 +6,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/vault.mdx
@@ -7,8 +7,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/basic.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/testing.mdx
@@ -6,8 +6,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,8 +6,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/what.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.22.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.22.x/content/sentinel/intro/why.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/changelog.mdx
@@ -6,8 +6,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/commands/apply.mdx
@@ -6,8 +6,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/commands/test.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/concepts/language.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,8 +8,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/configuration/index.mdx
@@ -6,8 +6,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/configuration/overrides.mdx
@@ -6,8 +6,8 @@ description: >-
   Override files merge additional settings into existing configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,8 +6,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/consul.mdx
@@ -7,8 +7,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/extending/internals.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/extending/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,8 +7,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/extending/static-imports.mdx
@@ -6,8 +6,8 @@ description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -8,8 +8,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -8,8 +8,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/append.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/delete.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/error.mdx
@@ -6,8 +6,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/keys.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/length.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/print.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/range.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/functions/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/base64.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,8 +6,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/http.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/index.mdx
@@ -6,8 +6,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/json.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/strings.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/time.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/types.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/units.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/imports/version.mdx
@@ -6,8 +6,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,8 +6,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,8 +6,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,8 +5,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,8 +5,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/functions.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/imports.mdx
@@ -6,8 +6,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/index.mdx
@@ -8,8 +8,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/loops.mdx
@@ -6,8 +6,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/maps.mdx
@@ -6,8 +6,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/parameters.mdx
@@ -6,8 +6,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/rules.mdx
@@ -6,8 +6,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/scope.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/slices.mdx
@@ -6,8 +6,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/spec.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/undefined.mdx
@@ -6,8 +6,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/language/variables.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/nomad.mdx
@@ -7,8 +7,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/terraform.mdx
@@ -6,8 +6,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/vault.mdx
@@ -7,8 +7,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/basic.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/testing.mdx
@@ -6,8 +6,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,8 +6,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/what.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.23.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.23.x/content/sentinel/intro/why.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/changelog.mdx
@@ -6,8 +6,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/commands/apply.mdx
@@ -6,8 +6,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/commands/test.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/concepts/language.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,8 +8,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/configuration/index.mdx
@@ -6,8 +6,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/configuration/overrides.mdx
@@ -6,8 +6,8 @@ description: >-
   Override files merge additional settings into existing configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,8 +6,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/consul.mdx
@@ -7,8 +7,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/extending/internals.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/extending/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,8 +7,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/extending/static-imports.mdx
@@ -6,8 +6,8 @@ description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -8,8 +8,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -8,8 +8,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/append.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/delete.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/error.mdx
@@ -6,8 +6,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/keys.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/length.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/print.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/range.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/functions/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/base64.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,8 +6,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/http.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/index.mdx
@@ -6,8 +6,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/json.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/strings.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/time.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/types.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/units.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/imports/version.mdx
@@ -6,8 +6,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,8 +6,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,8 +6,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,8 +5,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,8 +5,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/functions.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/imports.mdx
@@ -6,8 +6,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/index.mdx
@@ -8,8 +8,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/loops.mdx
@@ -6,8 +6,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/maps.mdx
@@ -6,8 +6,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/parameters.mdx
@@ -6,8 +6,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/rules.mdx
@@ -6,8 +6,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/scope.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/slices.mdx
@@ -6,8 +6,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/spec.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/undefined.mdx
@@ -6,8 +6,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/language/variables.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/nomad.mdx
@@ -7,8 +7,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/terraform.mdx
@@ -6,8 +6,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/vault.mdx
@@ -7,8 +7,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/basic.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/testing.mdx
@@ -6,8 +6,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,8 +6,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/what.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.24.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.24.x/content/sentinel/intro/why.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/changelog.mdx
@@ -6,8 +6,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/commands/apply.mdx
@@ -6,8 +6,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/commands/test.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/concepts/language.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,8 +8,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/configuration/index.mdx
@@ -6,8 +6,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/configuration/overrides.mdx
@@ -6,8 +6,8 @@ description: >-
   Override files merge additional settings into existing configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,8 +6,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/consul.mdx
@@ -7,8 +7,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/extending/internals.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/extending/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,8 +7,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/extending/static-imports.mdx
@@ -6,8 +6,8 @@ description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -8,8 +8,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -8,8 +8,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/append.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/delete.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/error.mdx
@@ -6,8 +6,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/keys.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/length.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/print.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/range.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/functions/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/base64.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,8 +6,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/http.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/index.mdx
@@ -6,8 +6,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/json.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/strings.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/time.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/types.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/units.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/imports/version.mdx
@@ -6,8 +6,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,8 +6,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,8 +6,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,8 +5,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,8 +5,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/functions.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/imports.mdx
@@ -6,8 +6,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/index.mdx
@@ -8,8 +8,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/loops.mdx
@@ -6,8 +6,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/maps.mdx
@@ -6,8 +6,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/parameters.mdx
@@ -6,8 +6,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/rules.mdx
@@ -6,8 +6,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/scope.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/slices.mdx
@@ -6,8 +6,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/spec.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/undefined.mdx
@@ -6,8 +6,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/language/variables.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/nomad.mdx
@@ -7,8 +7,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/terraform.mdx
@@ -6,8 +6,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/vault.mdx
@@ -7,8 +7,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/basic.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/testing.mdx
@@ -6,8 +6,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,8 +6,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/what.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.25.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.25.x/content/sentinel/intro/why.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/changelog.mdx
@@ -6,8 +6,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/commands/apply.mdx
@@ -6,8 +6,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/commands/test.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/concepts/language.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,8 +8,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/configuration/index.mdx
@@ -6,8 +6,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/configuration/overrides.mdx
@@ -6,8 +6,8 @@ description: >-
   Override files merge additional settings into existing configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,8 +6,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/consul.mdx
@@ -7,8 +7,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/extending/internals.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/extending/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,8 +7,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/extending/static-imports.mdx
@@ -6,8 +6,8 @@ description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -8,8 +8,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -8,8 +8,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/append.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/compare.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/compare.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-compare
 description: The built-in function `compare` compares two values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/delete.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/error.mdx
@@ -6,8 +6,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/keys.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/length.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/print.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/range.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/functions/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/base64.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/collection/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/collection/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-collection
 description: The collection import provides useful helpers for working with maps and lists.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/collection/lists.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/collection/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-collection-lists
 description: The collection/lists import provides useful helpers for working with lists.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/collection/maps.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/collection/maps.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-collection-maps
 description: The collection/maps import provides useful helpers for working with maps.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,8 +6,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/http.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/index.mdx
@@ -6,8 +6,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/json.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/strings.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/time.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/types.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/units.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/imports/version.mdx
@@ -6,8 +6,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,8 +6,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,8 +6,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,8 +5,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,8 +5,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/functions.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/imports.mdx
@@ -6,8 +6,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/index.mdx
@@ -8,8 +8,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/loops.mdx
@@ -6,8 +6,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/maps.mdx
@@ -6,8 +6,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/parameters.mdx
@@ -6,8 +6,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/rules.mdx
@@ -6,8 +6,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/scope.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/slices.mdx
@@ -6,8 +6,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/spec.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/undefined.mdx
@@ -6,8 +6,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/language/variables.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/nomad.mdx
@@ -7,8 +7,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/terraform.mdx
@@ -6,8 +6,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/vault.mdx
@@ -7,8 +7,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/basic.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/testing.mdx
@@ -6,8 +6,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,8 +6,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/what.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.26.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.26.x/content/sentinel/intro/why.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/changelog.mdx
@@ -6,8 +6,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/commands/apply.mdx
@@ -6,8 +6,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/commands/test.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/concepts/language.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,8 +8,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/configuration/index.mdx
@@ -6,8 +6,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/configuration/overrides.mdx
@@ -6,8 +6,8 @@ description: >-
   Override files merge additional settings into existing configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,8 +6,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/consul.mdx
@@ -7,8 +7,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/extending/internals.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/extending/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,8 +7,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/extending/static-imports.mdx
@@ -6,8 +6,8 @@ description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -8,8 +8,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -8,8 +8,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/append.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/compare.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/compare.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-compare
 description: The built-in function `compare` compares two values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/delete.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/error.mdx
@@ -6,8 +6,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/keys.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/length.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/print.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/range.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/functions/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/base64.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/collection/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/collection/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-collection
 description: The collection import provides useful helpers for working with maps and lists.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/collection/lists.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/collection/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-collection-lists
 description: The collection/lists import provides useful helpers for working with lists.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/collection/maps.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/collection/maps.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-collection-maps
 description: The collection/maps import provides useful helpers for working with maps.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,8 +6,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/http.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/index.mdx
@@ -6,8 +6,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/json.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/strings.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/time.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/types.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/units.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/imports/version.mdx
@@ -6,8 +6,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,8 +6,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,8 +6,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,8 +5,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,8 +5,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/functions.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/imports.mdx
@@ -6,8 +6,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/index.mdx
@@ -8,8 +8,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/loops.mdx
@@ -6,8 +6,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/maps.mdx
@@ -6,8 +6,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/parameters.mdx
@@ -6,8 +6,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/rules.mdx
@@ -6,8 +6,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/scope.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/slices.mdx
@@ -6,8 +6,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/spec.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/undefined.mdx
@@ -6,8 +6,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/language/variables.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/nomad.mdx
@@ -7,8 +7,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/terraform.mdx
@@ -6,8 +6,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/vault.mdx
@@ -7,8 +7,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/basic.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/testing.mdx
@@ -6,8 +6,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,8 +6,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/first-policy.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/first-policy.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-first
 description: Let's begin by writing a working Sentinel policy.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/imports.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-imports
 description: Imports enable Sentinel to access external data and functions.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-overview
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/install.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/install.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-install
 description: The first step to using Sentinel is to get the CLI installed.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/logic.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/logic.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-logic
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/next-steps.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/next-steps.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-nextsteps
 description: That concludes the getting started guide for Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/rules.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/rules.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-rules
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/testing.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/getting-started/testing.mdx
@@ -4,8 +4,8 @@ sidebar_current: intro-getting-started-testing
 description: A rule describes a set of conditions that result in either true or false.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/intro/index.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/index.mdx
@@ -6,8 +6,8 @@ description: >-
   Sentinel is a language and framework for policy built to be embedded in
   existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/intro/what.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/what.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.27.x/content/sentinel/intro/why.mdx
+++ b/content/sentinel/v0.27.x/content/sentinel/intro/why.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/changelog.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/changelog.mdx
@@ -6,8 +6,8 @@ description: >-
   for the latest updates.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/commands/apply.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/commands/apply.mdx
@@ -6,8 +6,8 @@ description: >-
   development purposes.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/commands/fmt.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/commands/fmt.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-fmt
 description: The `sentinel fmt` command formats a policy source to a canonical format.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/commands/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/commands/index.mdx
@@ -6,8 +6,8 @@ description: >-
   testing policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/commands/test.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/commands/test.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-commands-test
 description: The `sentinel test` command runs policies against the Sentinel test framework.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/concepts/enforcement-levels.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/concepts/enforcement-levels.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-levels
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/concepts/imports.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/concepts/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/concepts/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/concepts/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/concepts/language.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/concepts/language.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-concepts-language
 description: Basic concepts that are important to understand for Sentinel usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/concepts/policy-as-code.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/concepts/policy-as-code.mdx
@@ -8,8 +8,8 @@ description: >-
   automated testing, and automated deployment.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/configuration/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/configuration/index.mdx
@@ -6,8 +6,8 @@ description: >-
   behavior of the simulator during apply and test operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/configuration/overrides.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/configuration/overrides.mdx
@@ -6,8 +6,8 @@ description: >-
   Override files merge additional settings into existing configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/configuration/remote-sources.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/configuration/remote-sources.mdx
@@ -6,8 +6,8 @@ description: >-
   source attribute on policy and module blocks.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/consul.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/consul.mdx
@@ -7,8 +7,8 @@ description: >-
   the KV Store.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/extending/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/extending/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-extending
 description: Learn how to create your own Sentinel imports to extend Sentinel's functionality.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/extending/internals.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/extending/internals.mdx
@@ -5,8 +5,8 @@ sidebar_current: docs-extending-internals
 description: This Section covers some details about Sentinel's import internals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/extending/modules.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/extending/modules.mdx
@@ -6,8 +6,8 @@ description: >-
   Modules allow you to re-use Sentinel code as an import.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/extending/plugins.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/extending/plugins.mdx
@@ -7,8 +7,8 @@ description: >-
   extend Sentinel in ways not normally possible with policy code alone.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/extending/static-imports.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/extending/static-imports.mdx
@@ -6,8 +6,8 @@ description: >-
   Static imports allow you to write imports that use static data files.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features
 description: Learn how features can enhance the Sentinel runtime by enabling further capabilities.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform
 description: Learn about the terraform feature and its capabilities.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfconfig-v1.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-config-v1
 description: The tfconfig/v1 import provides access to a Terraform configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfconfig-v2.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfconfig-v2
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfplan-v1.mdx
@@ -8,8 +8,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfplan-v2.mdx
@@ -8,8 +8,8 @@ description: >-
   infrastructure to reach the desired state represented by the configuration.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfstate-v1.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfstate-v1
 description: The tfstate/v1 import provides access to a Terraform state.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/features/terraform/tfstate-v2.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-features-terraform-tfstate-v2
 description: The tfstate/v2 import provides access to a Terraform state.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/append.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/append.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-append
 description: The built-in function `append` appends a value to the end of a list.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/compare.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/compare.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-compare
 description: The built-in function `compare` compares two values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/delete.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/delete.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-delete
 description: The built-in function `delete` deletes an element from a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/error.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/error.mdx
@@ -6,8 +6,8 @@ description: >-
   message.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/keys.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/keys.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-keys
 description: The built-in function `keys` returns the keys of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/length.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/length.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-length
 description: Builtin functions are functions that are available in all Sentinel policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/print.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/print.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-print
 description: The built-in function `print` is used for logging and debugging.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/range.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/range.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-range
 description: The built-in function `range` returns a list of numbers in a range.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/functions/values.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/functions/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-funcs-values
 description: The built-in function `values` returns the values of a map.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/base64.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/base64.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-base64
 description: The base64 import enables a Sentinel policy to encode and decode Base64 values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/collection/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/collection/index.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-collection
 description: The collection import provides useful helpers for working with maps and lists.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/collection/lists.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/collection/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-collection-lists
 description: The collection/lists import provides useful helpers for working with lists.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/collection/maps.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/collection/maps.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-collection-maps
 description: The collection/maps import provides useful helpers for working with maps.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/decimal.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/decimal.mdx
@@ -6,8 +6,8 @@ description: |-
   as decimals.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/http.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-http
 description: The http import enables the use of HTTP-accessible data from outside the runtime in Sentinel policy rules.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/index.mdx
@@ -6,8 +6,8 @@ description: >-
   policies.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/json.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/json.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-json
 description: The json import enables a Sentinel policy to parse and access a JSON document.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/runtime.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/runtime.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-runtime
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/sockaddr.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/sockaddr.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-sockaddr
 description: The sockaddr import makes working with IP addresses easy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/strings.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/strings.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-strings
 description: The strings import exposes common string operations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/time.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/time.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-time
 description: The time import provides access to the execution time and time functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/types.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/types.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-types
 description: The types import enables a Sentinel policy to parse an object's type.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/units.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/units.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-imports-units
 description: The runtime import contains various information about the Sentinel runtime.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/imports/version.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/imports/version.mdx
@@ -6,8 +6,8 @@ description: |-
   and verifying versions against a set of constraints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/index.mdx
@@ -5,8 +5,8 @@ sidebar_current: 'docs-home'
 description: |-
   Sentinel is a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/intro.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/intro.mdx
@@ -6,8 +6,8 @@ description: >-
   existing software to enable fine-grained, logic-based policy decisions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/arithmetic.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/arithmetic.mdx
@@ -6,8 +6,8 @@ description: >-
   supports sum, difference, product, quotient, and remainder.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/boolexpr.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/boolexpr.mdx
@@ -6,8 +6,8 @@ description: >-
   result of a combination of one or more comparisons and logical operators.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/collection-operations.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/collection-operations.mdx
@@ -5,8 +5,8 @@ description: |-
   Operations for interacting with collections (list, map).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/conditionals.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/conditionals.mdx
@@ -5,8 +5,8 @@ description: |-
   Conditional statements allow your policy to behave differently depending on a condition.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/functions.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/functions.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-functions
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/imports.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/imports.mdx
@@ -6,8 +6,8 @@ description: >-
   data and functions.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/index.mdx
@@ -8,8 +8,8 @@ description: |-
   formal programming experience.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/lists.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/lists.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-lists
 description: Lists are a collection of zero or more values.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/logging-errors.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/logging-errors.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-log
 description: The built-in functions `print` and `error` can be used for logging and errors.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/loops.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/loops.mdx
@@ -6,8 +6,8 @@ description: >-
   collection or for some fixed number of times.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-10-10T13:09:20-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/maps.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/maps.mdx
@@ -6,8 +6,8 @@ description: >-
   storing values that are looked up by a unique key.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/parameters.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/parameters.mdx
@@ -6,8 +6,8 @@ description: >-
   to be supplied by the calling application, in addition to any default value.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/rules.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/rules.mdx
@@ -6,8 +6,8 @@ description: >-
   passing or failing (true or false).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/scope.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/scope.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-scope
 description: Functions allow you to create reusable code to perform computations.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/slices.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/slices.mdx
@@ -6,8 +6,8 @@ description: >-
   string or list, respectively.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/spec.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/spec.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-spec
 description: This is the specification for the Sentinel policy language.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/undefined.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/undefined.mdx
@@ -6,8 +6,8 @@ description: >-
   unknown value. Any operation on an `undefined` value results in `undefined`.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/values.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/values.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-values
 description: Values are the data that Sentinel policies operate on.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/language/variables.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/language/variables.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-language-vars
 description: Variables store values that can be used later.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/nomad.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/nomad.mdx
@@ -7,8 +7,8 @@ description: >-
   submission (creation, update).
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/terraform.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/terraform.mdx
@@ -6,8 +6,8 @@ description: >-
   on Terraform configurations, states, and plans.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/vault.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/vault.mdx
@@ -7,8 +7,8 @@ description: >-
   to enable complex, flexible policies across identities and endpoints.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/why.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/why.mdx
@@ -6,8 +6,8 @@ description: >-
   with Sentinel.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/basic.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/basic.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/debugging.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/debugging.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-debugging
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/imports.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/imports.mdx
@@ -4,8 +4,8 @@ sidebar_current: docs-writing-imports
 description: Imports enable policy decision based on arbitrary external information.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/index.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/index.mdx
@@ -8,8 +8,8 @@ description: >-
   Basic concepts that are important to understand for Vault usage.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/rules.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/rules.mdx
@@ -7,8 +7,8 @@ description: >-
   Sentinel policies to get started.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/testing.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/testing.mdx
@@ -6,8 +6,8 @@ description: >-
   expected.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/sentinel/v0.28.x/content/sentinel/docs/writing/tracing.mdx
+++ b/content/sentinel/v0.28.x/content/sentinel/docs/writing/tracing.mdx
@@ -6,8 +6,8 @@ description: >-
   policy.
 layout: docs
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-09-17T13:35:48-05:00
-last_modified: 2025-09-17T13:35:48-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 


### PR DESCRIPTION
### Description

This PR adds a default date for the metadata for older versions of the sentinel documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715. Older docs versions have been updated with default dates for the versions specified in [this spreadsheet](https://docs.google.com/spreadsheets/d/16FpDhKA4ZBOVtxHWw2ebMjS56mdSask1FBCVecn9QnQ/edit?gid=0#gid=0)

### Testing

Check that sentinel docs look normal in the preview: https://unified-docs-frontend-preview-f4w6hmain-hashicorp.vercel.app/sentinel/docs