### PR TITLE
feat: add default date in frontmatter for older versions of terraform-migrate docs

### DIFF
--- a/content/terraform-migrate/v1.0.x/docs/migrate/authenticate.mdx
+++ b/content/terraform-migrate/v1.0.x/docs/migrate/authenticate.mdx
@@ -3,8 +3,8 @@ page_title: Authenticate `tf-migrate`
 description: >-
   Learn how to authenticate tf-migrate to migrate existing state to HCP Terraform or Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-08-07T22:55:42-04:00
-last_modified: 2025-08-08T10:51:30-04:00
+created_at: 2025-07-01T00:00:00.000Z
+last_modified: 2025-07-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-migrate/v1.0.x/docs/migrate/index.mdx
+++ b/content/terraform-migrate/v1.0.x/docs/migrate/index.mdx
@@ -3,8 +3,8 @@ page_title: Migrate to HCP Terraform
 description: >-
   The tf-migrate CLI migrates existing Terraform state to HCP Terraform or Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-08-07T22:55:42-04:00
-last_modified: 2025-08-08T11:46:17-04:00
+created_at: 2025-07-01T00:00:00.000Z
+last_modified: 2025-07-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-migrate/v1.0.x/docs/migrate/install.mdx
+++ b/content/terraform-migrate/v1.0.x/docs/migrate/install.mdx
@@ -3,8 +3,8 @@ page_title: Install tf-migrate
 description: >-
   Install the tf-migrate CLI tool to migrate existing state to HCP Terraform or Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-08-07T22:55:42-04:00
-last_modified: 2025-08-08T10:51:30-04:00
+created_at: 2025-07-01T00:00:00.000Z
+last_modified: 2025-07-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-migrate/v1.0.x/docs/migrate/reference/configuration.mdx
+++ b/content/terraform-migrate/v1.0.x/docs/migrate/reference/configuration.mdx
@@ -3,8 +3,8 @@ page_title: Configuration file reference
 description: >-
   Configure `tf-migrate` to control how it migrates your state to HCP Terraform or Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-08-07T22:55:42-04:00
-last_modified: 2025-08-08T10:11:57-04:00
+created_at: 2025-07-01T00:00:00.000Z
+last_modified: 2025-07-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-migrate/v1.0.x/docs/migrate/reference/execute.mdx
+++ b/content/terraform-migrate/v1.0.x/docs/migrate/reference/execute.mdx
@@ -3,8 +3,8 @@ page_title: tf-migrate execute reference
 description: >-
   The `tf-migrate execute` command runs a prepared migration to migrate locally existing state to HCP Terraform or Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-08-07T22:55:42-04:00
-last_modified: 2025-08-07T22:55:42-04:00
+created_at: 2025-07-01T00:00:00.000Z
+last_modified: 2025-07-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-migrate/v1.0.x/docs/migrate/reference/prepare.mdx
+++ b/content/terraform-migrate/v1.0.x/docs/migrate/reference/prepare.mdx
@@ -3,8 +3,8 @@ page_title: tf-migrate prepare reference
 description: >-
   The `tf-migrate prepare` command creates a plan to migrate your Terraform Community Edition state to HCP Terraform or Terraform Enterprise.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-08-07T22:55:42-04:00
-last_modified: 2025-08-08T10:11:57-04:00
+created_at: 2025-07-01T00:00:00.000Z
+last_modified: 2025-07-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 


### PR DESCRIPTION
### Description

This PR adds a default date for the metadata for older versions of the terraform-migrate documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715. Older docs versions have been updated with default dates for the versions specified in [this spreadsheet](https://docs.google.com/spreadsheets/d/16FpDhKA4ZBOVtxHWw2ebMjS56mdSask1FBCVecn9QnQ/edit?gid=0#gid=0)

### Testing

Check that terraform-migrate docs look normal in the preview: https://unified-docs-frontend-preview-mrfn66ong-hashicorp.vercel.app/terraform/migrate