### PR TITLE
feat: add default date in frontmatter for older versions of terraform-plugin-framework

### DIFF
--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/data-sources.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/data-sources.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/index.mdx
@@ -4,8 +4,8 @@ description: |-
   An overview of terraform-plugin-framework, a next-generation SDK for
   Terraform plugin development.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/paths.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/providers.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/schemas.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/types.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/types.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/writing-state.mdx
+++ b/content/terraform-plugin-framework/v0.10.x/docs/plugin/framework/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/data-sources.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/data-sources.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/index.mdx
@@ -4,8 +4,8 @@ description: |-
   An overview of terraform-plugin-framework, a next-generation SDK for
   Terraform plugin development.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/paths.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/providers.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/schemas.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/types.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/types.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/writing-state.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/index.mdx
@@ -4,8 +4,8 @@ description: |-
   An overview of terraform-plugin-framework, a next-generation SDK for
   Terraform plugin development.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/paths.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/providers.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/schemas.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/types.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/types.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/writing-state.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/index.mdx
@@ -4,8 +4,8 @@ description: |-
   An overview of terraform-plugin-framework, a next-generation SDK for
   Terraform plugin development.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/paths.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/providers.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/schemas.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/types.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/types.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/writing-state.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/paths.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/schemas.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/types.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/types.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/writing-state.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/paths.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/schemas.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/types.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/types.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/writing-state.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/paths.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/schemas.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/types.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/types.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/writing-state.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/paths.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/schemas.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/types.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/types.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/writing-state.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/data-sources.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/data-sources.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/index.mdx
@@ -4,8 +4,8 @@ description: |-
   An overview of terraform-plugin-framework, a next-generation SDK for
   Terraform plugin development.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/providers.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/providers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider in the provider development framework. Providers
   are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/schemas.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/types.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/types.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/writing-state.mdx
+++ b/content/terraform-plugin-framework/v0.7.x/docs/plugin/framework/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/data-sources.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/data-sources.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/index.mdx
@@ -4,8 +4,8 @@ description: |-
   An overview of terraform-plugin-framework, a next-generation SDK for
   Terraform plugin development.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/providers.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/providers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider in the provider development framework. Providers
   are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/schemas.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/types.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/types.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/writing-state.mdx
+++ b/content/terraform-plugin-framework/v0.8.x/docs/plugin/framework/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/data-sources.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/data-sources.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/index.mdx
@@ -4,8 +4,8 @@ description: |-
   An overview of terraform-plugin-framework, a next-generation SDK for
   Terraform plugin development.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/providers.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/providers.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/schemas.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/types.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/types.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/writing-state.mdx
+++ b/content/terraform-plugin-framework/v0.9.x/docs/plugin/framework/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/attributes.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Blocks'
 description: >-
   Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/conversion-rules.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/conversion-rules.mdx
@@ -4,8 +4,8 @@ description: |-
   Converting from Framework Types to Go types and from Go types
   to Framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/custom-types.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/custom-types.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/attributes.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Blocks'
 description: >-
   Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/conversion-rules.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/conversion-rules.mdx
@@ -4,8 +4,8 @@ description: |-
   Converting from Framework Types to Go types and from Go types
   to Framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/custom-types.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/custom-types.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/deprecations.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/concepts.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Function Concepts'
 description: >-
   Terraform concepts for provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/documentation.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/documentation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Document Functions'
 description: >-
   How to document provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/errors.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/errors.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return function errors from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/implementation.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/implementation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Implement Functions'
 description: >-
   How to implement provider-defined functions in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/index.mdx
@@ -5,8 +5,8 @@ description: >-
   functions expose logic beyond Terraform's built-in functions and simplify
   practitioner configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/bool.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Parameter'
 description: >-
   Learn the bool function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Parameter'
 description: >-
   Learn the dynamic function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/float32.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Function Parameter'
 description: >-
   Learn the float32 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/float64.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Parameter'
 description: >-
   Learn the float64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function parameter types in the provider development framework.
   Parameters are positional data arguments in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/int32.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Function Parameter'
 description: >-
   Learn the int32 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/int64.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Parameter'
 description: >-
   Learn the int64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/list.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Parameter'
 description: >-
   Learn the list function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/map.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Parameter'
 description: >-
   Learn the map function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/number.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Parameter'
 description: >-
   Learn the number function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/object.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Parameter'
 description: >-
   Learn the object function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/set.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Parameter'
 description: >-
   Learn the set function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/string.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/parameters/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Parameter'
 description: >-
   Learn the string function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/bool.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Return'
 description: >-
   Learn the bool function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Return'
 description: >-
   Learn the dynamic function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/float32.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Function Return'
 description: >-
   Learn the float32 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/float64.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Return'
 description: >-
   Learn the float64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function return types in the provider development framework.
   A return describes the output data in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/int32.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Function Return'
 description: >-
   Learn the int32 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/int64.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Return'
 description: >-
   Learn the int64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/list.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Return'
 description: >-
   Learn the list function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/map.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Return'
 description: >-
   Learn the map function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/number.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Return'
 description: >-
   Learn the number function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/object.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Return'
 description: >-
   Learn the object function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/set.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Return'
 description: >-
   Learn the set function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/string.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/returns/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Return'
 description: >-
   Learn the string function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/testing.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/functions/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Testing Functions'
 description: >-
   How to test provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Attribute'
 description: >-
   Learn the bool attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Attribute'
 description: >-
   Learn the dynamic attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/float32.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Attribute'
 description: >-
   Learn the float32 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Attribute'
 description: >-
   Learn the float64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attribute types in the provider development framework. Attributes
   are fields in a resource, data source, or provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/int32.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Attribute'
 description: >-
   Learn the int32 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Attribute'
 description: >-
   Learn the int64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Attribute'
 description: >-
   Learn the list nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Attribute'
 description: >-
   Learn the list attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Nested Attribute'
 description: >-
   Learn the map nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Attribute'
 description: >-
   Learn the map attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Attribute'
 description: >-
   Learn the number attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Attribute'
 description: >-
   Learn the object attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Attribute'
 description: >-
   Learn the set nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Attribute'
 description: >-
   Learn the set attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Attribute'
 description: >-
   Learn the single nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Attribute'
 description: >-
   Learn the string attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   are containers for nested attributes and blocks in a resource, data source, or
   provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Block'
 description: >-
   Learn the list nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Block'
 description: >-
   Learn the set nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Block'
 description: >-
   Learn the single nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/dynamic-data.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/dynamic-data.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Dynamic Data'
 description: >-
   How to handle data when utilizing dynamic types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Type'
 description: >-
   Learn the bool value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Type'
 description: >-
   Learn the dynamic value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/float32.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Type'
 description: >-
   Learn the float32 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the types in the provider development framework. Attributes and blocks
   in a resource, data source, or provider schema map to specific framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/int32.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Type'
 description: >-
   Learn the int32 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Type'
 description: >-
   Learn the int64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Type'
 description: >-
   Learn the list value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Type'
 description: >-
   Learn the map value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Type'
 description: >-
   Learn the object value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Type'
 description: >-
   Learn the set value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Type'
 description: >-
   Learn the string value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Tuple Type'
 description: >-
   Learn the tuple value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/internals/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/internals/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Internals'
 description: >-
   Framewwork internals.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/internals/rpcs.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/internals/rpcs.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: RPCs'
 description: >-
   Relationship between RPCs and framework functionality.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for resource attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/benefits.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/benefits.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Benefits'
 description: >-
   The plugin framework offers significant advantages in comparison to the prior SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/mux.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/mux.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Using Mux'
 description: >-
   Iteratively migrate from terraform-plugin-sdk to terraform-plugin-framework using terraform-plugin-mux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/default.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/default.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Default'
 description: >-
   How to set default values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/state-move.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/state-move.mdx
@@ -4,8 +4,8 @@ description: >-
   How to move state data across managed resource types using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/deprecations.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/concepts.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Function Concepts'
 description: >-
   Terraform concepts for provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/documentation.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/documentation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Document Functions'
 description: >-
   How to document provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/errors.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/errors.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return function errors from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/implementation.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/implementation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Implement Functions'
 description: >-
   How to implement provider-defined functions in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/index.mdx
@@ -5,8 +5,8 @@ description: >-
   functions expose logic beyond Terraform's built-in functions and simplify
   practitioner configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/bool.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Parameter'
 description: >-
   Learn the bool function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Parameter'
 description: >-
   Learn the dynamic function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/float32.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Function Parameter'
 description: >-
   Learn the float32 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/float64.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Parameter'
 description: >-
   Learn the float64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function parameter types in the provider development framework.
   Parameters are positional data arguments in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/int32.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Function Parameter'
 description: >-
   Learn the int32 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/int64.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Parameter'
 description: >-
   Learn the int64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/list.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Parameter'
 description: >-
   Learn the list function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/map.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Parameter'
 description: >-
   Learn the map function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/number.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Parameter'
 description: >-
   Learn the number function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/object.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Parameter'
 description: >-
   Learn the object function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/set.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Parameter'
 description: >-
   Learn the set function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/string.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/parameters/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Parameter'
 description: >-
   Learn the string function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/bool.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Return'
 description: >-
   Learn the bool function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Return'
 description: >-
   Learn the dynamic function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/float32.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Function Return'
 description: >-
   Learn the float32 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/float64.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Return'
 description: >-
   Learn the float64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function return types in the provider development framework.
   A return describes the output data in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/int32.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Function Return'
 description: >-
   Learn the int32 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/int64.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Return'
 description: >-
   Learn the int64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/list.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Return'
 description: >-
   Learn the list function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/map.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Return'
 description: >-
   Learn the map function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/number.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Return'
 description: >-
   Learn the number function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/object.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Return'
 description: >-
   Learn the object function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/set.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Return'
 description: >-
   Learn the set function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/string.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/returns/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Return'
 description: >-
   Learn the string function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/testing.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/functions/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Testing Functions'
 description: >-
   How to test provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Attribute'
 description: >-
   Learn the bool attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Attribute'
 description: >-
   Learn the dynamic attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/float32.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Attribute'
 description: >-
   Learn the float32 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Attribute'
 description: >-
   Learn the float64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attribute types in the provider development framework. Attributes
   are fields in a resource, data source, or provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/int32.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Attribute'
 description: >-
   Learn the int32 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Attribute'
 description: >-
   Learn the int64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Attribute'
 description: >-
   Learn the list nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Attribute'
 description: >-
   Learn the list attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Nested Attribute'
 description: >-
   Learn the map nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Attribute'
 description: >-
   Learn the map attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Attribute'
 description: >-
   Learn the number attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Attribute'
 description: >-
   Learn the object attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Attribute'
 description: >-
   Learn the set nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Attribute'
 description: >-
   Learn the set attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Attribute'
 description: >-
   Learn the single nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Attribute'
 description: >-
   Learn the string attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   are containers for nested attributes and blocks in a resource, data source, or
   provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Block'
 description: >-
   Learn the list nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Block'
 description: >-
   Learn the set nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Block'
 description: >-
   Learn the single nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/dynamic-data.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/dynamic-data.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Dynamic Data'
 description: >-
   How to handle data when utilizing dynamic types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Type'
 description: >-
   Learn the bool value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Type'
 description: >-
   Learn the dynamic value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/float32.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Type'
 description: >-
   Learn the float32 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the types in the provider development framework. Attributes and blocks
   in a resource, data source, or provider schema map to specific framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/int32.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Type'
 description: >-
   Learn the int32 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Type'
 description: >-
   Learn the int64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Type'
 description: >-
   Learn the list value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Type'
 description: >-
   Learn the map value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Type'
 description: >-
   Learn the object value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Type'
 description: >-
   Learn the set value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Type'
 description: >-
   Learn the string value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Tuple Type'
 description: >-
   Learn the tuple value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/internals/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/internals/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Internals'
 description: >-
   Framewwork internals.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/internals/rpcs.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/internals/rpcs.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: RPCs'
 description: >-
   Relationship between RPCs and framework functionality.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for resource attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/benefits.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/benefits.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Benefits'
 description: >-
   The plugin framework offers significant advantages in comparison to the prior SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/mux.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/mux.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Using Mux'
 description: >-
   Iteratively migrate from terraform-plugin-sdk to terraform-plugin-framework using terraform-plugin-mux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/default.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/default.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Default'
 description: >-
   How to set default values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/state-move.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/state-move.mdx
@@ -4,8 +4,8 @@ description: >-
   How to move state data across managed resource types using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/deprecations.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/concepts.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Function Concepts'
 description: >-
   Terraform concepts for provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/documentation.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/documentation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Document Functions'
 description: >-
   How to document provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/errors.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/errors.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return function errors from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/implementation.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/implementation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Implement Functions'
 description: >-
   How to implement provider-defined functions in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/index.mdx
@@ -5,8 +5,8 @@ description: >-
   functions expose logic beyond Terraform's built-in functions and simplify
   practitioner configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/bool.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Parameter'
 description: >-
   Learn the bool function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Parameter'
 description: >-
   Learn the dynamic function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/float32.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Function Parameter'
 description: >-
   Learn the float32 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/float64.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Parameter'
 description: >-
   Learn the float64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function parameter types in the provider development framework.
   Parameters are positional data arguments in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/int32.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Function Parameter'
 description: >-
   Learn the int32 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/int64.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Parameter'
 description: >-
   Learn the int64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/list.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Parameter'
 description: >-
   Learn the list function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/map.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Parameter'
 description: >-
   Learn the map function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/number.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Parameter'
 description: >-
   Learn the number function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/object.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Parameter'
 description: >-
   Learn the object function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/set.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Parameter'
 description: >-
   Learn the set function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/string.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/parameters/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Parameter'
 description: >-
   Learn the string function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/bool.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Return'
 description: >-
   Learn the bool function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Return'
 description: >-
   Learn the dynamic function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/float32.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Function Return'
 description: >-
   Learn the float32 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/float64.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Return'
 description: >-
   Learn the float64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function return types in the provider development framework.
   A return describes the output data in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/int32.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Function Return'
 description: >-
   Learn the int32 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/int64.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Return'
 description: >-
   Learn the int64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/list.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Return'
 description: >-
   Learn the list function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/map.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Return'
 description: >-
   Learn the map function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/number.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Return'
 description: >-
   Learn the number function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/object.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Return'
 description: >-
   Learn the object function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/set.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Return'
 description: >-
   Learn the set function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/string.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/returns/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Return'
 description: >-
   Learn the string function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/testing.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/functions/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Testing Functions'
 description: >-
   How to test provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Attribute'
 description: >-
   Learn the bool attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Attribute'
 description: >-
   Learn the dynamic attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/float32.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Attribute'
 description: >-
   Learn the float32 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Attribute'
 description: >-
   Learn the float64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attribute types in the provider development framework. Attributes
   are fields in a resource, data source, or provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/int32.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Attribute'
 description: >-
   Learn the int32 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Attribute'
 description: >-
   Learn the int64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Attribute'
 description: >-
   Learn the list nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Attribute'
 description: >-
   Learn the list attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Nested Attribute'
 description: >-
   Learn the map nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Attribute'
 description: >-
   Learn the map attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Attribute'
 description: >-
   Learn the number attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Attribute'
 description: >-
   Learn the object attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Attribute'
 description: >-
   Learn the set nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Attribute'
 description: >-
   Learn the set attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Attribute'
 description: >-
   Learn the single nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Attribute'
 description: >-
   Learn the string attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   are containers for nested attributes and blocks in a resource, data source, or
   provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Block'
 description: >-
   Learn the list nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Block'
 description: >-
   Learn the set nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Block'
 description: >-
   Learn the single nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/dynamic-data.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/dynamic-data.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Dynamic Data'
 description: >-
   How to handle data when utilizing dynamic types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Type'
 description: >-
   Learn the bool value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Type'
 description: >-
   Learn the dynamic value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/float32.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Type'
 description: >-
   Learn the float32 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the types in the provider development framework. Attributes and blocks
   in a resource, data source, or provider schema map to specific framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/int32.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Type'
 description: >-
   Learn the int32 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Type'
 description: >-
   Learn the int64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Type'
 description: >-
   Learn the list value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Type'
 description: >-
   Learn the map value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Type'
 description: >-
   Learn the object value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Type'
 description: >-
   Learn the set value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Type'
 description: >-
   Learn the string value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Tuple Type'
 description: >-
   Learn the tuple value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/internals/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/internals/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Internals'
 description: >-
   Framewwork internals.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/internals/rpcs.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/internals/rpcs.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: RPCs'
 description: >-
   Relationship between RPCs and framework functionality.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for resource attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/benefits.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/benefits.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Benefits'
 description: >-
   The plugin framework offers significant advantages in comparison to the prior SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/mux.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/mux.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Using Mux'
 description: >-
   Iteratively migrate from terraform-plugin-sdk to terraform-plugin-framework using terraform-plugin-mux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/default.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/default.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Default'
 description: >-
   How to set default values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/state-move.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/state-move.mdx
@@ -4,8 +4,8 @@ description: >-
   How to move state data across managed resource types using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/deprecations.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/ephemeral-resources/close.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/ephemeral-resources/close.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Open Ephemeral Resources'
 description: >-
   How to implement ephemeral resource close in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/ephemeral-resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/ephemeral-resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Ephemeral Resources'
 description: >-
   How to configure ephemeral resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/ephemeral-resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/ephemeral-resources/index.mdx
@@ -5,8 +5,8 @@ description: >-
   resources allow Terraform to reference external data, while guaranteeing that this
   data will not be persisted in plan or state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/ephemeral-resources/open.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/ephemeral-resources/open.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Open Ephemeral Resources'
 description: >-
   How to implement ephemeral resource open in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/ephemeral-resources/renew.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/ephemeral-resources/renew.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Open Ephemeral Resources'
 description: >-
   How to implement ephemeral resource renew in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/ephemeral-resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/ephemeral-resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Ephemeral Resource Configu
 description: >-
   How to validate ephemeral resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/concepts.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Function Concepts'
 description: >-
   Terraform concepts for provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/documentation.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/documentation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Document Functions'
 description: >-
   How to document provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/errors.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/errors.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return function errors from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/implementation.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/implementation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Implement Functions'
 description: >-
   How to implement provider-defined functions in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/index.mdx
@@ -5,8 +5,8 @@ description: >-
   functions expose logic beyond Terraform's built-in functions and simplify
   practitioner configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/bool.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Parameter'
 description: >-
   Learn the bool function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Parameter'
 description: >-
   Learn the dynamic function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/float32.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Function Parameter'
 description: >-
   Learn the float32 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/float64.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Parameter'
 description: >-
   Learn the float64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function parameter types in the provider development framework.
   Parameters are positional data arguments in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/int32.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Function Parameter'
 description: >-
   Learn the int32 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/int64.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Parameter'
 description: >-
   Learn the int64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/list.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Parameter'
 description: >-
   Learn the list function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/map.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Parameter'
 description: >-
   Learn the map function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/number.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Parameter'
 description: >-
   Learn the number function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/object.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Parameter'
 description: >-
   Learn the object function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/set.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Parameter'
 description: >-
   Learn the set function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/string.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/parameters/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Parameter'
 description: >-
   Learn the string function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/bool.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Return'
 description: >-
   Learn the bool function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Return'
 description: >-
   Learn the dynamic function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/float32.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Function Return'
 description: >-
   Learn the float32 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/float64.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Return'
 description: >-
   Learn the float64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function return types in the provider development framework.
   A return describes the output data in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/int32.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Function Return'
 description: >-
   Learn the int32 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/int64.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Return'
 description: >-
   Learn the int64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/list.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Return'
 description: >-
   Learn the list function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/map.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Return'
 description: >-
   Learn the map function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/number.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Return'
 description: >-
   Learn the number function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/object.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Return'
 description: >-
   Learn the object function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/set.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Return'
 description: >-
   Learn the set function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/string.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/returns/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Return'
 description: >-
   Learn the string function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/testing.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/functions/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Testing Functions'
 description: >-
   How to test provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Attribute'
 description: >-
   Learn the bool attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Attribute'
 description: >-
   Learn the dynamic attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/float32.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Attribute'
 description: >-
   Learn the float32 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Attribute'
 description: >-
   Learn the float64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attribute types in the provider development framework. Attributes
   are fields in a resource, data source, or provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/int32.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Attribute'
 description: >-
   Learn the int32 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Attribute'
 description: >-
   Learn the int64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Attribute'
 description: >-
   Learn the list nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Attribute'
 description: >-
   Learn the list attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Nested Attribute'
 description: >-
   Learn the map nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Attribute'
 description: >-
   Learn the map attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Attribute'
 description: >-
   Learn the number attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Attribute'
 description: >-
   Learn the object attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Attribute'
 description: >-
   Learn the set nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Attribute'
 description: >-
   Learn the set attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Attribute'
 description: >-
   Learn the single nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Attribute'
 description: >-
   Learn the string attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   are containers for nested attributes and blocks in a resource, data source, or
   provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Block'
 description: >-
   Learn the list nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Block'
 description: >-
   Learn the set nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Block'
 description: >-
   Learn the single nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/dynamic-data.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/dynamic-data.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Dynamic Data'
 description: >-
   How to handle data when utilizing dynamic types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Type'
 description: >-
   Learn the bool value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Type'
 description: >-
   Learn the dynamic value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/float32.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float32 Type'
 description: >-
   Learn the float32 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the types in the provider development framework. Attributes and blocks
   in a resource, data source, or provider schema map to specific framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/int32.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int32 Type'
 description: >-
   Learn the int32 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Type'
 description: >-
   Learn the int64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Type'
 description: >-
   Learn the list value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Type'
 description: >-
   Learn the map value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Type'
 description: >-
   Learn the object value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Type'
 description: >-
   Learn the set value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Type'
 description: >-
   Learn the string value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Tuple Type'
 description: >-
   Learn the tuple value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/internals/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/internals/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Internals'
 description: >-
   Framewwork internals.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/internals/rpcs.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/internals/rpcs.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: RPCs'
 description: >-
   Relationship between RPCs and framework functionality.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for resource attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/benefits.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/benefits.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Benefits'
 description: >-
   The plugin framework offers significant advantages in comparison to the prior SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/mux.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/mux.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Using Mux'
 description: >-
   Iteratively migrate from terraform-plugin-sdk to terraform-plugin-framework using terraform-plugin-mux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/default.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/default.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Default'
 description: >-
   How to set default values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/state-move.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/state-move.mdx
@@ -4,8 +4,8 @@ description: >-
   How to move state data across managed resource types using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/deprecations.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/attributes.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/attributes.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attributes in the provider development framework and how to make
   your own. Attributes are fields in a resource, data source, or provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Blocks'
 description: >-
   Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/conversion-rules.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/conversion-rules.mdx
@@ -4,8 +4,8 @@ description: |-
   Converting from Framework Types to Go types and from Go types
   to Framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/custom-types.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/custom-types.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/internals/index.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/internals/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Internals'
 description: >-
   Framewwork internals.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/internals/rpcs.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/internals/rpcs.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: RPCs'
 description: >-
   Relationship between RPCs and framework functionality.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for resource attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/benefits.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/benefits.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Benefits'
 description: >-
   The plugin framework offers significant advantages in comparison to the prior SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/mux.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/mux.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Using Mux'
 description: >-
   Iteratively migrate from terraform-plugin-sdk to terraform-plugin-framework using terraform-plugin-mux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/default.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/default.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Default'
 description: >-
   How to set default values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/deprecations.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Attribute'
 description: >-
   Learn the bool attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Attribute'
 description: >-
   Learn the float64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attribute types in the provider development framework. Attributes
   are fields in a resource, data source, or provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Attribute'
 description: >-
   Learn the int64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Attribute'
 description: >-
   Learn the list nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Attribute'
 description: >-
   Learn the list attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Nested Attribute'
 description: >-
   Learn the map nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Attribute'
 description: >-
   Learn the map attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Attribute'
 description: >-
   Learn the number attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Attribute'
 description: >-
   Learn the object attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Attribute'
 description: >-
   Learn the set nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Attribute'
 description: >-
   Learn the set attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Attribute'
 description: >-
   Learn the single nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Attribute'
 description: >-
   Learn the string attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   are containers for nested attributes and blocks in a resource, data source, or
   provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Block'
 description: >-
   Learn the list nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Block'
 description: >-
   Learn the set nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Block'
 description: >-
   Learn the single nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Type'
 description: >-
   Learn the bool value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the types in the provider development framework. Attributes and blocks
   in a resource, data source, or provider schema map to specific framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Type'
 description: >-
   Learn the int64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Type'
 description: >-
   Learn the list value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Type'
 description: >-
   Learn the map value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Type'
 description: >-
   Learn the object value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Type'
 description: >-
   Learn the set value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Type'
 description: >-
   Learn the string value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/internals/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/internals/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Internals'
 description: >-
   Framewwork internals.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/internals/rpcs.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/internals/rpcs.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: RPCs'
 description: >-
   Relationship between RPCs and framework functionality.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for resource attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/benefits.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/benefits.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Benefits'
 description: >-
   The plugin framework offers significant advantages in comparison to the prior SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/mux.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/mux.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Using Mux'
 description: >-
   Iteratively migrate from terraform-plugin-sdk to terraform-plugin-framework using terraform-plugin-mux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/default.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/default.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Default'
 description: >-
   How to set default values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/deprecations.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Attribute'
 description: >-
   Learn the bool attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Attribute'
 description: >-
   Learn the float64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attribute types in the provider development framework. Attributes
   are fields in a resource, data source, or provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Attribute'
 description: >-
   Learn the int64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Attribute'
 description: >-
   Learn the list nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Attribute'
 description: >-
   Learn the list attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Nested Attribute'
 description: >-
   Learn the map nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Attribute'
 description: >-
   Learn the map attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Attribute'
 description: >-
   Learn the number attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Attribute'
 description: >-
   Learn the object attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Attribute'
 description: >-
   Learn the set nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Attribute'
 description: >-
   Learn the set attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Attribute'
 description: >-
   Learn the single nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Attribute'
 description: >-
   Learn the string attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   are containers for nested attributes and blocks in a resource, data source, or
   provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Block'
 description: >-
   Learn the list nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Block'
 description: >-
   Learn the set nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Block'
 description: >-
   Learn the single nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Type'
 description: >-
   Learn the bool value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the types in the provider development framework. Attributes and blocks
   in a resource, data source, or provider schema map to specific framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Type'
 description: >-
   Learn the int64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Type'
 description: >-
   Learn the list value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Type'
 description: >-
   Learn the map value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Type'
 description: >-
   Learn the object value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Type'
 description: >-
   Learn the set value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Type'
 description: >-
   Learn the string value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/internals/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/internals/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Internals'
 description: >-
   Framewwork internals.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/internals/rpcs.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/internals/rpcs.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: RPCs'
 description: >-
   Relationship between RPCs and framework functionality.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for resource attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/benefits.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/benefits.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Benefits'
 description: >-
   The plugin framework offers significant advantages in comparison to the prior SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/mux.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/mux.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Using Mux'
 description: >-
   Iteratively migrate from terraform-plugin-sdk to terraform-plugin-framework using terraform-plugin-mux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/default.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/default.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Default'
 description: >-
   How to set default values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/deprecations.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/concepts.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Function Concepts'
 description: >-
   Terraform concepts for provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/documentation.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/documentation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Document Functions'
 description: >-
   How to document provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/implementation.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/implementation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Implement Functions'
 description: >-
   How to implement provider-defined functions in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/index.mdx
@@ -5,8 +5,8 @@ description: >-
   functions expose logic beyond Terraform's built-in functions and simplify
   practitioner configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/bool.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Parameter'
 description: >-
   Learn the bool function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/float64.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Parameter'
 description: >-
   Learn the float64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function parameter types in the provider development framework.
   Parameters are positional data arguments in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/int64.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Parameter'
 description: >-
   Learn the int64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/list.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Parameter'
 description: >-
   Learn the list function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/map.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Parameter'
 description: >-
   Learn the map function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/number.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Parameter'
 description: >-
   Learn the number function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/object.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Parameter'
 description: >-
   Learn the object function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/set.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Parameter'
 description: >-
   Learn the set function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/string.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/parameters/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Parameter'
 description: >-
   Learn the string function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/bool.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Return'
 description: >-
   Learn the bool function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/float64.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Return'
 description: >-
   Learn the float64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function return types in the provider development framework.
   A return describes the output data in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-10T10:50:00-04:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/int64.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Return'
 description: >-
   Learn the int64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/list.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Return'
 description: >-
   Learn the list function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/map.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Return'
 description: >-
   Learn the map function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/number.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Return'
 description: >-
   Learn the number function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/object.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Return'
 description: >-
   Learn the object function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/set.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Return'
 description: >-
   Learn the set function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/string.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/returns/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Return'
 description: >-
   Learn the string function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/testing.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/functions/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Testing Functions'
 description: >-
   How to test provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Attribute'
 description: >-
   Learn the bool attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Attribute'
 description: >-
   Learn the float64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attribute types in the provider development framework. Attributes
   are fields in a resource, data source, or provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Attribute'
 description: >-
   Learn the int64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Attribute'
 description: >-
   Learn the list nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Attribute'
 description: >-
   Learn the list attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Nested Attribute'
 description: >-
   Learn the map nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Attribute'
 description: >-
   Learn the map attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Attribute'
 description: >-
   Learn the number attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Attribute'
 description: >-
   Learn the object attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Attribute'
 description: >-
   Learn the set nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Attribute'
 description: >-
   Learn the set attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Attribute'
 description: >-
   Learn the single nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Attribute'
 description: >-
   Learn the string attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   are containers for nested attributes and blocks in a resource, data source, or
   provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Block'
 description: >-
   Learn the list nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Block'
 description: >-
   Learn the set nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Block'
 description: >-
   Learn the single nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Type'
 description: >-
   Learn the bool value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the types in the provider development framework. Attributes and blocks
   in a resource, data source, or provider schema map to specific framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Type'
 description: >-
   Learn the int64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Type'
 description: >-
   Learn the list value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Type'
 description: >-
   Learn the map value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Type'
 description: >-
   Learn the object value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Type'
 description: >-
   Learn the set value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Type'
 description: >-
   Learn the string value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Tuple Type'
 description: >-
   Learn the tuple value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/internals/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/internals/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Internals'
 description: >-
   Framewwork internals.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/internals/rpcs.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/internals/rpcs.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: RPCs'
 description: >-
   Relationship between RPCs and framework functionality.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for resource attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/benefits.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/benefits.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Benefits'
 description: >-
   The plugin framework offers significant advantages in comparison to the prior SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/mux.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/mux.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Using Mux'
 description: >-
   Iteratively migrate from terraform-plugin-sdk to terraform-plugin-framework using terraform-plugin-mux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/default.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/default.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Default'
 description: >-
   How to set default values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/deprecations.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/concepts.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Function Concepts'
 description: >-
   Terraform concepts for provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/documentation.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/documentation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Document Functions'
 description: >-
   How to document provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/errors.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/errors.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return function errors from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/implementation.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/implementation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Implement Functions'
 description: >-
   How to implement provider-defined functions in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/index.mdx
@@ -5,8 +5,8 @@ description: >-
   functions expose logic beyond Terraform's built-in functions and simplify
   practitioner configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/bool.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Parameter'
 description: >-
   Learn the bool function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/float64.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Parameter'
 description: >-
   Learn the float64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function parameter types in the provider development framework.
   Parameters are positional data arguments in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/int64.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Parameter'
 description: >-
   Learn the int64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/list.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Parameter'
 description: >-
   Learn the list function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/map.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Parameter'
 description: >-
   Learn the map function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/number.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Parameter'
 description: >-
   Learn the number function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/object.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Parameter'
 description: >-
   Learn the object function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/set.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Parameter'
 description: >-
   Learn the set function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/string.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/parameters/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Parameter'
 description: >-
   Learn the string function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/bool.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Return'
 description: >-
   Learn the bool function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/float64.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Return'
 description: >-
   Learn the float64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function return types in the provider development framework.
   A return describes the output data in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/int64.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Return'
 description: >-
   Learn the int64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/list.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Return'
 description: >-
   Learn the list function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/map.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Return'
 description: >-
   Learn the map function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/number.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Return'
 description: >-
   Learn the number function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/object.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Return'
 description: >-
   Learn the object function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/set.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Return'
 description: >-
   Learn the set function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/string.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/returns/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Return'
 description: >-
   Learn the string function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/testing.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/functions/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Testing Functions'
 description: >-
   How to test provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Attribute'
 description: >-
   Learn the bool attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Attribute'
 description: >-
   Learn the float64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attribute types in the provider development framework. Attributes
   are fields in a resource, data source, or provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Attribute'
 description: >-
   Learn the int64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Attribute'
 description: >-
   Learn the list nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Attribute'
 description: >-
   Learn the list attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Nested Attribute'
 description: >-
   Learn the map nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Attribute'
 description: >-
   Learn the map attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Attribute'
 description: >-
   Learn the number attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Attribute'
 description: >-
   Learn the object attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Attribute'
 description: >-
   Learn the set nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Attribute'
 description: >-
   Learn the set attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Attribute'
 description: >-
   Learn the single nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Attribute'
 description: >-
   Learn the string attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   are containers for nested attributes and blocks in a resource, data source, or
   provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Block'
 description: >-
   Learn the list nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Block'
 description: >-
   Learn the set nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Block'
 description: >-
   Learn the single nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Type'
 description: >-
   Learn the bool value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the types in the provider development framework. Attributes and blocks
   in a resource, data source, or provider schema map to specific framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Type'
 description: >-
   Learn the int64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Type'
 description: >-
   Learn the list value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Type'
 description: >-
   Learn the map value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Type'
 description: >-
   Learn the object value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Type'
 description: >-
   Learn the set value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Type'
 description: >-
   Learn the string value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Tuple Type'
 description: >-
   Learn the tuple value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/internals/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/internals/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Internals'
 description: >-
   Framewwork internals.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/internals/rpcs.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/internals/rpcs.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: RPCs'
 description: >-
   Relationship between RPCs and framework functionality.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for resource attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/benefits.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/benefits.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Benefits'
 description: >-
   The plugin framework offers significant advantages in comparison to the prior SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/mux.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/mux.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Using Mux'
 description: >-
   Iteratively migrate from terraform-plugin-sdk to terraform-plugin-framework using terraform-plugin-mux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/default.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/default.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Default'
 description: >-
   How to set default values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/state-move.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/state-move.mdx
@@ -4,8 +4,8 @@ description: >-
   How to move state data across managed resource types using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/deprecations.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/concepts.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Function Concepts'
 description: >-
   Terraform concepts for provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/documentation.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/documentation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Document Functions'
 description: >-
   How to document provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/errors.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/errors.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return function errors from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/implementation.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/implementation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Implement Functions'
 description: >-
   How to implement provider-defined functions in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/index.mdx
@@ -5,8 +5,8 @@ description: >-
   functions expose logic beyond Terraform's built-in functions and simplify
   practitioner configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/bool.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Parameter'
 description: >-
   Learn the bool function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Parameter'
 description: >-
   Learn the dynamic function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/float64.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Parameter'
 description: >-
   Learn the float64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function parameter types in the provider development framework.
   Parameters are positional data arguments in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/int64.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Parameter'
 description: >-
   Learn the int64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/list.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Parameter'
 description: >-
   Learn the list function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/map.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Parameter'
 description: >-
   Learn the map function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/number.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Parameter'
 description: >-
   Learn the number function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/object.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Parameter'
 description: >-
   Learn the object function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/set.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Parameter'
 description: >-
   Learn the set function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/string.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/parameters/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Parameter'
 description: >-
   Learn the string function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/bool.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Return'
 description: >-
   Learn the bool function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Return'
 description: >-
   Learn the dynamic function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/float64.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Return'
 description: >-
   Learn the float64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function return types in the provider development framework.
   A return describes the output data in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/int64.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Return'
 description: >-
   Learn the int64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/list.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Return'
 description: >-
   Learn the list function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/map.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Return'
 description: >-
   Learn the map function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/number.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Return'
 description: >-
   Learn the number function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/object.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Return'
 description: >-
   Learn the object function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/set.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Return'
 description: >-
   Learn the set function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/string.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/returns/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Return'
 description: >-
   Learn the string function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/testing.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/functions/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Testing Functions'
 description: >-
   How to test provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Attribute'
 description: >-
   Learn the bool attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Attribute'
 description: >-
   Learn the dynamic attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Attribute'
 description: >-
   Learn the float64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attribute types in the provider development framework. Attributes
   are fields in a resource, data source, or provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Attribute'
 description: >-
   Learn the int64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Attribute'
 description: >-
   Learn the list nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Attribute'
 description: >-
   Learn the list attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Nested Attribute'
 description: >-
   Learn the map nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Attribute'
 description: >-
   Learn the map attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Attribute'
 description: >-
   Learn the number attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Attribute'
 description: >-
   Learn the object attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Attribute'
 description: >-
   Learn the set nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Attribute'
 description: >-
   Learn the set attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Attribute'
 description: >-
   Learn the single nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Attribute'
 description: >-
   Learn the string attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   are containers for nested attributes and blocks in a resource, data source, or
   provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Block'
 description: >-
   Learn the list nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Block'
 description: >-
   Learn the set nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Block'
 description: >-
   Learn the single nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/dynamic-data.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/dynamic-data.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Dynamic Data'
 description: >-
   How to handle data when utilizing dynamic types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Type'
 description: >-
   Learn the bool value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Type'
 description: >-
   Learn the dynamic value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the types in the provider development framework. Attributes and blocks
   in a resource, data source, or provider schema map to specific framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Type'
 description: >-
   Learn the int64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Type'
 description: >-
   Learn the list value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Type'
 description: >-
   Learn the map value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Type'
 description: >-
   Learn the object value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Type'
 description: >-
   Learn the set value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Type'
 description: >-
   Learn the string value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Tuple Type'
 description: >-
   Learn the tuple value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/internals/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/internals/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Internals'
 description: >-
   Framewwork internals.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/internals/rpcs.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/internals/rpcs.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: RPCs'
 description: >-
   Relationship between RPCs and framework functionality.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for resource attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/benefits.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/benefits.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Benefits'
 description: >-
   The plugin framework offers significant advantages in comparison to the prior SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/mux.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/mux.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Using Mux'
 description: >-
   Iteratively migrate from terraform-plugin-sdk to terraform-plugin-framework using terraform-plugin-mux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/default.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/default.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Default'
 description: >-
   How to set default values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/state-move.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/state-move.mdx
@@ -4,8 +4,8 @@ description: >-
   How to move state data across managed resource types using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/deprecations.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/concepts.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Function Concepts'
 description: >-
   Terraform concepts for provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/documentation.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/documentation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Document Functions'
 description: >-
   How to document provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/errors.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/errors.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return function errors from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/implementation.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/implementation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Implement Functions'
 description: >-
   How to implement provider-defined functions in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/index.mdx
@@ -5,8 +5,8 @@ description: >-
   functions expose logic beyond Terraform's built-in functions and simplify
   practitioner configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/bool.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Parameter'
 description: >-
   Learn the bool function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Parameter'
 description: >-
   Learn the dynamic function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/float64.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Parameter'
 description: >-
   Learn the float64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function parameter types in the provider development framework.
   Parameters are positional data arguments in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/int64.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Parameter'
 description: >-
   Learn the int64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/list.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Parameter'
 description: >-
   Learn the list function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/map.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Parameter'
 description: >-
   Learn the map function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/number.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Parameter'
 description: >-
   Learn the number function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/object.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Parameter'
 description: >-
   Learn the object function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/set.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Parameter'
 description: >-
   Learn the set function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/string.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/parameters/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Parameter'
 description: >-
   Learn the string function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/bool.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Return'
 description: >-
   Learn the bool function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Return'
 description: >-
   Learn the dynamic function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/float64.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Return'
 description: >-
   Learn the float64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function return types in the provider development framework.
   A return describes the output data in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/int64.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Return'
 description: >-
   Learn the int64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/list.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Return'
 description: >-
   Learn the list function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/map.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Return'
 description: >-
   Learn the map function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/number.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Return'
 description: >-
   Learn the number function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/object.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Return'
 description: >-
   Learn the object function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/set.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Return'
 description: >-
   Learn the set function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/string.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/returns/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Return'
 description: >-
   Learn the string function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/testing.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/functions/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Testing Functions'
 description: >-
   How to test provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Attribute'
 description: >-
   Learn the bool attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Attribute'
 description: >-
   Learn the dynamic attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Attribute'
 description: >-
   Learn the float64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attribute types in the provider development framework. Attributes
   are fields in a resource, data source, or provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Attribute'
 description: >-
   Learn the int64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Attribute'
 description: >-
   Learn the list nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Attribute'
 description: >-
   Learn the list attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Nested Attribute'
 description: >-
   Learn the map nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Attribute'
 description: >-
   Learn the map attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Attribute'
 description: >-
   Learn the number attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Attribute'
 description: >-
   Learn the object attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Attribute'
 description: >-
   Learn the set nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Attribute'
 description: >-
   Learn the set attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Attribute'
 description: >-
   Learn the single nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Attribute'
 description: >-
   Learn the string attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   are containers for nested attributes and blocks in a resource, data source, or
   provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Block'
 description: >-
   Learn the list nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Block'
 description: >-
   Learn the set nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Block'
 description: >-
   Learn the single nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/dynamic-data.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/dynamic-data.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Dynamic Data'
 description: >-
   How to handle data when utilizing dynamic types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Type'
 description: >-
   Learn the bool value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Type'
 description: >-
   Learn the dynamic value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the types in the provider development framework. Attributes and blocks
   in a resource, data source, or provider schema map to specific framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Type'
 description: >-
   Learn the int64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Type'
 description: >-
   Learn the list value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Type'
 description: >-
   Learn the map value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Type'
 description: >-
   Learn the object value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Type'
 description: >-
   Learn the set value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Type'
 description: >-
   Learn the string value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Tuple Type'
 description: >-
   Learn the tuple value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/internals/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/internals/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Internals'
 description: >-
   Framewwork internals.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/internals/rpcs.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/internals/rpcs.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: RPCs'
 description: >-
   Relationship between RPCs and framework functionality.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for resource attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/benefits.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/benefits.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Benefits'
 description: >-
   The plugin framework offers significant advantages in comparison to the prior SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/mux.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/mux.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Using Mux'
 description: >-
   Iteratively migrate from terraform-plugin-sdk to terraform-plugin-framework using terraform-plugin-mux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/default.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/default.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Default'
 description: >-
   How to set default values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/state-move.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/state-move.mdx
@@ -4,8 +4,8 @@ description: >-
   How to move state data across managed resource types using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/acctests.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/acctests.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write acceptance tests for providers built on the framework. Acceptance
   tests imitate applying configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/data-sources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/data-sources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Data Sources'
 description: >-
   How to configure data sources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/data-sources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build data sources in the provider development framework. Data sources
   allow Terraform to reference external data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Data Source Configurations
 description: >-
   How to validate data source configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/debugging.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging Framework Providers
 description: How to implement debugger support in Framework Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/deprecations.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/diagnostics.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return errors and warnings from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/concepts.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Function Concepts'
 description: >-
   Terraform concepts for provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/documentation.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/documentation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Document Functions'
 description: >-
   How to document provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/errors.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/errors.mdx
@@ -4,8 +4,8 @@ description: |-
   How to return function errors from the Terraform provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/implementation.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/implementation.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Implement Functions'
 description: >-
   How to implement provider-defined functions in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/index.mdx
@@ -5,8 +5,8 @@ description: >-
   functions expose logic beyond Terraform's built-in functions and simplify
   practitioner configurations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/bool.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Parameter'
 description: >-
   Learn the bool function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Parameter'
 description: >-
   Learn the dynamic function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/float64.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Parameter'
 description: >-
   Learn the float64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function parameter types in the provider development framework.
   Parameters are positional data arguments in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/int64.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Parameter'
 description: >-
   Learn the int64 function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/list.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Parameter'
 description: >-
   Learn the list function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/map.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Parameter'
 description: >-
   Learn the map function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/number.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Parameter'
 description: >-
   Learn the number function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/object.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Parameter'
 description: >-
   Learn the object function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/set.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Parameter'
 description: >-
   Learn the set function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/string.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/parameters/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Parameter'
 description: >-
   Learn the string function parameter type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/bool.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Function Return'
 description: >-
   Learn the bool function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Function Return'
 description: >-
   Learn the dynamic function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/float64.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Function Return'
 description: >-
   Learn the float64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the function return types in the provider development framework.
   A return describes the output data in a function definition.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/int64.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Function Return'
 description: >-
   Learn the int64 function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/list.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Function Return'
 description: >-
   Learn the list function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/map.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Function Return'
 description: >-
   Learn the map function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/number.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Function Return'
 description: >-
   Learn the number function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/object.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Function Return'
 description: >-
   Learn the object function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/set.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Function Return'
 description: >-
   Learn the set function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/string.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/returns/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Function Return'
 description: >-
   Learn the string function return type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/testing.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/functions/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Testing Functions'
 description: >-
   How to test provider-defined functions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Getting Started - Code Walkthrough'
 description: >-
   How to setup and configure a simple plugin provider.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -4,8 +4,8 @@ description: |-
   How to read values from state, config, and plan in the Terraform plugin
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Attribute'
 description: >-
   Learn the bool attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Attribute'
 description: >-
   Learn the dynamic attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Attribute'
 description: >-
   Learn the float64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the attribute types in the provider development framework. Attributes
   are fields in a resource, data source, or provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Attribute'
 description: >-
   Learn the int64 attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Attribute'
 description: >-
   Learn the list nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Attribute'
 description: >-
   Learn the list attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Nested Attribute'
 description: >-
   Learn the map nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Attribute'
 description: >-
   Learn the map attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Attribute'
 description: >-
   Learn the number attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Attribute'
 description: >-
   Learn the object attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Attribute'
 description: >-
   Learn the set nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Attribute'
 description: >-
   Learn the set attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Attribute'
 description: >-
   Learn the single nested attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Attribute'
 description: >-
   Learn the string attribute type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -5,8 +5,8 @@ description: >-
   are containers for nested attributes and blocks in a resource, data source, or
   provider schema.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Nested Block'
 description: >-
   Learn the list nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Nested Block'
 description: >-
   Learn the set nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Single Nested Block'
 description: >-
   Learn the single nested block type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/dynamic-data.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/dynamic-data.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Dynamic Data'
 description: >-
   How to handle data when utilizing dynamic types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -5,8 +5,8 @@ description: >-
   Path expressions are logic built on top of paths, which may represent one or
   more actual paths within schema data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/paths.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/paths.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement paths in the provider development framework.
   Paths represent a location within a schema or schema-based data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/schemas.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/schemas.mdx
@@ -4,8 +4,8 @@ description: >-
   How to define a schema using the provider development framework. Schemas
   specify the constraints of Terraform configuration blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Terraform Concepts'
 description: >-
   Configuration, Schemas, Attributes and Blocks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Bool Type'
 description: >-
   Learn the bool value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Handling Data - Custom Types'
 description: >-
   Custom Types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Dynamic Type'
 description: >-
   Learn the dynamic value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Float64 Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Learn the types in the provider development framework. Attributes and blocks
   in a resource, data source, or provider schema map to specific framework types.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Int64 Type'
 description: >-
   Learn the int64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/list.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: List Type'
 description: >-
   Learn the list value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/map.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Map Type'
 description: >-
   Learn the map value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/number.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Number Type'
 description: >-
   Learn the float64 value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/object.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Object Type'
 description: >-
   Learn the object value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/set.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Set Type'
 description: >-
   Learn the set value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/string.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: String Type'
 description: >-
   Learn the string value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Tuple Type'
 description: >-
   Learn the tuple value type in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/handling-data/writing-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to write and update the Terraform statefile using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/index.mdx
@@ -3,8 +3,8 @@ page_title: "Home - Plugin Development: Framework"
 description: |-
   Develop Terraform providers using the recommended plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/internals/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/internals/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Internals'
 description: >-
   Framewwork internals.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/internals/rpcs.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/internals/rpcs.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: RPCs'
 description: >-
   Relationship between RPCs and framework functionality.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Schema: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attributes from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -3,8 +3,8 @@ page_title: 'Computed Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks with computed fields from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -3,8 +3,8 @@ page_title: 'Blocks: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate blocks from SDKv2 to attribute validators in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -4,8 +4,8 @@ description: >-
   Specify a default when the Terraform configuration does not supply a value for resource attributes.
   Migrate attribute defaults in SDKv2 to AttributePlanModifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Fields: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute required, optional, computed, and sensitive fields from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute ForceNew triggers: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute force new in SDKv2 to an attribute plan modifier in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Types: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate attribute type from SDKv2 to the plugin Framework
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Attribute Custom Validators: Migrating from SDKv2 to the Framework'
 description: >-
   Validations check for required syntax, types, and acceptable values. Migrate custom attribute validation functions from SDKv2 to attribute validators in the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -4,8 +4,8 @@ description: >-
   Validations check required syntax, types, and acceptable values.
   Migrate the predefined ConflictsWith, ExactlyOneOf, AtLeastOneOf and RequiredWith validators to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/benefits.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/benefits.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Benefits'
 description: >-
   The plugin framework offers significant advantages in comparison to the prior SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Data Sources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a data source from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating from SDKv2 to the plugin Framework'
 description: >-
   Migrate your provider from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/mux.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/mux.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Migration Using Mux'
 description: >-
   Iteratively migrate from terraform-plugin-sdk to terraform-plugin-framework using terraform-plugin-mux.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/providers/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Provider: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a provider definition and schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/resources/crud.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CRUD Functions: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate resource create, read, update, and delete (CRUD) functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/resources/import.mdx
@@ -4,8 +4,8 @@ description: >-
   Practitioners use the import command to let Terraform manage existing infrastructure resources.
   Migrate import functions from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/resources/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources: Migrating from SDKv2 to the Framework'
 description: >-
   Migrate a resource from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -3,8 +3,8 @@ page_title: 'Resources - CustomizeDiff and PlanModifiers: Migrating from SDKv2 t
 description: >-
   Migrate resource customizediff functions in SDKv2 to plan modifiers in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   State upgraders let users update resources provisioned with old schema configurations.
   Migrate resource StateUpgraders in SDKv2 to UpgradeState in the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to migrate timeouts from SDKv2 to the Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/schema/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/schema/index.mdx
@@ -3,8 +3,8 @@ page_title: 'Schema: Migrating from SDKv2 to the Framework'
 description: >-
    Migrate a schema from SDKv2 to the plugin Framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/testing.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/migrating/testing.mdx
@@ -3,8 +3,8 @@ page_title: 'Testing Migration: Migrating from SDKv2 to the Framework'
 description: >-
   Write tests that verify that switching from SDKv2 to the Framework does not affect provider behavior.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/provider-servers.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/provider-servers.mdx
@@ -4,8 +4,8 @@ description: >-
   How to implement a provider server in the provider development framework.
   Provider servers are plugins that allow Terraform to interact with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/providers/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/providers/index.mdx
@@ -5,8 +5,8 @@ description: >-
   wrapped by a provider server, are plugins that allow Terraform to interact
   with APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/providers/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Provider Configurations'
 description: >-
   How to validate provider configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/configure.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/configure.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Configure Resources'
 description: >-
   How to configure resources with provider data or clients in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/create.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/create.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Create Resources'
 description: >-
   How to implement resource creation in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T14:39:20-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/default.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/default.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Default'
 description: >-
   How to set default values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/delete.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/delete.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Delete Resources'
 description: >-
   How to implement resource deletion in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/import.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/import.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Resource Import'
 description: >-
   How to support resource import using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/index.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   How to build resources in the provider development framework. Resources allow
   Terraform to manage infrastructure objects.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/plan-modification.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/plan-modification.mdx
@@ -4,8 +4,8 @@ description: >-
   How to modify plan values and behaviors using the provider development
   framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/private-state.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/private-state.mdx
@@ -4,8 +4,8 @@ description: >-
   How to manage private state data in the provider development framework.
   Private state is provider-only data storage for resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/read.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/read.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Read Resources'
 description: >-
   How to implement resource read in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/state-move.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/state-move.mdx
@@ -4,8 +4,8 @@ description: >-
   How to move state data across managed resource types using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/state-upgrade.mdx
@@ -4,8 +4,8 @@ description: >-
   How to upgrade state data after breaking schema changes using the provider
   development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/timeouts.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/timeouts.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Timeouts'
 description: >-
   How to use timeouts with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/update.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Update Resources'
 description: >-
   How to implement resource in-place update in the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/resources/validate-configuration.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Framework: Validate Resource Configurations'
 description: >-
   How to validate resource configurations with the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/validation.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/validation.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Framework: Validation'
 description: How to validate configuration values using the provider development framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 


### PR DESCRIPTION
### Description

This PR adds a default date for the metadata for older versions of the terraform-plugin-framework documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715. Older docs versions have been updated with default dates for the versions specified in [this spreadsheet](https://docs.google.com/spreadsheets/d/16FpDhKA4ZBOVtxHWw2ebMjS56mdSask1FBCVecn9QnQ/edit?gid=0#gid=0)

NOTE: The run link checker action is expected to fail for this PR since there are so many files changed. This action is not blocking merge and can be ignored.

### Testing

Check that terraform-plugin-framework docs look normal in the preview: https://unified-docs-frontend-preview-5vhgl5c0z-hashicorp.vercel.app/terraform/plugin/framework
