### PR TITLE
Remove non publicly accessible link.

### DIFF
--- a/content/hcp-docs/content/docs/vault-radar/api/events.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/api/events.mdx
@@ -387,4 +387,3 @@ $ curl -X PUT \
 ## Additional resources
 
 - [HashiCorp Cloud Platform authentication documentation](/hcp/docs/hcp/api#authenticate-to-hcp)
-- [Vault Radar Swagger file](https://github.com/hashicorp/hcp-specs/blob/main/specs/cloud-vault-radar/preview/2023-05-01/hcp.swagger.json)

--- a/content/hcp-docs/content/docs/vault-radar/api/resources.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/api/resources.mdx
@@ -316,5 +316,3 @@ $ curl -X POST \
 ## Additional resources
 
 - [HashiCorp Cloud Platform authentication documentation](/hcp/docs/hcp/api#authenticate-to-hcp)
-- [Vault Radar Swagger file](https://github.com/hashicorp/hcp-specs/blob/main/specs/cloud-vault-radar/preview/2023-05-01/hcp.swagger.json)
-


### PR DESCRIPTION
Remove reference to non-publicly accessible link from Radar docs.