### PR TITLE
feat: add default date in frontmatter for older versions of terraform-plugin-log

### DIFF
--- a/content/terraform-plugin-log/v0.4.x/docs/plugin/log/index.mdx
+++ b/content/terraform-plugin-log/v0.4.x/docs/plugin/log/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Logging: Overview"
 description: >-
   Learn about logging with Terraform Providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-log/v0.4.x/docs/plugin/log/managing.mdx
+++ b/content/terraform-plugin-log/v0.4.x/docs/plugin/log/managing.mdx
@@ -3,8 +3,8 @@ page_title: 'Home - Plugin Development: Managing Log Output'
 description: >-
   Filter log outputs by subsystem and verbosity level. Set the log format and output path.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-log/v0.4.x/docs/plugin/log/writing.mdx
+++ b/content/terraform-plugin-log/v0.4.x/docs/plugin/log/writing.mdx
@@ -3,8 +3,8 @@ page_title: 'Home - Plugin Development: Writing Log Output'
 description: >-
   Write logs from your provider that help users debug issues and understand operations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-log/v0.5.x/docs/plugin/log/index.mdx
+++ b/content/terraform-plugin-log/v0.5.x/docs/plugin/log/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Logging: Overview"
 description: >-
   Learn about logging with Terraform Providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-log/v0.5.x/docs/plugin/log/managing.mdx
+++ b/content/terraform-plugin-log/v0.5.x/docs/plugin/log/managing.mdx
@@ -3,8 +3,8 @@ page_title: 'Home - Plugin Development: Managing Log Output'
 description: >-
   Filter log outputs by subsystem and verbosity level. Set the log format and output path.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-log/v0.5.x/docs/plugin/log/writing.mdx
+++ b/content/terraform-plugin-log/v0.5.x/docs/plugin/log/writing.mdx
@@ -3,8 +3,8 @@ page_title: 'Home - Plugin Development: Writing Log Output'
 description: >-
   Write logs from your provider that help users debug issues and understand operations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-log/v0.6.x/docs/plugin/log/filtering.mdx
+++ b/content/terraform-plugin-log/v0.6.x/docs/plugin/log/filtering.mdx
@@ -3,8 +3,8 @@ page_title: 'Home - Plugin Development: Filtering Log Output'
 description: >-
   Omit or mask specific log information from your provider to hide sensitive data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-log/v0.6.x/docs/plugin/log/index.mdx
+++ b/content/terraform-plugin-log/v0.6.x/docs/plugin/log/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Logging: Overview"
 description: >-
   Learn about logging with Terraform Providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-log/v0.6.x/docs/plugin/log/managing.mdx
+++ b/content/terraform-plugin-log/v0.6.x/docs/plugin/log/managing.mdx
@@ -3,8 +3,8 @@ page_title: 'Home - Plugin Development: Managing Log Output'
 description: >-
   Filter log outputs by subsystem and verbosity level. Set the log format and output path.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-log/v0.6.x/docs/plugin/log/writing.mdx
+++ b/content/terraform-plugin-log/v0.6.x/docs/plugin/log/writing.mdx
@@ -3,8 +3,8 @@ page_title: 'Home - Plugin Development: Writing Log Output'
 description: >-
   Write logs from your provider that help users debug issues and understand operations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 


### PR DESCRIPTION
### Description

This PR adds a default date for the metadata for older versions of the terraform-plugin-log documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715. Older docs versions have been updated with default dates for the versions specified in [this spreadsheet](https://docs.google.com/spreadsheets/d/16FpDhKA4ZBOVtxHWw2ebMjS56mdSask1FBCVecn9QnQ/edit?gid=0#gid=0)

### Testing

Check that terraform-plugin-log docs look normal in the preview: https://unified-docs-frontend-preview-cmo6luofb-hashicorp.vercel.app/terraform/plugin/log