### PR TITLE
feat: add default date in frontmatter for older versions of terraform-plugin-mux

### DIFF
--- a/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.10.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.11.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.12.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.13.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.14.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.15.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.16.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.17.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.18.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.6.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.7.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.8.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 5 Providers'
 description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Combining Protocol Version 6 Providers'
 description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/index.mdx
+++ b/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/index.mdx
@@ -3,8 +3,8 @@ page_title: "Plugin Development - Combining and Translating Providers: Overview"
 description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 5 to 6'
 description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/content/terraform-plugin-mux/v0.9.x/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Translating Protocol Version 6 to 5'
 description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 


### PR DESCRIPTION
### Description

This PR adds a default date for the metadata for older versions of the terraform-plugin-mux documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715. Older docs versions have been updated with default dates for the versions specified in [this spreadsheet](https://docs.google.com/spreadsheets/d/16FpDhKA4ZBOVtxHWw2ebMjS56mdSask1FBCVecn9QnQ/edit?gid=0#gid=0)

### Testing

Check that terraform-plugin-mux docs look normal in the preview: https://unified-docs-frontend-preview-drut1ody4-hashicorp.vercel.app/terraform/plugin/mux